### PR TITLE
docs: replace em dashes with double hyphens

### DIFF
--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -7,7 +7,7 @@ defmodule ClaudeWrapper do
 
   ## Quick start
 
-      # One-shot query (convenience — uses default config)
+      # One-shot query (convenience -- uses default config)
       {:ok, result} = ClaudeWrapper.query("Explain this error: ...")
 
       # With options
@@ -36,11 +36,11 @@ defmodule ClaudeWrapper do
 
   ## Commands
 
-    * `ClaudeWrapper.Query` — the main query/prompt interface
-    * `ClaudeWrapper.Commands.Auth` — login, logout, status, token
-    * `ClaudeWrapper.Commands.Mcp` — MCP server management
-    * `ClaudeWrapper.Commands.Doctor` — CLI health check
-    * `ClaudeWrapper.Commands.Version` — CLI version
+    * `ClaudeWrapper.Query` -- the main query/prompt interface
+    * `ClaudeWrapper.Commands.Auth` -- login, logout, status, token
+    * `ClaudeWrapper.Commands.Mcp` -- MCP server management
+    * `ClaudeWrapper.Commands.Doctor` -- CLI health check
+    * `ClaudeWrapper.Commands.Version` -- CLI version
 
   ## Binary discovery
 

--- a/lib/claude_wrapper/commands/auth.ex
+++ b/lib/claude_wrapper/commands/auth.ex
@@ -1,6 +1,6 @@
 defmodule ClaudeWrapper.Commands.Auth do
   @moduledoc """
-  Authentication commands — login, logout, status, token setup.
+  Authentication commands -- login, logout, status, token setup.
   """
 
   alias ClaudeWrapper.Config
@@ -70,7 +70,7 @@ defmodule ClaudeWrapper.Commands.Auth do
   end
 
   @doc """
-  Login via browser. This is interactive — the CLI will open a browser.
+  Login via browser. This is interactive -- the CLI will open a browser.
   """
   @spec login(Config.t()) :: {:ok, String.t()} | {:error, term()}
   def login(%Config{} = config) do

--- a/lib/claude_wrapper/commands/doctor.ex
+++ b/lib/claude_wrapper/commands/doctor.ex
@@ -1,6 +1,6 @@
 defmodule ClaudeWrapper.Commands.Doctor do
   @moduledoc """
-  `claude doctor` command — checks CLI health.
+  `claude doctor` command -- checks CLI health.
   """
 
   alias ClaudeWrapper.Config

--- a/lib/claude_wrapper/config.ex
+++ b/lib/claude_wrapper/config.ex
@@ -2,7 +2,7 @@ defmodule ClaudeWrapper.Config do
   @moduledoc """
   Shared client configuration for the Claude CLI.
 
-  Equivalent to the Rust `Claude` struct — holds binary path, working directory,
+  Equivalent to the Rust `Claude` struct -- holds binary path, working directory,
   environment variables, and default options that apply across all commands.
 
   ## Usage

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -1,6 +1,6 @@
 defmodule ClaudeWrapper.Query do
   @moduledoc """
-  Query command — the primary interface for executing prompts.
+  Query command -- the primary interface for executing prompts.
 
   Wraps `claude -p <prompt>` with the full set of CLI flags.
 
@@ -120,7 +120,7 @@ defmodule ClaudeWrapper.Query do
     %__MODULE__{prompt: prompt}
   end
 
-  # Builder functions — each returns the updated struct for piping.
+  # Builder functions -- each returns the updated struct for piping.
 
   @doc ~s[Set the model (e.g. "sonnet", "opus", "haiku").]
   @spec model(t(), String.t()) :: t()
@@ -335,7 +335,7 @@ defmodule ClaudeWrapper.Query do
             end
 
           {^port, {:data, {:noeol, _partial}}} ->
-            # Line exceeded buffer — skip for now
+            # Line exceeded buffer -- skip for now
             {[], port}
 
           {^port, {:exit_status, _code}} ->

--- a/lib/claude_wrapper/result.ex
+++ b/lib/claude_wrapper/result.ex
@@ -2,7 +2,7 @@ defmodule ClaudeWrapper.Result do
   @moduledoc """
   Result from a completed query execution.
 
-  Maps to the Rust `QueryResult` — the parsed JSON output from
+  Maps to the Rust `QueryResult` -- the parsed JSON output from
   `--output-format json`.
   """
 

--- a/lib/claude_wrapper/session.ex
+++ b/lib/claude_wrapper/session.ex
@@ -96,7 +96,7 @@ defmodule ClaudeWrapper.Session do
   Send a message and return a stream of events.
 
   Returns `{session, stream}`. The returned `session` is the **same
-  session passed in** — this function does *not* thread `session_id`
+  session passed in** -- this function does *not* thread `session_id`
   across turns. If you need multi-turn continuity, use `send/3`
   instead, which runs the turn synchronously and updates
   `session_id` from the final result.

--- a/lib/claude_wrapper/stream_event.ex
+++ b/lib/claude_wrapper/stream_event.ex
@@ -8,12 +8,12 @@ defmodule ClaudeWrapper.StreamEvent do
   ## Event types
 
   Common event types include:
-  - `"system"` — system initialization
-  - `"assistant"` — assistant message content
-  - `"tool_use"` — tool invocation
-  - `"tool_result"` — tool execution result
-  - `"result"` — final result with cost/session info
-  - `"error"` — error during execution
+  - `"system"` -- system initialization
+  - `"assistant"` -- assistant message content
+  - `"tool_use"` -- tool invocation
+  - `"tool_result"` -- tool execution result
+  - `"result"` -- final result with cost/session info
+  - `"error"` -- error during execution
   """
 
   @type t :: %__MODULE__{


### PR DESCRIPTION
## Summary

- Mechanical sweep: 21 em dashes across 8 files in `lib/` replaced with `--` to match house style (no em dashes in docs or code comments).
- Purely typographic; every hit was an aside/separator in a moduledoc, inline comment, or CLI output format description. No sentence structure or behavior changes.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (97 tests, 0 failures)