### PR TITLE
feat: IEx REPL helpers for conversational Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,34 @@ ClaudeWrapper.Session.total_cost(session)
 #=> 0.12
 ```
 
+## IEx REPL
+
+Use Claude conversationally from IEx:
+
+```elixir
+iex> import ClaudeWrapper.IEx
+
+iex> chat("explain this codebase", working_dir: ".", model: "sonnet")
+# => prints response
+# ($0.07, 1 turn)
+
+iex> say("now add tests for the retry module")
+# => continues the conversation
+# ($0.04 this turn, $0.11 total, 2 turns)
+
+iex> cost()
+# $0.11 across 2 turns
+
+iex> history()
+# prints full conversation
+
+iex> session_id()
+# "abc-123" -- save this to resume later
+
+iex> reset()
+# start fresh
+```
+
 ## Query builder
 
 For full control, use the `Query` struct directly:
@@ -166,6 +194,7 @@ ClaudeWrapper.raw(["config", "list"])
 | `ClaudeWrapper.SessionServer` | GenServer wrapper for sessions |
 | `ClaudeWrapper.McpConfig` | `.mcp.json` builder |
 | `ClaudeWrapper.Retry` | Exponential backoff retry |
+| `ClaudeWrapper.IEx` | Interactive REPL helpers |
 | `ClaudeWrapper.Commands.Auth` | Auth management |
 | `ClaudeWrapper.Commands.Mcp` | MCP server CRUD |
 | `ClaudeWrapper.Commands.Plugin` | Plugin install/enable/disable/update |

--- a/lib/claude_wrapper/iex.ex
+++ b/lib/claude_wrapper/iex.ex
@@ -1,0 +1,227 @@
+defmodule ClaudeWrapper.IEx do
+  @moduledoc """
+  Interactive helpers for conversational use in IEx.
+
+  Provides a minimal, REPL-friendly interface that manages session state
+  implicitly so you can just talk to Claude.
+
+  ## Usage
+
+      iex> import ClaudeWrapper.IEx
+
+      iex> chat("explain this codebase", working_dir: ".")
+      # => prints response, shows cost
+
+      iex> say("now add tests for the retry module")
+      # => continues the conversation
+
+      iex> say("looks good, ship it")
+      # => keeps going
+
+      iex> cost()
+      # => $0.21 across 3 turns
+
+      iex> history()
+      # => prints conversation
+
+      iex> reset()
+      # => starts fresh
+
+  ## Configuration
+
+  Pass options to `chat/2` to configure the session. These persist for
+  subsequent `say/2` calls:
+
+      chat("hello", model: "sonnet", working_dir: "/my/project", max_turns: 5)
+
+  Override per-turn with `say/2`:
+
+      say("do something expensive", max_turns: 20)
+  """
+
+  alias ClaudeWrapper.{Config, Result, Session}
+
+  @session_key :claude_wrapper_iex_session
+  @config_key :claude_wrapper_iex_config
+
+  @doc """
+  Start a new conversation. Prints the response.
+
+  Accepts all options from `ClaudeWrapper.query/2` -- config options
+  (`:working_dir`, `:binary`, `:env`, `:timeout`, `:verbose`, `:debug`)
+  and query options (`:model`, `:max_turns`, `:permission_mode`, etc.).
+  """
+  def chat(prompt, opts \\ []) do
+    {config_opts, query_opts} = split_opts(opts)
+    config = Config.new(config_opts)
+    session = Session.new(config, query_opts)
+
+    Process.put(@config_key, config)
+
+    do_send(session, prompt, [])
+  end
+
+  @doc """
+  Continue the current conversation. Prints the response.
+
+  Accepts per-turn query option overrides.
+  """
+  def say(prompt, opts \\ []) do
+    case Process.get(@session_key) do
+      nil ->
+        IO.puts("\e[31mNo active session. Start one with chat/2.\e[0m")
+        :no_session
+
+      session ->
+        do_send(session, prompt, opts)
+    end
+  end
+
+  @doc """
+  Show total cost and turn count for the current session.
+  """
+  def cost do
+    case Process.get(@session_key) do
+      nil ->
+        IO.puts("\e[31mNo active session.\e[0m")
+        :no_session
+
+      session ->
+        total = Session.total_cost(session)
+        turns = Session.turn_count(session)
+        IO.puts("\e[33m$#{Float.round(total, 4)} across #{turns} turn#{plural(turns)}\e[0m")
+        total
+    end
+  end
+
+  @doc """
+  Print the conversation history.
+  """
+  def history do
+    case Process.get(@session_key) do
+      nil ->
+        IO.puts("\e[31mNo active session.\e[0m")
+        :no_session
+
+      session ->
+        session |> Session.turns() |> print_history()
+        :ok
+    end
+  end
+
+  @doc """
+  Reset the session (start fresh on next `chat/2`).
+  """
+  def reset do
+    Process.delete(@session_key)
+    Process.delete(@config_key)
+    IO.puts("\e[33mSession cleared.\e[0m")
+    :ok
+  end
+
+  @doc """
+  Get the session ID (for resuming later).
+  """
+  def session_id do
+    case Process.get(@session_key) do
+      nil -> nil
+      session -> Session.session_id(session)
+    end
+  end
+
+  @doc """
+  Resume a previous session by ID.
+
+  Uses the same config as the last `chat/2` call, or pass new options.
+  """
+  def resume(sid, opts \\ []) do
+    {config_opts, query_opts} = split_opts(opts)
+
+    config =
+      if config_opts == [] do
+        Process.get(@config_key) || Config.new()
+      else
+        Config.new(config_opts)
+      end
+
+    session = Session.resume(config, sid, query_opts)
+    Process.put(@session_key, session)
+    Process.put(@config_key, config)
+    IO.puts("\e[33mResumed session #{sid}\e[0m")
+    :ok
+  end
+
+  @doc """
+  Get the last result struct (for programmatic access).
+  """
+  def last do
+    case Process.get(@session_key) do
+      nil -> nil
+      session -> Session.last_result(session)
+    end
+  end
+
+  # --- Private ---
+
+  defp print_history([]) do
+    IO.puts("\e[33mNo turns yet.\e[0m")
+  end
+
+  defp print_history(turns) do
+    turns
+    |> Enum.with_index(1)
+    |> Enum.each(&print_turn/1)
+  end
+
+  defp print_turn({result, i}) do
+    cost_str = if result.cost_usd, do: " ($#{Float.round(result.cost_usd, 4)})", else: ""
+    error_str = if result.is_error, do: " \e[31m[error]\e[0m", else: ""
+
+    IO.puts("\e[36m--- Turn #{i}#{cost_str}#{error_str} ---\e[0m")
+    IO.puts(result.result)
+    IO.puts("")
+  end
+
+  defp do_send(session, prompt, opts) do
+    IO.puts("\e[33m...\e[0m")
+
+    case Session.send(session, prompt, opts) do
+      {:ok, new_session, result} ->
+        Process.put(@session_key, new_session)
+        print_result(result, new_session)
+        :ok
+
+      {:error, reason} ->
+        IO.puts("\e[31mError: #{inspect(reason)}\e[0m")
+        {:error, reason}
+    end
+  end
+
+  defp print_result(%Result{} = result, session) do
+    IO.puts("")
+    IO.puts(result.result)
+    IO.puts("")
+
+    cost_str = if result.cost_usd, do: "$#{Float.round(result.cost_usd, 4)}", else: "?"
+    total = Session.total_cost(session)
+    turns = Session.turn_count(session)
+
+    meta =
+      if turns > 1 do
+        "\e[33m(#{cost_str} this turn, $#{Float.round(total, 4)} total, #{turns} turns)\e[0m"
+      else
+        "\e[33m(#{cost_str}, #{turns} turn)\e[0m"
+      end
+
+    IO.puts(meta)
+  end
+
+  @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]
+
+  defp split_opts(opts) do
+    Enum.split_with(opts, fn {k, _v} -> k in @config_keys end)
+  end
+
+  defp plural(1), do: ""
+  defp plural(_), do: "s"
+end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -403,4 +403,61 @@ defmodule ClaudeWrapperTest do
       assert {:update, 2} in Marketplace.__info__(:functions)
     end
   end
+
+  describe "IEx helpers" do
+    alias ClaudeWrapper.IEx, as: CIEx
+
+    setup do
+      # Clean process dictionary state between tests
+      Process.delete(:claude_wrapper_iex_session)
+      Process.delete(:claude_wrapper_iex_config)
+      :ok
+    end
+
+    test "cost returns :no_session when no session active" do
+      assert CIEx.cost() == :no_session
+    end
+
+    test "say returns :no_session when no session active" do
+      assert CIEx.say("hello") == :no_session
+    end
+
+    test "session_id returns nil when no session active" do
+      assert CIEx.session_id() == nil
+    end
+
+    test "last returns nil when no session active" do
+      assert CIEx.last() == nil
+    end
+
+    test "history returns :no_session when no session active" do
+      assert CIEx.history() == :no_session
+    end
+
+    test "reset clears state" do
+      assert CIEx.reset() == :ok
+    end
+
+    test "resume sets up session state" do
+      assert CIEx.resume("test-session-id") == :ok
+      assert CIEx.session_id() == "test-session-id"
+    end
+
+    test "resume with options" do
+      assert CIEx.resume("sid-123", working_dir: "/tmp") == :ok
+      assert CIEx.session_id() == "sid-123"
+    end
+
+    test "module exports expected functions" do
+      Code.ensure_loaded!(CIEx)
+      assert {:chat, 2} in CIEx.__info__(:functions)
+      assert {:say, 2} in CIEx.__info__(:functions)
+      assert {:cost, 0} in CIEx.__info__(:functions)
+      assert {:history, 0} in CIEx.__info__(:functions)
+      assert {:reset, 0} in CIEx.__info__(:functions)
+      assert {:session_id, 0} in CIEx.__info__(:functions)
+      assert {:resume, 2} in CIEx.__info__(:functions)
+      assert {:last, 0} in CIEx.__info__(:functions)
+    end
+  end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -98,4 +98,32 @@ defmodule ClaudeWrapper.IntegrationTest do
       assert result.result =~ "pong"
     end
   end
+
+  describe "IEx helpers" do
+    alias ClaudeWrapper.IEx, as: CIEx
+
+    setup do
+      CIEx.reset()
+      :ok
+    end
+
+    test "chat and say multi-turn" do
+      assert :ok =
+               CIEx.chat("Respond with exactly: hello",
+                 max_turns: 1,
+                 dangerously_skip_permissions: true,
+                 no_session_persistence: true
+               )
+
+      assert CIEx.session_id() != nil
+      assert CIEx.last().result =~ "hello"
+
+      assert :ok = CIEx.say("Respond with exactly: goodbye")
+      assert CIEx.last().result =~ "goodbye"
+
+      total = CIEx.cost()
+      assert is_float(total)
+      assert total > 0.0
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds `ClaudeWrapper.IEx` -- a set of helpers that turn IEx into a conversational Claude UI:

- `chat/2` -- start a new conversation with config options
- `say/2` -- continue the conversation
- `cost/0` -- show spend and turn count
- `history/0` -- print the full conversation
- `reset/0` -- clear session state
- `session_id/0` -- get the session ID for later resume
- `resume/2` -- resume a previous session by ID
- `last/0` -- get the last `%Result{}` struct

Session state lives in the process dictionary so it's zero-ceremony -- just `import ClaudeWrapper.IEx` and go.

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- 0 issues
- [x] `mix test` -- 52 pass, 7 integration excluded
- [x] Integration test for `chat` + `say` multi-turn flow