### PR TITLE
feat: add agents command

### DIFF
--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -152,6 +152,23 @@ defmodule ClaudeWrapper do
     Commands.Doctor.execute(config)
   end
 
+  @doc """
+  List configured agents.
+
+  Returns a list of agent maps with `:name` and `:model` keys.
+
+  ## Options
+
+    * `:setting_sources` - comma-separated setting sources (e.g. `"user,project"`)
+
+  """
+  @spec agents(keyword()) :: {:ok, [map()]} | {:error, term()}
+  def agents(opts \\ []) do
+    {config_opts, agent_opts} = split_opts(opts)
+    config = Config.new(config_opts)
+    Commands.Agents.list(config, agent_opts)
+  end
+
   # --- Private ---
 
   @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]

--- a/lib/claude_wrapper/commands/agents.ex
+++ b/lib/claude_wrapper/commands/agents.ex
@@ -1,0 +1,70 @@
+defmodule ClaudeWrapper.Commands.Agents do
+  @moduledoc """
+  `claude agents` command -- lists configured agents.
+  """
+
+  alias ClaudeWrapper.Config
+
+  @type agent :: %{
+          name: String.t(),
+          model: String.t()
+        }
+
+  @doc """
+  Run `claude agents` and return the parsed agent list.
+
+  ## Options
+
+    * `:setting_sources` - comma-separated setting sources to load
+      (e.g. `"user,project"`)
+
+  ## Examples
+
+      {:ok, agents} = ClaudeWrapper.Commands.Agents.list(config)
+      # => {:ok, [%{name: "Explore", model: "haiku"}, ...]}
+
+  """
+  @spec list(Config.t(), keyword()) :: {:ok, [agent()]} | {:error, term()}
+  def list(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ ["agents"] ++ build_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, parse_agents(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Run `claude agents` and return the raw output string.
+  """
+  @spec execute(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def execute(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ ["agents"] ++ build_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  defp build_args(opts) do
+    case Keyword.get(opts, :setting_sources) do
+      nil -> []
+      sources -> ["--setting-sources", sources]
+    end
+  end
+
+  defp parse_agents(output) do
+    output
+    |> String.split("\n")
+    |> Enum.reduce([], fn line, acc ->
+      line = String.trim(line)
+
+      case Regex.run(~r/^(.+?)\s+·\s+(.+)$/, line) do
+        [_, name, model] -> [%{name: String.trim(name), model: String.trim(model)} | acc]
+        _ -> acc
+      end
+    end)
+    |> Enum.reverse()
+  end
+end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -406,6 +406,53 @@ defmodule ClaudeWrapperTest do
     end
   end
 
+  describe "Commands.Agents" do
+    alias ClaudeWrapper.Commands.Agents
+
+    test "module is loaded and has expected functions" do
+      Code.ensure_loaded!(Agents)
+      assert {:list, 1} in Agents.__info__(:functions)
+      assert {:list, 2} in Agents.__info__(:functions)
+      assert {:execute, 1} in Agents.__info__(:functions)
+      assert {:execute, 2} in Agents.__info__(:functions)
+    end
+
+    test "parse_agents extracts agent names and models" do
+      output = """
+      5 active agents
+
+      Built-in agents:
+        claude-code-guide · haiku
+        Explore · haiku
+        general-purpose · inherit
+        Plan · inherit
+        statusline-setup · sonnet
+      """
+
+      # Call list via execute and parse manually to test parsing
+      # (list calls System.cmd which we can't mock easily here)
+      agents =
+        output
+        |> String.split("\n")
+        |> Enum.reduce([], fn line, acc ->
+          line = String.trim(line)
+
+          case Regex.run(~r/^(.+?)\s+·\s+(.+)$/, line) do
+            [_, name, model] -> [%{name: String.trim(name), model: String.trim(model)} | acc]
+            _ -> acc
+          end
+        end)
+        |> Enum.reverse()
+
+      assert length(agents) == 5
+      assert %{name: "claude-code-guide", model: "haiku"} in agents
+      assert %{name: "Explore", model: "haiku"} in agents
+      assert %{name: "general-purpose", model: "inherit"} in agents
+      assert %{name: "Plan", model: "inherit"} in agents
+      assert %{name: "statusline-setup", model: "sonnet"} in agents
+    end
+  end
+
   describe "Commands.Marketplace" do
     alias ClaudeWrapper.Commands.Marketplace
 


### PR DESCRIPTION
## Summary

- Add `ClaudeWrapper.Commands.Agents` module wrapping `claude agents`
- `list/2` returns parsed agent list (`[%{name: "Explore", model: "haiku"}, ...]`)
- `execute/2` returns raw output string
- Optional `--setting-sources` filter via `setting_sources: "user,project"` opt
- `ClaudeWrapper.agents/1` convenience function

Closes #8