### PR TITLE
fix: resolve doc warnings for Config.new/1 references

### DIFF
--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -84,7 +84,7 @@ defmodule ClaudeWrapper do
 
   ## Options
 
-  Config options (passed to `Config.new/1`):
+  Config options (passed to `ClaudeWrapper.Config.new/1`):
     * `:binary` - Path to claude binary
     * `:working_dir` - Working directory
     * `:env` - Environment variables


### PR DESCRIPTION
## Summary

Use fully qualified `ClaudeWrapper.Config.new/1` in docstrings so ExDoc resolves the link correctly. Fixes the two warnings seen during `mix hex.publish`.

## Test plan

- [x] `mix docs` -- zero warnings
- [x] `mix test` -- 52 pass