### PR TITLE
fix: close stdin on Query.stream/2 Port path

### DIFF
--- a/lib/claude_wrapper/command.ex
+++ b/lib/claude_wrapper/command.ex
@@ -51,4 +51,27 @@ defmodule ClaudeWrapper.Command do
       nil -> {:error, {:timeout, timeout}}
     end
   end
+
+  # Build the `:args` list for a `Port.open({:spawn_executable, "/bin/sh"}, ...)`
+  # call that runs `binary` with `args` and redirects stdin from `/dev/null`.
+  # Used by streaming paths (`Query.stream/2`) to prevent the CLI from
+  # blocking on an inherited-but-empty stdin pipe. `System.cmd`-based
+  # callers (the non-streaming `execute` path) close stdin automatically
+  # and do not need this.
+  @doc false
+  @spec shell_cmd_args(String.t(), [String.t()]) :: [String.t()]
+  def shell_cmd_args(binary, args) do
+    escaped_args = Enum.map_join(args, " ", &shell_escape/1)
+    shell_cmd = "#{binary} #{escaped_args} < /dev/null"
+    ["-c", shell_cmd]
+  end
+
+  @doc false
+  def shell_escape(arg) do
+    if String.contains?(arg, ["'", " ", "\"", "\\", "(", ")", "$", "`", "!", "&", "|", ";", "\n"]) do
+      "'" <> String.replace(arg, "'", "'\\''") <> "'"
+    else
+      arg
+    end
+  end
 end

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -23,7 +23,7 @@ defmodule ClaudeWrapper.Query do
       |> Stream.run()
   """
 
-  alias ClaudeWrapper.{Config, Result, StreamEvent}
+  alias ClaudeWrapper.{Command, Config, Result, StreamEvent}
 
   @type permission_mode ::
           :default | :accept_edits | :bypass_permissions | :dont_ask | :plan | :auto
@@ -315,15 +315,16 @@ defmodule ClaudeWrapper.Query do
     base = Config.base_args(config)
     base = if "--verbose" in base, do: base, else: ["--verbose" | base]
     args = base ++ build_args(query)
+    shell_args = Command.shell_cmd_args(config.binary, args)
 
     port_opts =
-      [:binary, :exit_status, {:line, 1_048_576}, {:args, args}] ++
+      [:binary, :exit_status, {:line, 1_048_576}, {:args, shell_args}] ++
         port_env_opts(config) ++
         port_cd_opts(config)
 
     Stream.resource(
       fn ->
-        Port.open({:spawn_executable, config.binary}, port_opts)
+        Port.open({:spawn_executable, "/bin/sh"}, port_opts)
       end,
       fn port ->
         receive do


### PR DESCRIPTION
## Summary

- Preventative fix for the same latent Port-stdin issue that `codex_wrapper_ex` just addressed (see [codex_wrapper_ex#37](https://github.com/joshrotenberg/codex_wrapper_ex/issues/37) / [#38](https://github.com/joshrotenberg/codex_wrapper_ex/pull/38)).
- `Query.stream/2` was opening a raw `Port` with stdin inherited from the parent process. Claude CLI doesn't currently try to read stdin when given a prompt as an arg, so this never triggered a visible hang — but the code path is structurally identical to the one that *does* hang against `codex-cli 0.118+`. If a future Claude CLI version ever peeks at stdin, `Query.stream/2` would hang indefinitely on the open-but-empty pipe.
- Wrap the binary invocation via a new `Command.shell_cmd_args/2` helper that builds a `sh -c "binary args < /dev/null"` invocation, then `Port.open/2` spawns `/bin/sh` with those args.
- The non-streaming `execute` path uses `System.cmd` (which closes stdin automatically) and does not need this fix.

Closes #42.

## Test plan

- [x] `mix test` — 97 tests pass, no regressions
- [x] **Live regression check against `claude 2.1.101`**:
  ```
  Calling Query.stream/2 ...
  Stream completed in 7951ms with 4 events.
  Event types: ["system", "assistant", "rate_limit_event", "result"]
  SUCCESS: saw :result
  ```
  Same event types and similar timing as before the change — the shell wrapper adds no meaningful overhead.

## Background

Discovered while building a `GenAgent` backend adapter against `codex_wrapper_ex`, where this exact bug currently blocks any streaming consumer. Filed [#42](https://github.com/joshrotenberg/claude_wrapper_ex/issues/42) as a preventative issue for symmetry between the two sibling wrappers, and fixing it now keeps them structurally aligned — a future contributor debugging one won't be surprised that the other uses a different pattern.

No new dependencies. Unix only (`/bin/sh`), same as the existing `System.cmd` path.