### PR TITLE
fix: update source URL to genagent org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClaudeWrapper
 
-[![CI](https://github.com/joshrotenberg/claude_wrapper_ex/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude_wrapper_ex/actions/workflows/ci.yml)
+[![CI](https://github.com/genagent/claude_wrapper_ex/actions/workflows/ci.yml/badge.svg)](https://github.com/genagent/claude_wrapper_ex/actions/workflows/ci.yml)
 [![Hex.pm](https://img.shields.io/hexpm/v/claude_wrapper.svg)](https://hex.pm/packages/claude_wrapper)
 [![Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/claude_wrapper)
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ClaudeWrapper.MixProject do
   use Mix.Project
 
   @version "0.5.0"
-  @source_url "https://github.com/joshrotenberg/claude_wrapper_ex"
+  @source_url "https://github.com/genagent/claude_wrapper_ex"
 
   def project do
     [


### PR DESCRIPTION
## Summary

Repository moved from \`joshrotenberg/claude_wrapper_ex\` to
\`genagent/claude_wrapper_ex\` as part of consolidating the
GenAgent ecosystem under a dedicated org. Update package
metadata and README badge so the next published release reflects
the canonical location.

## Files

- \`mix.exs\`: \`@source_url\` (used by docs \`source_url\` and
  package \`links:\`)
- \`README.md\`: CI badge URL

## Why a patch release?

GitHub auto-redirects from the old URL, so existing published
versions remain reachable and there's no user-visible break.
But the stale URL is baked into the hex package metadata for
v0.5.0 (visible on hex.pm/packages/claude_wrapper) -- the only
way to correct it is to publish a new version with the correct
URL. Using \`fix:\` prefix so release-please cuts 0.5.1.