### PR TITLE
Add DuplexSession subscribers (PR 2 of 4)

### DIFF
--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -18,24 +18,43 @@ defmodule ClaudeWrapper.DuplexSession do
   See `https://github.com/genagent/claude_wrapper_ex/issues/55` for the
   full design discussion and phased rollout.
 
-  ## PR 1 scope
+  ## Current scope
 
-  This module currently implements the minimal happy path: `start_link/1`,
-  `send/3`, port spawn, line buffering, and `result -> reply`. Subscribers,
-  permission callbacks, and interrupt are **not yet wired** -- they land in
-  follow-up PRs.
+  Implemented so far: minimal happy path (PR 1) and subscribers (PR 2).
+  Permission callbacks (PR 3) and interrupt (PR 4) are **not yet wired**.
 
   ## Usage
 
       config = ClaudeWrapper.Config.new()
 
       {:ok, pid} = ClaudeWrapper.DuplexSession.start_link(config: config)
+
+      # Subscribe the calling process to streaming events.
+      :ok = ClaudeWrapper.DuplexSession.subscribe(pid)
+
       {:ok, result} = ClaudeWrapper.DuplexSession.send(pid, "Say hi.")
 
-      ClaudeWrapper.DuplexSession.session_id(pid)
-      #=> "abc123-..."
+      # Drain subscriber mailbox for streaming events.
+      flush()
+      #=> {:claude, {:system_init, "abc123-..."}}
+      #=> {:claude, {:assistant, %{...}}}
+      #=> {:claude, {:result, %ClaudeWrapper.Result{}}}
 
       ClaudeWrapper.DuplexSession.stop(pid)
+
+  ## Subscriber events
+
+  Subscribers receive plain messages of the form `{:claude, event}`:
+
+    * `{:system_init, session_id}` -- the CLI's init event
+    * `{:assistant, msg}` -- a full assistant turn (`SDKAssistantMessage`)
+    * `{:stream_event, msg}` -- a partial assistant token
+      (`SDKPartialAssistantMessage`)
+    * `{:user, msg}` -- a user message (e.g. tool results, replays)
+    * `{:result, %ClaudeWrapper.Result{}}` -- the parsed turn boundary
+
+  Subscribers are monitored; if a subscriber crashes or exits, it is
+  automatically removed.
   """
 
   use GenServer
@@ -54,7 +73,8 @@ defmodule ClaudeWrapper.DuplexSession do
           config: Config.t(),
           session_id: String.t() | nil,
           buffer: binary(),
-          pending_turn: {GenServer.from(), [map()]} | nil
+          pending_turn: {GenServer.from(), [map()]} | nil,
+          subscribers: %{pid() => reference()}
         }
 
   defstruct [
@@ -62,7 +82,8 @@ defmodule ClaudeWrapper.DuplexSession do
     :config,
     :session_id,
     buffer: <<>>,
-    pending_turn: nil
+    pending_turn: nil,
+    subscribers: %{}
   ]
 
   # --- Public API ------------------------------------------------------
@@ -108,6 +129,24 @@ defmodule ClaudeWrapper.DuplexSession do
   def session_id(server), do: GenServer.call(server, :session_id)
 
   @doc """
