### PR TITLE
feat: plugin commands, marketplace commands, and SessionServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,52 @@ ClaudeWrapper.Retry.execute(query, config,
 )
 ```
 
+## SessionServer (GenServer)
+
+For OTP applications that need a supervised, process-based session:
+
+```elixir
+{:ok, pid} = ClaudeWrapper.SessionServer.start_link(
+  config: config,
+  query_opts: [model: "sonnet", max_turns: 5]
+)
+
+{:ok, result} = ClaudeWrapper.SessionServer.send_message(pid, "Fix the tests")
+ClaudeWrapper.SessionServer.total_cost(pid)
+```
+
+Works with supervision trees:
+
+```elixir
+children = [
+  {ClaudeWrapper.SessionServer,
+   name: :my_agent, config: config, query_opts: [model: "sonnet"]}
+]
+```
+
+## Plugin management
+
+```elixir
+alias ClaudeWrapper.Commands.Plugin
+
+{:ok, plugins} = Plugin.list(config)
+{:ok, _} = Plugin.install(config, "my-plugin", scope: :project)
+{:ok, _} = Plugin.enable(config, "my-plugin")
+{:ok, _} = Plugin.disable(config, "my-plugin")
+{:ok, _} = Plugin.uninstall(config, "my-plugin")
+```
+
+## Marketplace management
+
+```elixir
+alias ClaudeWrapper.Commands.Marketplace
+
+{:ok, marketplaces} = Marketplace.list(config)
+{:ok, _} = Marketplace.add(config, "https://github.com/org/marketplace")
+{:ok, _} = Marketplace.remove(config, "my-marketplace")
+{:ok, _} = Marketplace.update(config)
+```
+
 ## Raw CLI escape hatch
 
 For subcommands not yet wrapped:
@@ -117,10 +163,13 @@ ClaudeWrapper.raw(["config", "list"])
 | `ClaudeWrapper.Result` | Parsed JSON result |
 | `ClaudeWrapper.StreamEvent` | NDJSON streaming event |
 | `ClaudeWrapper.Session` | Multi-turn session management |
+| `ClaudeWrapper.SessionServer` | GenServer wrapper for sessions |
 | `ClaudeWrapper.McpConfig` | `.mcp.json` builder |
 | `ClaudeWrapper.Retry` | Exponential backoff retry |
 | `ClaudeWrapper.Commands.Auth` | Auth management |
 | `ClaudeWrapper.Commands.Mcp` | MCP server CRUD |
+| `ClaudeWrapper.Commands.Plugin` | Plugin install/enable/disable/update |
+| `ClaudeWrapper.Commands.Marketplace` | Marketplace add/remove/list/update |
 | `ClaudeWrapper.Commands.Doctor` | CLI health check |
 | `ClaudeWrapper.Commands.Version` | CLI version |
 

--- a/lib/claude_wrapper/commands/marketplace.ex
+++ b/lib/claude_wrapper/commands/marketplace.ex
@@ -1,0 +1,110 @@
+defmodule ClaudeWrapper.Commands.Marketplace do
+  @moduledoc """
+  Plugin marketplace management commands.
+
+  Wraps `claude plugin marketplace add|remove|list|update`.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # List configured marketplaces
+      {:ok, marketplaces} = ClaudeWrapper.Commands.Marketplace.list(config)
+
+      # Add a marketplace from a URL or GitHub repo
+      {:ok, _} = ClaudeWrapper.Commands.Marketplace.add(config, "https://github.com/org/marketplace")
+
+      # Add with sparse checkout for monorepos
+      {:ok, _} = ClaudeWrapper.Commands.Marketplace.add(config, "https://github.com/org/repo",
+        sparse: [".claude-plugin", "plugins"]
+      )
+
+      # Remove a marketplace
+      {:ok, _} = ClaudeWrapper.Commands.Marketplace.remove(config, "my-marketplace")
+
+      # Update all marketplaces
+      {:ok, _} = ClaudeWrapper.Commands.Marketplace.update(config)
+  """
+
+  alias ClaudeWrapper.Config
+
+  @type scope :: :user | :project | :local
+
+  @doc """
+  List all configured marketplaces.
+  """
+  @spec list(Config.t()) :: {:ok, list(map())} | {:error, term()}
+  def list(%Config{} = config) do
+    args = Config.base_args(config) ++ ["plugin", "marketplace", "list", "--json"]
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} ->
+        case Jason.decode(output) do
+          {:ok, data} -> {:ok, data}
+          {:error, reason} -> {:error, {:json_decode, reason}}
+        end
+
+      {output, code} ->
+        {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Add a marketplace from a URL, path, or GitHub repo.
+
+  ## Options
+
+    * `:scope` - Where to declare the marketplace (`:user`, `:project`, or `:local`). Default: `:user`.
+    * `:sparse` - List of directories for git sparse-checkout (for monorepos).
+  """
+  @spec add(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def add(%Config{} = config, source, opts \\ []) do
+    args = Config.base_args(config) ++ ["plugin", "marketplace", "add", source]
+    args = args ++ scope_args(opts[:scope])
+
+    args =
+      case opts[:sparse] do
+        nil -> args
+        paths when is_list(paths) -> args ++ ["--sparse" | paths]
+      end
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Remove a configured marketplace by name.
+  """
+  @spec remove(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def remove(%Config{} = config, name) do
+    args = Config.base_args(config) ++ ["plugin", "marketplace", "remove", name]
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Update marketplace(s) from their source.
+
+  If no name is given, updates all marketplaces.
+  """
+  @spec update(Config.t(), String.t() | nil) :: {:ok, String.t()} | {:error, term()}
+  def update(%Config{} = config, name \\ nil) do
+    args = Config.base_args(config) ++ ["plugin", "marketplace", "update"]
+    args = if name, do: args ++ [name], else: args
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  defp scope_args(nil), do: []
+  defp scope_args(:user), do: ["--scope", "user"]
+  defp scope_args(:project), do: ["--scope", "project"]
+  defp scope_args(:local), do: ["--scope", "local"]
+end

--- a/lib/claude_wrapper/commands/plugin.ex
+++ b/lib/claude_wrapper/commands/plugin.ex
@@ -1,0 +1,171 @@
+defmodule ClaudeWrapper.Commands.Plugin do
+  @moduledoc """
+  Plugin management commands.
+
+  Wraps `claude plugin install|uninstall|list|enable|disable|update|validate`.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # List installed plugins
+      {:ok, plugins} = ClaudeWrapper.Commands.Plugin.list(config)
+
+      # List with available marketplace plugins
+      {:ok, plugins} = ClaudeWrapper.Commands.Plugin.list(config, available: true)
+
+      # Install a plugin
+      {:ok, _} = ClaudeWrapper.Commands.Plugin.install(config, "my-plugin")
+
+      # Install from a specific marketplace
+      {:ok, _} = ClaudeWrapper.Commands.Plugin.install(config, "my-plugin@my-marketplace")
+
+      # Enable / disable
+      {:ok, _} = ClaudeWrapper.Commands.Plugin.enable(config, "my-plugin")
+      {:ok, _} = ClaudeWrapper.Commands.Plugin.disable(config, "my-plugin")
+  """
+
+  alias ClaudeWrapper.Config
+
+  @type scope :: :user | :project | :local
+
+  @doc """
+  List installed plugins.
+
+  ## Options
+
+    * `:available` - Include available plugins from marketplaces (boolean, requires JSON output)
+  """
+  @spec list(Config.t(), keyword()) :: {:ok, list(map())} | {:error, term()}
+  def list(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ ["plugin", "list", "--json"]
+    args = if opts[:available], do: args ++ ["--available"], else: args
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} ->
+        case Jason.decode(output) do
+          {:ok, data} -> {:ok, data}
+          {:error, reason} -> {:error, {:json_decode, reason}}
+        end
+
+      {output, code} ->
+        {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Install a plugin from available marketplaces.
+
+  Use `"name@marketplace"` to install from a specific marketplace.
+
+  ## Options
+
+    * `:scope` - Installation scope (`:user`, `:project`, or `:local`). Default: `:user`.
+  """
+  @spec install(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def install(%Config{} = config, plugin, opts \\ []) do
+    args = Config.base_args(config) ++ ["plugin", "install", plugin]
+    args = args ++ scope_args(opts[:scope])
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Uninstall an installed plugin.
+
+  ## Options
+
+    * `:scope` - Scope to uninstall from (`:user`, `:project`, or `:local`). Default: `:user`.
+    * `:keep_data` - Preserve the plugin's persistent data directory (boolean).
+  """
+  @spec uninstall(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def uninstall(%Config{} = config, plugin, opts \\ []) do
+    args = Config.base_args(config) ++ ["plugin", "uninstall", plugin]
+    args = args ++ scope_args(opts[:scope])
+    args = if opts[:keep_data], do: args ++ ["--keep-data"], else: args
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Enable a disabled plugin.
+
+  ## Options
+
+    * `:scope` - Scope (`:user`, `:project`, or `:local`). Default: auto-detect.
+  """
+  @spec enable(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def enable(%Config{} = config, plugin, opts \\ []) do
+    args = Config.base_args(config) ++ ["plugin", "enable", plugin]
+    args = args ++ scope_args(opts[:scope])
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Disable an enabled plugin.
+
+  ## Options
+
+    * `:scope` - Scope (`:user`, `:project`, or `:local`). Default: auto-detect.
+    * `:all` - Disable all enabled plugins (boolean).
+  """
+  @spec disable(Config.t(), String.t() | nil, keyword()) :: {:ok, String.t()} | {:error, term()}
+  def disable(%Config{} = config, plugin \\ nil, opts \\ []) do
+    args = Config.base_args(config) ++ ["plugin", "disable"]
+    args = if plugin, do: args ++ [plugin], else: args
+    args = args ++ scope_args(opts[:scope])
+    args = if opts[:all], do: args ++ ["--all"], else: args
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Update a plugin to the latest version.
+
+  ## Options
+
+    * `:scope` - Scope (`:user`, `:project`, `:local`, or `:managed`). Default: `:user`.
+  """
+  @spec update(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def update(%Config{} = config, plugin, opts \\ []) do
+    args = Config.base_args(config) ++ ["plugin", "update", plugin]
+    args = args ++ scope_args(opts[:scope])
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Validate a plugin or marketplace manifest at the given path.
+  """
+  @spec validate(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def validate(%Config{} = config, path) do
+    args = Config.base_args(config) ++ ["plugin", "validate", path]
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  defp scope_args(nil), do: []
+  defp scope_args(:user), do: ["--scope", "user"]
+  defp scope_args(:project), do: ["--scope", "project"]
+  defp scope_args(:local), do: ["--scope", "local"]
+  defp scope_args(:managed), do: ["--scope", "managed"]
+end

--- a/lib/claude_wrapper/session_server.ex
+++ b/lib/claude_wrapper/session_server.ex
@@ -1,0 +1,179 @@
+defmodule ClaudeWrapper.SessionServer do
+  @moduledoc """
+  GenServer wrapper for long-running multi-turn sessions.
+
+  Holds a `ClaudeWrapper.Session` in state and provides a process-based
+  interface for OTP applications, supervision trees, and concurrent access.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new(working_dir: "/path/to/project")
+
+      {:ok, pid} = ClaudeWrapper.SessionServer.start_link(
+        config: config,
+        query_opts: [model: "sonnet", max_turns: 5]
+      )
+
+      {:ok, result} = ClaudeWrapper.SessionServer.send_message(pid, "What files are here?")
+      {:ok, result} = ClaudeWrapper.SessionServer.send_message(pid, "Add tests for lib/foo.ex")
+
+      ClaudeWrapper.SessionServer.total_cost(pid)
+      #=> 0.12
+
+  ## Supervision
+
+      children = [
+        {ClaudeWrapper.SessionServer,
+         name: :my_agent,
+         config: config,
+         query_opts: [model: "sonnet"]}
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
+
+      # Then use the registered name
+      ClaudeWrapper.SessionServer.send_message(:my_agent, "hello")
+  """
+
+  use GenServer
+
+  alias ClaudeWrapper.{Config, Result, Session}
+
+  @type server :: GenServer.server()
+
+  @type option ::
+          {:config, Config.t()}
+          | {:query_opts, keyword()}
+          | {:session_id, String.t()}
+          | {:name, GenServer.name()}
+          | GenServer.option()
+
+  # --- Client API ---
+
+  @doc """
+  Start a session server.
+
+  ## Options
+
+    * `:config` - (required) `%Config{}` struct
+    * `:query_opts` - Query options applied to every turn (e.g. `model`, `max_turns`)
+    * `:session_id` - Resume an existing session by ID
+    * `:name` - Register the process with a name
+
+  Also accepts standard `GenServer.start_link/3` options.
+  """
+  @spec start_link([option()]) :: GenServer.on_start()
+  def start_link(opts) do
+    {config, opts} = Keyword.pop!(opts, :config)
+    {query_opts, opts} = Keyword.pop(opts, :query_opts, [])
+    {session_id, opts} = Keyword.pop(opts, :session_id)
+
+    init_arg = %{config: config, query_opts: query_opts, session_id: session_id}
+    GenServer.start_link(__MODULE__, init_arg, opts)
+  end
+
+  @doc """
+  Send a message in the session. Blocks until the CLI responds.
+
+  Returns `{:ok, %Result{}}` or `{:error, reason}`.
+  """
+  @spec send_message(server(), String.t(), keyword()) ::
+          {:ok, Result.t()} | {:error, term()}
+  def send_message(server, prompt, opts \\ []) do
+    GenServer.call(server, {:send, prompt, opts}, :infinity)
+  end
+
+  @doc """
+  Get the session ID (if established).
+  """
+  @spec session_id(server()) :: String.t() | nil
+  def session_id(server) do
+    GenServer.call(server, :session_id)
+  end
+
+  @doc """
+  Get the number of completed turns.
+  """
+  @spec turn_count(server()) :: non_neg_integer()
+  def turn_count(server) do
+    GenServer.call(server, :turn_count)
+  end
+
+  @doc """
+  Get the total cost across all turns.
+  """
+  @spec total_cost(server()) :: float()
+  def total_cost(server) do
+    GenServer.call(server, :total_cost)
+  end
+
+  @doc """
+  Get the last result, if any.
+  """
+  @spec last_result(server()) :: Result.t() | nil
+  def last_result(server) do
+    GenServer.call(server, :last_result)
+  end
+
+  @doc """
+  Get the full conversation history.
+  """
+  @spec history(server()) :: [Result.t()]
+  def history(server) do
+    GenServer.call(server, :history)
+  end
+
+  @doc """
+  Get the underlying `%Session{}` struct (snapshot).
+  """
+  @spec get_session(server()) :: Session.t()
+  def get_session(server) do
+    GenServer.call(server, :get_session)
+  end
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(%{config: config, query_opts: query_opts, session_id: nil}) do
+    {:ok, Session.new(config, query_opts)}
+  end
+
+  def init(%{config: config, query_opts: query_opts, session_id: session_id}) do
+    {:ok, Session.resume(config, session_id, query_opts)}
+  end
+
+  @impl true
+  def handle_call({:send, prompt, opts}, _from, session) do
+    case Session.send(session, prompt, opts) do
+      {:ok, new_session, result} ->
+        {:reply, {:ok, result}, new_session}
+
+      {:error, _reason} = error ->
+        {:reply, error, session}
+    end
+  end
+
+  def handle_call(:session_id, _from, session) do
+    {:reply, Session.session_id(session), session}
+  end
+
+  def handle_call(:turn_count, _from, session) do
+    {:reply, Session.turn_count(session), session}
+  end
+
+  def handle_call(:total_cost, _from, session) do
+    {:reply, Session.total_cost(session), session}
+  end
+
+  def handle_call(:last_result, _from, session) do
+    {:reply, Session.last_result(session), session}
+  end
+
+  def handle_call(:history, _from, session) do
+    {:reply, Session.turns(session), session}
+  end
+
+  def handle_call(:get_session, _from, session) do
+    {:reply, session, session}
+  end
+end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -1,7 +1,16 @@
 defmodule ClaudeWrapperTest do
   use ExUnit.Case, async: true
 
-  alias ClaudeWrapper.{Config, McpConfig, Query, Result, Retry, Session, StreamEvent}
+  alias ClaudeWrapper.{
+    Config,
+    McpConfig,
+    Query,
+    Result,
+    Retry,
+    Session,
+    SessionServer,
+    StreamEvent
+  }
 
   describe "Config" do
     test "new with defaults" do
@@ -318,6 +327,80 @@ defmodule ClaudeWrapperTest do
         assert delay >= 0
         assert delay <= 4000
       end
+    end
+  end
+
+  describe "SessionServer" do
+    test "start_link and initial state" do
+      config = Config.new()
+      {:ok, pid} = SessionServer.start_link(config: config)
+
+      assert SessionServer.session_id(pid) == nil
+      assert SessionServer.turn_count(pid) == 0
+      assert SessionServer.total_cost(pid) == 0.0
+      assert SessionServer.last_result(pid) == nil
+      assert SessionServer.history(pid) == []
+    end
+
+    test "start_link with query opts" do
+      config = Config.new()
+      {:ok, pid} = SessionServer.start_link(config: config, query_opts: [model: "sonnet"])
+
+      session = SessionServer.get_session(pid)
+      assert session.query_opts == [model: "sonnet"]
+    end
+
+    test "start_link with session_id for resume" do
+      config = Config.new()
+      {:ok, pid} = SessionServer.start_link(config: config, session_id: "abc-123")
+
+      assert SessionServer.session_id(pid) == "abc-123"
+    end
+
+    test "start_link with name registration" do
+      config = Config.new()
+
+      {:ok, _pid} =
+        SessionServer.start_link(config: config, name: :test_session_server)
+
+      assert SessionServer.turn_count(:test_session_server) == 0
+    end
+
+    test "child_spec for supervision" do
+      config = Config.new()
+      spec = SessionServer.child_spec(config: config, name: :supervised_test)
+
+      assert spec.id == SessionServer
+
+      assert spec.start ==
+               {SessionServer, :start_link, [[config: config, name: :supervised_test]]}
+    end
+  end
+
+  describe "Commands.Plugin" do
+    alias ClaudeWrapper.Commands.Plugin
+
+    test "module is loaded and has expected functions" do
+      Code.ensure_loaded!(Plugin)
+      assert {:list, 2} in Plugin.__info__(:functions)
+      assert {:install, 3} in Plugin.__info__(:functions)
+      assert {:uninstall, 3} in Plugin.__info__(:functions)
+      assert {:enable, 3} in Plugin.__info__(:functions)
+      assert {:disable, 3} in Plugin.__info__(:functions)
+      assert {:update, 3} in Plugin.__info__(:functions)
+      assert {:validate, 2} in Plugin.__info__(:functions)
+    end
+  end
+
+  describe "Commands.Marketplace" do
+    alias ClaudeWrapper.Commands.Marketplace
+
+    test "module is loaded and has expected functions" do
+      Code.ensure_loaded!(Marketplace)
+      assert {:list, 1} in Marketplace.__info__(:functions)
+      assert {:add, 3} in Marketplace.__info__(:functions)
+      assert {:remove, 2} in Marketplace.__info__(:functions)
+      assert {:update, 2} in Marketplace.__info__(:functions)
     end
   end
 end


### PR DESCRIPTION
## Summary

- **Plugin commands** (`ClaudeWrapper.Commands.Plugin`) -- install, uninstall, list, enable, disable, update, validate with scope support
- **Marketplace commands** (`ClaudeWrapper.Commands.Marketplace`) -- add, remove, list, update with sparse checkout for monorepos
- **SessionServer** (`ClaudeWrapper.SessionServer`) -- GenServer wrapper around `Session` with supervision tree support, named registration, `send_message/2`, cost/history tracking

Closes #2, closes #3, closes #4

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- 0 issues
- [x] `mix test` -- 43 pass, 6 integration excluded
- [x] `mix docs` builds clean