### PR TITLE
feat: add Workshop.load/1 for setup files

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -13,4 +13,9 @@ IO.puts("""
   pipe(:impl, :reviewer, "Review this")
   info(:impl)                 \e[33m# agent details\e[0m
   inspect_agent(:impl)        \e[33m# show CLI command\e[0m
+  load()                      \e[33m# load .workshop.exs\e[0m
 """)
+
+if File.exists?(".workshop.exs") do
+  ClaudeWrapper.Workshop.load()
+end

--- a/lib/claude_wrapper/workshop.ex
+++ b/lib/claude_wrapper/workshop.ex
@@ -58,6 +58,8 @@ defmodule ClaudeWrapper.Workshop do
 
   ## Lifecycle
 
+    * `load/0` -- load `.workshop.exs` (auto-loaded on startup if present)
+    * `load/1` -- load a specific setup file
     * `reset/1` -- clear an agent's conversation (keeps role and config)
     * `dismiss/1` -- remove an agent entirely
     * `reset_all/0` -- stop everything, clear config
@@ -435,6 +437,43 @@ defmodule ClaudeWrapper.Workshop do
     agents() |> Enum.each(&dismiss/1)
     Agent.update(@state, fn _ -> default_state() end)
     :ok
+  end
+
+  @doc """
+  Load a Workshop setup file (`.exs`).
+
+  The file is evaluated with `import ClaudeWrapper.Workshop` in scope,
+  so it can call `configure/1`, `agent/3`, etc. directly.
+
+  With no argument, looks for `.workshop.exs` in the current directory.
+
+  ## Example file (.workshop.exs)
+
+      configure(working_dir: ".", model: "sonnet",
+        context: "Elixir project. Run mix test before committing.")
+
+      agent(:impl, "You write clean code.", max_turns: 15)
+      agent(:reviewer, "Review only.", model: "opus",
+        allowed_tools: ["Read", "Bash"])
+
+  ## Examples
+
+      load()                        # loads .workshop.exs
+      load("setups/review.exs")     # loads a specific file
+  """
+  @spec load(String.t()) :: :ok | {:error, :not_found}
+  def load(path \\ ".workshop.exs") do
+    path = Path.expand(path)
+
+    if File.exists?(path) do
+      code = "import ClaudeWrapper.Workshop\n" <> File.read!(path)
+      Code.eval_string(code, [], file: path)
+      print_info("Loaded #{path}")
+      :ok
+    else
+      print_error("File not found: #{path}")
+      {:error, :not_found}
+    end
   end
 
   # ── Interaction ───────────────────────────────────────────────

--- a/test/workshop_test.exs
+++ b/test/workshop_test.exs
@@ -241,6 +241,27 @@ defmodule ClaudeWrapper.WorkshopTest do
     end
   end
 
+  describe "load/1" do
+    test "loads a workshop setup file" do
+      path = Path.join(System.tmp_dir!(), "test_workshop_#{:rand.uniform(100_000)}.exs")
+
+      File.write!(path, """
+      configure(model: "sonnet")
+      agent(:loaded, "From file")
+      """)
+
+      assert :ok = Workshop.load(path)
+      assert :loaded in Workshop.agents()
+      assert Workshop.info(:loaded).model == "sonnet"
+
+      File.rm!(path)
+    end
+
+    test "returns error for missing file" do
+      assert {:error, :not_found} = Workshop.load("nonexistent.exs")
+    end
+  end
+
   describe "error handling" do
     test "ask raises for unknown agent" do
       assert_raise ArgumentError, fn ->


### PR DESCRIPTION
## Summary

Load Workshop configuration from `.exs` files. Put your `configure` and `agent` calls in `.workshop.exs` and they auto-load on `iex -S mix`.

### Example `.workshop.exs`

```elixir
configure(working_dir: ".", model: "sonnet",
  context: "Elixir project. Run mix test before committing.")

agent(:impl, "You write clean code.", max_turns: 15)
agent(:reviewer, "Review only.", model: "opus",
  allowed_tools: ["Read", "Bash"])
```

### API

- `load()` -- loads `.workshop.exs` from current directory
- `load("setups/review.exs")` -- loads a specific file
- `.iex.exs` auto-loads `.workshop.exs` on startup if present

The file is evaluated with `import ClaudeWrapper.Workshop` in scope, so `configure`, `agent`, etc. work directly.

## Test plan

- [x] 94 tests pass (2 new load tests)
- [x] `mix format --check-formatted` clean
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo` clean