+  Subscribe the calling process to streaming events.
+
+  Subscribers receive plain `{:claude, event}` messages -- see the
+  module doc for the event vocabulary. The subscriber is monitored;
+  if it exits, it is automatically removed.
+
+  Subscribing the same process twice is a no-op.
+  """
+  @spec subscribe(GenServer.server()) :: :ok
+  def subscribe(server), do: GenServer.call(server, {:subscribe, self()})
+
+  @doc """
+  Stop sending events to the calling process. Idempotent.
+  """
+  @spec unsubscribe(GenServer.server()) :: :ok
+  def unsubscribe(server), do: GenServer.call(server, {:unsubscribe, self()})
+
+  @doc """
   Stop the session. Closes the port, waits for the child to exit, and
   shuts down the GenServer.
   """
@@ -124,7 +163,10 @@ defmodule ClaudeWrapper.DuplexSession do
     config = Keyword.fetch!(opts, :config)
     extra_args = Keyword.get(opts, :extra_args, [])
 
-    args = build_args(extra_args)
+    # Tests substitute a fake binary (e.g. `cat`) that does not understand
+    # the duplex flag set; they pass `:args_override` to bypass defaults.
+    # Not part of the public surface.
+    args = Keyword.get(opts, :args_override, build_args(extra_args))
 
     port_opts =
       [:binary, :exit_status, :use_stdio, {:args, args}] ++
@@ -158,6 +200,22 @@ defmodule ClaudeWrapper.DuplexSession do
 
   def handle_call(:session_id, _from, state), do: {:reply, state.session_id, state}
 
+  def handle_call({:subscribe, pid}, _from, state) do
+    state =
+      if Map.has_key?(state.subscribers, pid) do
+        state
+      else
+        ref = Process.monitor(pid)
+        %{state | subscribers: Map.put(state.subscribers, pid, ref)}
+      end
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:unsubscribe, pid}, _from, state) do
+    {:reply, :ok, drop_subscriber(state, pid)}
+  end
+
   @impl true
   def handle_info({port, {:data, chunk}}, %{port: port} = state) do
     {complete, rest} = split_lines(state.buffer <> chunk)
@@ -173,6 +231,13 @@ defmodule ClaudeWrapper.DuplexSession do
   def handle_info({:EXIT, port, reason}, %{port: port} = state) do
     state = fail_pending(state, {:port_exit, reason})
     {:stop, :normal, %{state | port: nil}}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    case Map.get(state.subscribers, pid) do
+      ^ref -> {:noreply, %{state | subscribers: Map.delete(state.subscribers, pid)}}
+      _ -> {:noreply, state}
+    end
   end
 
   def handle_info(_other, state), do: {:noreply, state}
@@ -227,24 +292,67 @@ defmodule ClaudeWrapper.DuplexSession do
 
   # system/init carries the session_id we'll need for resume in later PRs.
   defp dispatch(%{"type" => "system", "subtype" => "init", "session_id" => sid}, state) do
+    broadcast(state, {:system_init, sid})
     %{state | session_id: sid}
   end
 
   # Turn boundary: reply to the waiting caller with a parsed Result.
   defp dispatch(%{"type" => "result"} = msg, %{pending_turn: {from, _events}} = state) do
-    GenServer.reply(from, {:ok, Result.from_json(msg)})
+    result = Result.from_json(msg)
+    broadcast(state, {:result, result})
+    GenServer.reply(from, {:ok, result})
     %{state | pending_turn: nil}
   end
 
-  defp dispatch(%{"type" => "result"}, state), do: state
+  defp dispatch(%{"type" => "result"} = msg, state) do
+    broadcast(state, {:result, Result.from_json(msg)})
+    state
+  end
 
-  # Within an active turn, accumulate every other event for later use
-  # (subscribers in PR 2 will read these). Outside a turn, drop.
-  defp dispatch(msg, %{pending_turn: {from, events}} = state) do
+  defp dispatch(%{"type" => "assistant"} = msg, state) do
+    broadcast(state, {:assistant, msg})
+    accumulate(state, msg)
+  end
+
+  defp dispatch(%{"type" => "stream_event"} = msg, state) do
+    broadcast(state, {:stream_event, msg})
+    accumulate(state, msg)
+  end
+
+  defp dispatch(%{"type" => "user"} = msg, state) do
+    broadcast(state, {:user, msg})
+    accumulate(state, msg)
+  end
+
+  # Other system subtypes (e.g. compact_boundary), unknown types: still
+  # accumulate inside an active turn so callers that later inspect the
+  # turn record can see them, but do not broadcast as a typed event.
+  defp dispatch(msg, state), do: accumulate(state, msg)
+
+  defp accumulate(%{pending_turn: {from, events}} = state, msg) do
     %{state | pending_turn: {from, [msg | events]}}
   end
 
-  defp dispatch(_msg, state), do: state
+  defp accumulate(state, _msg), do: state
+
+  defp broadcast(%{subscribers: subs}, _event) when map_size(subs) == 0, do: :ok
+
+  defp broadcast(%{subscribers: subs}, event) do
+    Enum.each(subs, fn {pid, _ref} ->
+      Process.send(pid, {:claude, event}, [])
+    end)
+  end
+
+  defp drop_subscriber(state, pid) do
+    case Map.pop(state.subscribers, pid) do
+      {nil, _} ->
+        state
+
+      {ref, rest} ->
+        Process.demonitor(ref, [:flush])
+        %{state | subscribers: rest}
+    end
+  end
 
   defp fail_pending(%{pending_turn: nil} = state, _reason), do: state
 

--- a/test/claude_wrapper/duplex_session_test.exs
+++ b/test/claude_wrapper/duplex_session_test.exs
@@ -1,7 +1,28 @@
 defmodule ClaudeWrapper.DuplexSessionTest do
   use ExUnit.Case, async: true
 
-  alias ClaudeWrapper.DuplexSession
+  alias ClaudeWrapper.{Config, DuplexSession}
+
+  # Helper: spawn a DuplexSession against `cat` so we can inject NDJSON
+  # bytes via Port.command/2 and observe how the GenServer demuxes them.
+  # cat does not understand the duplex flags but it doesn't have to --
+  # Port.command writes raw bytes to its stdin, which `cat` echoes back
+  # to stdout. The duplex_session reads and dispatches them as if they
+  # came from real claude.
+  defp start_with_fake_claude do
+    config = Config.new(binary: System.find_executable("cat"))
+    # cat does not understand the duplex flags, so override args entirely
+    # via the test-only :args_override hook.
+    {:ok, pid} = DuplexSession.start_link(config: config, args_override: [])
+    pid
+  end
+
+  defp inject(pid, term) do
+    state = :sys.get_state(pid)
+    Port.command(state.port, [Jason.encode!(term), ?\n])
+    # Yield so the inbound :data message is processed before we return.
+    :sys.get_state(pid)
+  end
 
   describe "split_lines/1" do
     test "empty buffer yields no complete lines" do
@@ -64,6 +85,135 @@ defmodule ClaudeWrapper.DuplexSessionTest do
 
       assert Enum.at(args, input_idx + 1) == "stream-json"
       assert Enum.at(args, output_idx + 1) == "stream-json"
+    end
+  end
+
+  describe "subscribe / unsubscribe (with fake claude)" do
+    test "broadcasts assistant events to subscribers" do
+      pid = start_with_fake_claude()
+
+      try do
+        :ok = DuplexSession.subscribe(pid)
+
+        inject(pid, %{type: "assistant", message: %{content: "hi"}, session_id: "s1"})
+
+        assert_receive {:claude, {:assistant, %{"type" => "assistant"}}}, 1_000
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "broadcasts system_init with the session id" do
+      pid = start_with_fake_claude()
+
+      try do
+        :ok = DuplexSession.subscribe(pid)
+
+        inject(pid, %{type: "system", subtype: "init", session_id: "abc-123"})
+
+        assert_receive {:claude, {:system_init, "abc-123"}}, 1_000
+        assert DuplexSession.session_id(pid) == "abc-123"
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "broadcasts stream_event and user events" do
+      pid = start_with_fake_claude()
+
+      try do
+        :ok = DuplexSession.subscribe(pid)
+
+        inject(pid, %{type: "stream_event", event: %{delta: "hel"}})
+        inject(pid, %{type: "user", message: %{content: "tool result"}})
+
+        assert_receive {:claude, {:stream_event, %{"type" => "stream_event"}}}, 1_000
+        assert_receive {:claude, {:user, %{"type" => "user"}}}, 1_000
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "subscribing twice does not double-deliver" do
+      pid = start_with_fake_claude()
+
+      try do
+        :ok = DuplexSession.subscribe(pid)
+        :ok = DuplexSession.subscribe(pid)
+
+        inject(pid, %{type: "assistant", message: %{}, session_id: "s1"})
+
+        assert_receive {:claude, {:assistant, _}}, 1_000
+        refute_receive {:claude, {:assistant, _}}, 200
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "unsubscribe stops further messages" do
+      pid = start_with_fake_claude()
+
+      try do
+        :ok = DuplexSession.subscribe(pid)
+        :ok = DuplexSession.unsubscribe(pid)
+
+        inject(pid, %{type: "assistant", message: %{}, session_id: "s1"})
+
+        refute_receive {:claude, _}, 200
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "subscribers are auto-removed when they exit" do
+      pid = start_with_fake_claude()
+
+      try do
+        # A short-lived subscriber that subscribes, waits for an ack,
+        # then dies. The session should detect the :DOWN and drop it.
+        parent = self()
+
+        sub =
+          spawn(fn ->
+            :ok = DuplexSession.subscribe(pid)
+            Kernel.send(parent, :subscribed)
+
+            receive do
+              :exit -> :ok
+            end
+          end)
+
+        assert_receive :subscribed, 1_000
+        assert :sys.get_state(pid).subscribers |> Map.has_key?(sub)
+
+        Kernel.send(sub, :exit)
+
+        # Wait for the GenServer to process the :DOWN.
+        wait_until(fn ->
+          not Map.has_key?(:sys.get_state(pid).subscribers, sub)
+        end)
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+  end
+
+  defp wait_until(fun, deadline_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) > deadline ->
+        flunk("condition not met before deadline")
+
+      true ->
+        Process.sleep(10)
+        do_wait_until(fun, deadline)
     end
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -153,6 +153,41 @@ defmodule ClaudeWrapper.IntegrationTest do
       end
     end
 
+    test "subscriber sees system_init, assistant, and result in order", %{config: config} do
+      {:ok, pid} =
+        DuplexSession.start_link(
+          config: config,
+          extra_args: [
+            "--permission-mode",
+            "plan",
+            "--max-turns",
+            "1",
+            "--no-session-persistence"
+          ]
+        )
+
+      try do
+        :ok = DuplexSession.subscribe(pid)
+
+        send_task =
+          Task.async(fn ->
+            DuplexSession.send(pid, "Respond with exactly: hello world")
+          end)
+
+        # The CLI emits system/init first, then at least one assistant turn,
+        # then a result. We assert the boundary events arrive in that order.
+        assert_receive {:claude, {:system_init, sid}}, 60_000
+        assert is_binary(sid)
+
+        assert_receive {:claude, {:assistant, %{"type" => "assistant"}}}, 120_000
+        assert_receive {:claude, {:result, %ClaudeWrapper.Result{}}}, 120_000
+
+        assert {:ok, %ClaudeWrapper.Result{}} = Task.await(send_task, 120_000)
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
     test "rejects overlapping sends with :turn_in_flight", %{config: config} do
       {:ok, pid} =
         DuplexSession.start_link(


### PR DESCRIPTION
## Summary

Second of four PRs for #55. Adds live event broadcasting to
`ClaudeWrapper.DuplexSession` so multiple processes can observe a
turn as it streams.

- `subscribe/1` -- monitors the calling process and adds it to the
  subscriber set
- `unsubscribe/1` -- explicit removal; idempotent
- Auto-cleanup when a subscriber crashes/exits (`:DOWN` handler)
- Broadcast inside `dispatch/2` for `system_init`, `assistant`,
  `stream_event`, `user`, and `result`. Subscribers receive
  `{:claude, event}` messages

The result is broadcast both to subscribers AND replied to the caller
of `send/3`. If those happen to be the same pid, the result arrives
twice -- documented in the moduledoc; callers can pattern-match on
whichever they want.

## Internals

- New state field `subscribers :: %{pid() => reference()}` keyed by
  subscriber pid, value is the monitor ref so we can demonitor on
  unsubscribe
- New init option `:args_override` (undocumented, test-only) lets
  tests spawn DuplexSession against a fake binary like `cat` without
  the duplex flag set, so they can inject NDJSON directly via
  `Port.command/2` and verify dispatch behavior

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- no issues
- [x] `mix dialyzer` -- no errors
- [x] `mix test` -- 124 passing, 0 failures (17 unit tests for
  DuplexSession; was 11 in PR 1)
- [x] `mix test --only integration` for DuplexSession tests:
  - new: subscriber sees `system_init`, `assistant`, `result` in order
  - PR 1's two tests still pass against the new code

## Out of scope (follow-up PRs)

- PR 3: permissions (`on_permission` callback,
  `--permission-prompt-tool stdio`, inbound `can_use_tool`)
- PR 4: interrupt + graceful close (outbound `control_request` with
  `request_id -> from` table)

Refs #55

Release Notes:

- Added `subscribe/1` and `unsubscribe/1` to
  `ClaudeWrapper.DuplexSession` so processes can observe streaming
  events on a long-lived session.