### PR TITLE
feat: add :telemetry events for exec/stream/session lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,52 @@ alias ClaudeWrapper.Commands.Marketplace
 {:ok, _} = Marketplace.update(config)
 ```
 
+## Telemetry
+
+ClaudeWrapper emits `:telemetry` events around its core exec paths
+so downstream applications can observe query/session/stream lifecycle
+with a single handler.
+
+Events (all use the `:telemetry.span/3` shape with `:start`, `:stop`,
+and `:exception` suffixes):
+
+| Event | Emitted by |
+|---|---|
+| `[:claude_wrapper, :exec, _]` | `ClaudeWrapper.Query.execute/2` (one-shot query) |
+| `[:claude_wrapper, :stream, _]` | `ClaudeWrapper.Query.stream/2` (NDJSON streaming) |
+| `[:claude_wrapper, :session, :turn, _]` | `ClaudeWrapper.Session.send/3` (single turn) |
+
+Start metadata:
+
+- `:command` -- atom (`:query`, `:stream`, `:session_turn`)
+- `:session_id` -- when known (resumed or provided)
+- `:model` -- from the query's `model` field
+- `:resume?` -- boolean, whether this call threads a previous session
+
+Stop metadata adds:
+
+- `:cost_usd` -- parsed from the final NDJSON result when available
+- `:exit_code` -- `0` on success, non-zero when the CLI exited with an error
+
+Subscribe with:
+
+```elixir
+:telemetry.attach_many(
+  "claude-wrapper-observer",
+  [
+    [:claude_wrapper, :exec, :stop],
+    [:claude_wrapper, :stream, :stop],
+    [:claude_wrapper, :session, :turn, :stop]
+  ],
+  fn event, measurements, metadata, _config ->
+    IO.inspect({event, measurements.duration, metadata})
+  end,
+  nil
+)
+```
+
+See `ClaudeWrapper.Telemetry` for the full event reference.
+
 ## Raw CLI escape hatch
 
 For subcommands not yet wrapped:
@@ -294,6 +340,7 @@ ClaudeWrapper.raw(["config", "list"])
 | `ClaudeWrapper.SessionServer` | GenServer wrapper for sessions |
 | `ClaudeWrapper.McpConfig` | `.mcp.json` builder |
 | `ClaudeWrapper.Retry` | Exponential backoff retry |
+| `ClaudeWrapper.Telemetry` | `:telemetry` spans for exec/stream/session |
 | `ClaudeWrapper.IEx` | Interactive REPL helpers |
 | `ClaudeWrapper.Workshop` | Multi-agent IEx coordination |
 | `ClaudeWrapper.Commands.Auth` | Auth management |

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -23,7 +23,7 @@ defmodule ClaudeWrapper.Query do
       |> Stream.run()
   """
 
-  alias ClaudeWrapper.{Command, Config, Result, StreamEvent}
+  alias ClaudeWrapper.{Command, Config, Result, StreamEvent, Telemetry}
 
   @type permission_mode ::
           :default | :accept_edits | :bypass_permissions | :dont_ask | :plan | :auto
@@ -278,6 +278,11 @@ defmodule ClaudeWrapper.Query do
   @spec execute(t(), Config.t()) :: {:ok, Result.t()} | {:error, term()}
   def execute(%__MODULE__{} = query, %Config{} = config) do
     query = %{query | output_format: :json}
+
+    Telemetry.span_exec(query, fn -> do_execute(query, config) end)
+  end
+
+  defp do_execute(%__MODULE__{} = query, %Config{} = config) do
     # Strip --verbose from base args: it causes the CLI to emit non-JSON
     # output (NDJSON stream lines, stdin warnings) that breaks JSON parsing.
     # Verbose is only meaningful for stream-json output.
@@ -311,6 +316,11 @@ defmodule ClaudeWrapper.Query do
   @spec stream(t(), Config.t()) :: Enumerable.t()
   def stream(%__MODULE__{} = query, %Config{} = config) do
     query = %{query | output_format: :stream_json}
+
+    Telemetry.span_stream(query, fn -> do_stream(query, config) end)
+  end
+
+  defp do_stream(%__MODULE__{} = query, %Config{} = config) do
     # stream-json with --print requires --verbose
     base = Config.base_args(config)
     base = if "--verbose" in base, do: base, else: ["--verbose" | base]

--- a/lib/claude_wrapper/session.ex
+++ b/lib/claude_wrapper/session.ex
@@ -22,7 +22,7 @@ defmodule ClaudeWrapper.Session do
       session = ClaudeWrapper.Session.resume(config, "session-id-abc")
   """
 
-  alias ClaudeWrapper.{Config, Query, Result}
+  alias ClaudeWrapper.{Config, Query, Result, Telemetry}
 
   @type t :: %__MODULE__{
           config: Config.t(),
@@ -75,21 +75,23 @@ defmodule ClaudeWrapper.Session do
   def send(%__MODULE__{} = session, prompt, opts \\ []) do
     query = build_query(session, prompt, opts)
 
-    case Query.execute(query, session.config) do
-      {:ok, result} ->
-        new_session_id = result.session_id || session.session_id
+    Telemetry.span_session_turn(session, query, fn ->
+      case Query.execute(query, session.config) do
+        {:ok, result} ->
+          new_session_id = result.session_id || session.session_id
 
-        updated = %{
-          session
-          | session_id: new_session_id,
-            history: session.history ++ [result]
-        }
+          updated = %{
+            session
+            | session_id: new_session_id,
+              history: session.history ++ [result]
+          }
 
-        {:ok, updated, result}
+          {:ok, updated, result}
 
-      {:error, _} = error ->
-        error
-    end
+        {:error, _} = error ->
+          error
+      end
+    end)
   end
 
   @doc """

--- a/lib/claude_wrapper/telemetry.ex
+++ b/lib/claude_wrapper/telemetry.ex
@@ -1,0 +1,311 @@
+defmodule ClaudeWrapper.Telemetry do
+  @moduledoc """
+  `:telemetry` events emitted by ClaudeWrapper.
+
+  Wraps the core exec paths with `:telemetry.span/3` so downstream
+  applications can subscribe once via `:telemetry.attach_many/4` and
+  observe query, stream, and session-turn lifecycle.
+
+  ## Events
+
+    * `[:claude_wrapper, :exec, :start | :stop | :exception]` --
+      emitted around `ClaudeWrapper.Query.execute/2` (one-shot,
+      synchronous query).
+
+    * `[:claude_wrapper, :stream, :start | :stop | :exception]` --
+      emitted around `ClaudeWrapper.Query.stream/2`. The `:stop`
+      event fires when the returned stream is fully consumed or
+      closed; `:start` fires when the stream is first reduced.
+
+    * `[:claude_wrapper, :session, :turn, :start | :stop | :exception]` --
+      emitted around `ClaudeWrapper.Session.send/3` (a single turn
+      of a multi-turn session).
+
+  ## Measurements
+
+  Automatically populated by `:telemetry.span/3`:
+
+    * `:start` -- `%{monotonic_time: integer(), system_time: integer()}`
+    * `:stop` -- `%{monotonic_time: integer(), duration: integer()}`
+    * `:exception` -- `%{monotonic_time: integer(), duration: integer()}`
+
+  ## Metadata
+
+  Every event carries at least:
+
+    * `:command` -- atom identifying the call site, e.g. `:query`
+      (one-shot execute), `:stream`, or `:session_turn`.
+    * `:session_id` -- present when known (a resumed session, or the
+      `session_id` returned by the CLI in the result).
+    * `:model` -- from `ClaudeWrapper.Query.model/2` or session
+      `query_opts`.
+    * `:resume?` -- boolean, whether this invocation threads a
+      previously established `session_id`.
+
+  `:stop` events additionally include:
+
+    * `:cost_usd` -- parsed from the final NDJSON result, when
+      available.
+    * `:exit_code` -- `0` on success, non-zero when the CLI exited
+      with an error that still produced output, `nil` for other
+      errors.
+
+  `:exception` events follow the standard `:telemetry.span/3` shape
+  and add `:kind`, `:reason`, and `:stacktrace`.
+
+  ## Example
+
+      :telemetry.attach_many(
+        "my-handler",
+        [
+          [:claude_wrapper, :exec, :stop],
+          [:claude_wrapper, :stream, :stop],
+          [:claude_wrapper, :session, :turn, :stop]
+        ],
+        fn event, measurements, metadata, _config ->
+          Logger.info(fn ->
+            "\#{inspect(event)} duration=\#{measurements.duration} cost=\#{inspect(metadata.cost_usd)}"
+          end)
+        end,
+        nil
+      )
+  """
+
+  alias ClaudeWrapper.{Query, Result, StreamEvent}
+
+  @type metadata :: %{optional(atom()) => term()}
+
+  @doc """
+  Wrap a one-shot query execution in a `[:claude_wrapper, :exec, _]` span.
+
+  `fun` must return `{:ok, %Result{}} | {:error, term()}`. Stop
+  metadata is derived from the return value.
+  """
+  @spec span_exec(Query.t(), (-> {:ok, Result.t()} | {:error, term()})) ::
+          {:ok, Result.t()} | {:error, term()}
+  def span_exec(%Query{} = query, fun) when is_function(fun, 0) do
+    start_metadata = exec_start_metadata(query)
+
+    :telemetry.span([:claude_wrapper, :exec], start_metadata, fn ->
+      result = fun.()
+      stop_metadata = Map.merge(start_metadata, exec_stop_metadata(result))
+      {result, stop_metadata}
+    end)
+  end
+
+  @doc """
+  Wrap a streaming query in a `[:claude_wrapper, :stream, _]` span.
+
+  `stream_fun` must return an `Enumerable.t()` of `%StreamEvent{}`.
+  The span's `:start` fires on first reduce, `:stop` fires when the
+  consumer halts or the producer is exhausted. `:stop` metadata
+  captures `cost_usd` / `session_id` from the terminal `result`
+  stream event, when observed.
+  """
+  @spec span_stream(Query.t(), (-> Enumerable.t())) :: Enumerable.t()
+  def span_stream(%Query{} = query, stream_fun) when is_function(stream_fun, 0) do
+    start_metadata = stream_start_metadata(query)
+
+    Stream.resource(
+      fn -> stream_start(start_metadata, stream_fun) end,
+      &stream_next/1,
+      &stream_stop/1
+    )
+  end
+
+  @doc """
+  Wrap a session turn in a `[:claude_wrapper, :session, :turn, _]` span.
+
+  `fun` must return `{:ok, updated_session, %Result{}} | {:error, term()}`.
+  """
+  @spec span_session_turn(
+          map(),
+          Query.t(),
+          (-> {:ok, map(), Result.t()} | {:error, term()})
+        ) ::
+          {:ok, map(), Result.t()} | {:error, term()}
+  def span_session_turn(session, %Query{} = query, fun) when is_function(fun, 0) do
+    start_metadata = session_turn_start_metadata(session, query)
+
+    :telemetry.span([:claude_wrapper, :session, :turn], start_metadata, fn ->
+      result = fun.()
+      stop_metadata = Map.merge(start_metadata, session_turn_stop_metadata(result))
+      {result, stop_metadata}
+    end)
+  end
+
+  # --- Metadata builders ---
+
+  defp exec_start_metadata(%Query{} = query) do
+    %{
+      command: :query,
+      session_id: query.session_id || query.resume,
+      model: query.model,
+      resume?: resume?(query)
+    }
+  end
+
+  defp stream_start_metadata(%Query{} = query) do
+    %{
+      command: :stream,
+      session_id: query.session_id || query.resume,
+      model: query.model,
+      resume?: resume?(query)
+    }
+  end
+
+  defp session_turn_start_metadata(session, %Query{} = query) do
+    session_id = Map.get(session, :session_id)
+
+    %{
+      command: :session_turn,
+      session_id: session_id || query.session_id || query.resume,
+      model: query.model,
+      resume?: is_binary(session_id)
+    }
+  end
+
+  defp exec_stop_metadata({:ok, %Result{} = result}) do
+    %{
+      cost_usd: result.cost_usd,
+      exit_code: 0,
+      session_id: result.session_id
+    }
+  end
+
+  defp exec_stop_metadata({:error, {:exit, code, _stdout}}) do
+    %{cost_usd: nil, exit_code: code}
+  end
+
+  defp exec_stop_metadata({:error, _reason}) do
+    %{cost_usd: nil, exit_code: nil}
+  end
+
+  defp session_turn_stop_metadata({:ok, _session, %Result{} = result}) do
+    %{
+      cost_usd: result.cost_usd,
+      exit_code: 0,
+      session_id: result.session_id
+    }
+  end
+
+  defp session_turn_stop_metadata({:error, {:exit, code, _stdout}}) do
+    %{cost_usd: nil, exit_code: code}
+  end
+
+  defp session_turn_stop_metadata({:error, _reason}) do
+    %{cost_usd: nil, exit_code: nil}
+  end
+
+  defp resume?(%Query{resume: resume, continue_session: continue, session_id: sid}) do
+    is_binary(resume) or continue or is_binary(sid)
+  end
+
+  # --- Stream lifecycle ---
+
+  # `Stream.resource/3` doesn't give us the producer as an
+  # `Enumerable.t()` directly -- we capture the underlying stream's
+  # continuation inside the accumulator so we can step through it.
+  defp stream_start(start_metadata, stream_fun) do
+    monotonic = System.monotonic_time()
+    system = System.system_time()
+
+    :telemetry.execute(
+      [:claude_wrapper, :stream, :start],
+      %{monotonic_time: monotonic, system_time: system},
+      start_metadata
+    )
+
+    enum = stream_fun.()
+    reducer = &Enumerable.reduce(enum, &1, fn elem, acc -> {:suspend, [elem | acc]} end)
+
+    %{
+      metadata: start_metadata,
+      monotonic: monotonic,
+      cont: reducer.({:cont, []})
+    }
+  end
+
+  defp stream_next(%{cont: cont, metadata: metadata} = state) do
+    case cont do
+      {:suspended, [elem | _], continuation} ->
+        updated_metadata = observe_stream_event(metadata, elem)
+
+        {[elem], %{state | metadata: updated_metadata, cont: continuation.({:cont, []})}}
+
+      {:done, _} ->
+        {:halt, %{state | cont: :done}}
+
+      {:halted, _} ->
+        {:halt, %{state | cont: :done}}
+
+      :done ->
+        {:halt, state}
+    end
+  catch
+    kind, reason ->
+      stacktrace = __STACKTRACE__
+      emit_exception(metadata, state.monotonic, kind, reason, stacktrace)
+      :erlang.raise(kind, reason, stacktrace)
+  end
+
+  defp stream_stop(%{cont: cont, metadata: metadata, monotonic: monotonic}) do
+    # If the consumer halted early, we must halt the suspended
+    # producer so its cleanup (closing the Port) runs.
+    _ =
+      case cont do
+        {:suspended, _elems, continuation} ->
+          try do
+            continuation.({:halt, []})
+          catch
+            _, _ -> :ok
+          end
+
+        _ ->
+          :ok
+      end
+
+    duration = System.monotonic_time() - monotonic
+
+    stop_metadata =
+      metadata
+      |> Map.put_new(:cost_usd, nil)
+      |> Map.put_new(:exit_code, 0)
+
+    :telemetry.execute(
+      [:claude_wrapper, :stream, :stop],
+      %{monotonic_time: System.monotonic_time(), duration: duration},
+      stop_metadata
+    )
+  end
+
+  defp emit_exception(metadata, monotonic, kind, reason, stacktrace) do
+    duration = System.monotonic_time() - monotonic
+
+    exception_metadata =
+      metadata
+      |> Map.put(:kind, kind)
+      |> Map.put(:reason, reason)
+      |> Map.put(:stacktrace, stacktrace)
+
+    :telemetry.execute(
+      [:claude_wrapper, :stream, :exception],
+      %{monotonic_time: System.monotonic_time(), duration: duration},
+      exception_metadata
+    )
+  end
+
+  # Inspect stream events to capture session_id / cost_usd from the
+  # terminal `result` event, so :stop metadata can carry them.
+  defp observe_stream_event(metadata, %StreamEvent{type: "result", data: data})
+       when is_map(data) do
+    metadata
+    |> maybe_put(:cost_usd, data["total_cost_usd"] || data["cost_usd"])
+    |> maybe_put(:session_id, data["session_id"])
+  end
+
+  defp observe_stream_event(metadata, _event), do: metadata
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule ClaudeWrapper.MixProject do
   defp deps do
     [
       {:jason, "~> 1.4"},
+      {:telemetry, "~> 1.0"},
       {:anubis_mcp, "~> 1.0", optional: true},
       {:bandit, "~> 1.0", optional: true},
       {:plug, "~> 1.16", optional: true},

--- a/test/claude_wrapper/telemetry_test.exs
+++ b/test/claude_wrapper/telemetry_test.exs
@@ -1,0 +1,215 @@
+defmodule ClaudeWrapper.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias ClaudeWrapper.{Query, Result, StreamEvent, Telemetry}
+
+  @doc false
+  def forward_event(event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry, event, measurements, metadata})
+  end
+
+  setup context do
+    test_pid = self()
+    handler_id = "claude-wrapper-telemetry-test-#{inspect(context.test)}"
+
+    events = [
+      [:claude_wrapper, :exec, :start],
+      [:claude_wrapper, :exec, :stop],
+      [:claude_wrapper, :exec, :exception],
+      [:claude_wrapper, :stream, :start],
+      [:claude_wrapper, :stream, :stop],
+      [:claude_wrapper, :stream, :exception],
+      [:claude_wrapper, :session, :turn, :start],
+      [:claude_wrapper, :session, :turn, :stop],
+      [:claude_wrapper, :session, :turn, :exception]
+    ]
+
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      &__MODULE__.forward_event/4,
+      test_pid
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    :ok
+  end
+
+  describe "span_exec/2" do
+    test "emits :start and :stop with expected metadata on success" do
+      query = Query.new("hi") |> Query.model("sonnet")
+      result = %Result{result: "hello", session_id: "sess-1", cost_usd: 0.42}
+
+      assert {:ok, ^result} = Telemetry.span_exec(query, fn -> {:ok, result} end)
+
+      assert_receive {:telemetry, [:claude_wrapper, :exec, :start], start_meas, start_meta}
+      assert is_integer(start_meas.monotonic_time)
+      assert is_integer(start_meas.system_time)
+      assert start_meta.command == :query
+      assert start_meta.model == "sonnet"
+      assert start_meta.resume? == false
+      assert start_meta.session_id == nil
+
+      assert_receive {:telemetry, [:claude_wrapper, :exec, :stop], stop_meas, stop_meta}
+      assert is_integer(stop_meas.duration)
+      assert stop_meas.duration >= 0
+      assert stop_meta.command == :query
+      assert stop_meta.cost_usd == 0.42
+      assert stop_meta.exit_code == 0
+      assert stop_meta.session_id == "sess-1"
+      assert stop_meta.model == "sonnet"
+    end
+
+    test "sets resume? when query resumes a session" do
+      query = Query.new("hi") |> Query.resume("sess-prev")
+
+      Telemetry.span_exec(query, fn -> {:ok, %Result{}} end)
+
+      assert_receive {:telemetry, [:claude_wrapper, :exec, :start], _, start_meta}
+      assert start_meta.resume? == true
+      assert start_meta.session_id == "sess-prev"
+    end
+
+    test "stop metadata on {:error, {:exit, code, stdout}} carries exit_code" do
+      query = Query.new("hi")
+
+      assert {:error, {:exit, 2, "boom"}} =
+               Telemetry.span_exec(query, fn -> {:error, {:exit, 2, "boom"}} end)
+
+      assert_receive {:telemetry, [:claude_wrapper, :exec, :stop], _, meta}
+      assert meta.exit_code == 2
+      assert meta.cost_usd == nil
+    end
+
+    test "emits :exception when function raises" do
+      query = Query.new("hi")
+
+      assert_raise RuntimeError, "nope", fn ->
+        Telemetry.span_exec(query, fn -> raise "nope" end)
+      end
+
+      assert_receive {:telemetry, [:claude_wrapper, :exec, :exception], meas, meta}
+      assert is_integer(meas.duration)
+      assert meta.kind == :error
+      assert %RuntimeError{message: "nope"} = meta.reason
+      assert is_list(meta.stacktrace)
+    end
+  end
+
+  describe "span_session_turn/3" do
+    test "emits start/stop with resume? true when session has established session_id" do
+      query = Query.new("follow-up")
+      session = %{session_id: "sess-abc"}
+      result = %Result{result: "ack", session_id: "sess-abc", cost_usd: 0.05}
+
+      assert {:ok, _session, ^result} =
+               Telemetry.span_session_turn(session, query, fn ->
+                 {:ok, session, result}
+               end)
+
+      assert_receive {:telemetry, [:claude_wrapper, :session, :turn, :start], _, start_meta}
+      assert start_meta.command == :session_turn
+      assert start_meta.session_id == "sess-abc"
+      assert start_meta.resume? == true
+
+      assert_receive {:telemetry, [:claude_wrapper, :session, :turn, :stop], _, stop_meta}
+      assert stop_meta.cost_usd == 0.05
+      assert stop_meta.exit_code == 0
+      assert stop_meta.session_id == "sess-abc"
+    end
+
+    test "first turn has resume? false when session has no established id" do
+      query = Query.new("first")
+      session = %{session_id: nil}
+
+      Telemetry.span_session_turn(session, query, fn ->
+        {:ok, session, %Result{}}
+      end)
+
+      assert_receive {:telemetry, [:claude_wrapper, :session, :turn, :start], _, meta}
+      assert meta.resume? == false
+    end
+
+    test "error tuple sets exit_code" do
+      query = Query.new("x")
+      session = %{session_id: nil}
+
+      assert {:error, {:exit, 1, "stderr"}} =
+               Telemetry.span_session_turn(session, query, fn ->
+                 {:error, {:exit, 1, "stderr"}}
+               end)
+
+      assert_receive {:telemetry, [:claude_wrapper, :session, :turn, :stop], _, meta}
+      assert meta.exit_code == 1
+      assert meta.cost_usd == nil
+    end
+  end
+
+  describe "span_stream/2" do
+    test "emits :start on first consume and :stop on full consume" do
+      query = Query.new("stream") |> Query.model("opus")
+
+      events = [
+        %StreamEvent{type: "system", data: %{"type" => "system"}},
+        %StreamEvent{
+          type: "result",
+          data: %{
+            "type" => "result",
+            "total_cost_usd" => 0.11,
+            "session_id" => "sess-stream"
+          }
+        }
+      ]
+
+      stream = Telemetry.span_stream(query, fn -> events end)
+      assert Enum.to_list(stream) == events
+
+      assert_receive {:telemetry, [:claude_wrapper, :stream, :start], _, start_meta}
+      assert start_meta.command == :stream
+      assert start_meta.model == "opus"
+
+      assert_receive {:telemetry, [:claude_wrapper, :stream, :stop], meas, stop_meta}
+      assert is_integer(meas.duration)
+      assert stop_meta.cost_usd == 0.11
+      assert stop_meta.session_id == "sess-stream"
+      assert stop_meta.exit_code == 0
+    end
+
+    test "emits :stop on early halt (take/1)" do
+      query = Query.new("stream")
+
+      events = [
+        %StreamEvent{type: "system", data: %{}},
+        %StreamEvent{type: "assistant", data: %{}},
+        %StreamEvent{type: "result", data: %{"total_cost_usd" => 0.5}}
+      ]
+
+      stream = Telemetry.span_stream(query, fn -> events end)
+      assert [%StreamEvent{type: "system"}] = Enum.take(stream, 1)
+
+      assert_receive {:telemetry, [:claude_wrapper, :stream, :start], _, _}
+      assert_receive {:telemetry, [:claude_wrapper, :stream, :stop], _, stop_meta}
+      # Stopped before seeing the result event; cost_usd stays nil.
+      assert stop_meta.cost_usd == nil
+    end
+
+    test "emits :exception when producer raises" do
+      query = Query.new("stream")
+
+      bad_stream =
+        Stream.map([1, 2, 3], fn
+          1 -> %StreamEvent{type: "system", data: %{}}
+          _ -> raise "boom"
+        end)
+
+      stream = Telemetry.span_stream(query, fn -> bad_stream end)
+
+      assert_raise RuntimeError, "boom", fn -> Enum.to_list(stream) end
+
+      assert_receive {:telemetry, [:claude_wrapper, :stream, :exception], _, meta}
+      assert meta.kind == :error
+      assert %RuntimeError{message: "boom"} = meta.reason
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `:telemetry.span/3` wrapping around the core exec paths so
downstream apps (`gen_agent`, `agent_workshop`, etc.) can subscribe
once and observe query lifecycle without per-site wiring.

Events:

- `[:claude_wrapper, :exec, :start | :stop | :exception]` -- `Query.execute/2`
- `[:claude_wrapper, :stream, :start | :stop | :exception]` -- `Query.stream/2`
- `[:claude_wrapper, :session, :turn, :start | :stop | :exception]` -- `Session.send/3`

Start metadata carries `:command`, `:session_id`, `:model`, `:resume?`.
Stop metadata additionally carries `:cost_usd` (parsed from the
final NDJSON result when available) and `:exit_code`.

A new `ClaudeWrapper.Telemetry` helper holds the spanning logic
so call sites stay clean. README gains a Telemetry section
documenting the event names and metadata, and `:telemetry` is now
an explicit dep (it was already present transitively via
`anubis_mcp`/`bandit`).

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` -- 107 passing (7 integration excluded), including
      10 new tests in `test/claude_wrapper/telemetry_test.exs`
      covering start/stop/exception across all three spans and the
      stream-event `cost_usd`/`session_id` capture

Closes #49