### PR TITLE
Add ClaudeWrapper.DuplexIEx for interactive REPL sessions

### DIFF
--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -1,0 +1,332 @@
+defmodule ClaudeWrapper.DuplexIEx do
+  @moduledoc """
+  Interactive helpers for driving `ClaudeWrapper.DuplexSession` from IEx.
+
+  Spawns a long-lived `claude` subprocess, holds it across many turns,
+  and prints streaming text deltas to stdout as they arrive. Sibling to
+  `ClaudeWrapper.IEx`, which uses the simpler per-call `Query`/`Session`
+  flow.
+
+  ## Usage
+
+      iex> import ClaudeWrapper.DuplexIEx
+
+      iex> start(working_dir: ".")
+      Claude session started.
+
+      iex> say("Explain the README briefly.")
+      ...streams text...
+      ($0.0123, 1 turn)
+      :ok
+
+      iex> say("Now suggest a one-line tagline.")
+      ...streams text...
+      :ok
+
+      iex> interrupt()
+      :ok
+
+      iex> stop()
+      :ok
+
+  ## When to use this vs `ClaudeWrapper.IEx`
+
+  Both are interactive REPL surfaces. `ClaudeWrapper.IEx` (the
+  pre-existing one) spawns a fresh `claude` subprocess per turn and is
+  the simplest thing that works for casual use. `ClaudeWrapper.DuplexIEx`
+  holds one subprocess open, so subsequent turns avoid CLI cold start
+  and the experience feels more like talking to a chat UI -- partial
+  tokens appear as they're generated, mid-turn cancel via `interrupt/0`
+  is clean, and a permission callback can react to tool requests in
+  flight.
+
+  ## Defaults
+
+  - Working dir defaults to `File.cwd!()` so the session sees your
+    current project
+  - Permission mode defaults to `"bypassPermissions"` so tool calls
+    just work in the REPL without a permission callback. **This is
+    not safe** for prompts you do not control. For trustworthy use,
+    pass `permission_mode: "default"` and an `on_permission` callback
+  - All `ClaudeWrapper.Config` options (`:binary`, `:env`, `:timeout`,
+    etc.) are accepted and forwarded to `Config.new/1`
+  - All `ClaudeWrapper.DuplexSession` options (`:on_permission`,
+    `:extra_args`) are forwarded as well
+  """
+
+  alias ClaudeWrapper.{Config, DuplexSession, Result}
+
+  @session_key :claude_wrapper_duplex_iex_session
+  @printer_key :claude_wrapper_duplex_iex_printer
+
+  # --- Public API -----------------------------------------------------
+
+  @doc """
+  Start a new duplex session and a streaming printer process.
+
+  Stores the session pid and printer pid in the process dictionary
+  for the rest of the helpers to find. If a session is already
+  running for this process, it is stopped first.
+  """
+  @spec start(keyword()) :: :ok | {:error, term()}
+  def start(opts \\ []) do
+    if Process.get(@session_key), do: stop()
+
+    {config_opts, duplex_opts} = split_opts(opts)
+
+    config_opts =
+      Keyword.put_new_lazy(config_opts, :working_dir, fn -> File.cwd!() end)
+
+    config = Config.new(config_opts)
+
+    extra_args =
+      duplex_opts
+      |> Keyword.get(:extra_args, [])
+      |> ensure_permission_mode(duplex_opts)
+
+    duplex_opts =
+      duplex_opts
+      |> Keyword.delete(:extra_args)
+      |> Keyword.put(:config, config)
+      |> Keyword.put(:extra_args, extra_args)
+
+    case DuplexSession.start_link(duplex_opts) do
+      {:ok, pid} ->
+        printer = spawn_printer(pid)
+        Process.put(@session_key, pid)
+        Process.put(@printer_key, printer)
+        IO.puts("\e[33mClaude session started.\e[0m")
+        :ok
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Send a prompt in the current session. Streaming text is printed as
+  it arrives. Returns `:ok` on success or `{:error, reason}` on failure.
+
+  Per-call options:
+    * `:timeout` -- override the 120-second default for this turn
+
+  All other options are ignored at this layer; pass DuplexSession
+  options (such as `:on_permission`) to `start/1` instead.
+  """
+  @spec say(String.t(), keyword()) :: :ok | {:error, term()}
+  def say(prompt, opts \\ []) when is_binary(prompt) do
+    case Process.get(@session_key) do
+      nil ->
+        IO.puts("\e[31mNo active session. Start one with start/1.\e[0m")
+        {:error, :no_session}
+
+      pid ->
+        timeout = Keyword.get(opts, :timeout, 120_000)
+
+        case DuplexSession.send(pid, prompt, timeout) do
+          {:ok, %Result{} = result} ->
+            print_meta(result)
+            :ok
+
+          {:error, reason} ->
+            IO.puts("\e[31mError: #{inspect(reason)}\e[0m")
+            {:error, reason}
+        end
+    end
+  end
+
+  @doc """
+  Cancel the current in-flight turn. Returns `:ok` once the CLI
+  acknowledges, or `{:error, reason}` if no session is running.
+  """
+  @spec interrupt(timeout()) :: :ok | {:error, term()}
+  def interrupt(timeout \\ 10_000) do
+    case Process.get(@session_key) do
+      nil ->
+        IO.puts("\e[31mNo active session.\e[0m")
+        {:error, :no_session}
+
+      pid ->
+        DuplexSession.interrupt(pid, timeout)
+    end
+  end
+
+  @doc """
+  Stop the current session, kill the printer, and clear stored state.
+  """
+  @spec stop() :: :ok
+  def stop do
+    if printer = Process.delete(@printer_key) do
+      Process.exit(printer, :shutdown)
+    end
+
+    if pid = Process.delete(@session_key) do
+      try do
+        DuplexSession.close(pid)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+
+    IO.puts("\e[33mSession stopped.\e[0m")
+    :ok
+  end
+
+  @doc """
+  Print the current session's id and pid.
+  """
+  @spec status() :: :ok | :no_session
+  def status do
+    case Process.get(@session_key) do
+      nil ->
+        IO.puts("\e[31mNo active session.\e[0m")
+        :no_session
+
+      pid ->
+        sid = DuplexSession.session_id(pid)
+        IO.puts("\e[33mSession #{sid || "<not yet initialized>"} (#{inspect(pid)})\e[0m")
+        :ok
+    end
+  end
+
+  @doc """
+  Return the CLI session id for resuming later, or `nil` if no
+  session is running.
+  """
+  @spec session_id() :: String.t() | nil
+  def session_id do
+    case Process.get(@session_key) do
+      nil -> nil
+      pid -> DuplexSession.session_id(pid)
+    end
+  end
+
+  @doc """
+  Return the raw `DuplexSession` pid for direct API access, or `nil`.
+  """
+  @spec pid() :: pid() | nil
+  def pid, do: Process.get(@session_key)
+
+  # --- Printer process -----------------------------------------------
+
+  # The printer subscribes to the session and writes incremental text
+  # to stdout. Running it in a separate process keeps the user's IEx
+  # mailbox clean and isolates the GenServer from any IO failure.
+  @doc false
+  def spawn_printer(session_pid) do
+    parent = self()
+
+    spawn_link(fn ->
+      Process.flag(:trap_exit, true)
+      :ok = DuplexSession.subscribe(session_pid)
+      Kernel.send(parent, :printer_subscribed)
+      printer_loop()
+    end)
+    |> tap(fn _printer ->
+      receive do
+        :printer_subscribed -> :ok
+      after
+        2_000 -> :ok
+      end
+    end)
+  end
+
+  defp printer_loop do
+    receive do
+      {:claude, event} ->
+        handle_event(event)
+        printer_loop()
+
+      {:EXIT, _from, _reason} ->
+        :ok
+
+      :stop ->
+        :ok
+
+      _ ->
+        printer_loop()
+    end
+  end
+
+  @doc false
+  def handle_event({:stream_event, %{"event" => %{"delta" => %{"text" => text}}}})
+      when is_binary(text) do
+    IO.write(text)
+  end
+
+  def handle_event({:stream_event, _other}), do: :ok
+
+  def handle_event({:assistant, _msg}), do: :ok
+
+  def handle_event({:user, %{"message" => %{"content" => content}}}) when is_list(content) do
+    Enum.each(content, fn
+      %{"type" => "tool_result", "content" => parts} when is_list(parts) ->
+        text =
+          Enum.map_join(parts, "", fn
+            %{"type" => "text", "text" => t} -> t
+            _ -> ""
+          end)
+
+        if text != "", do: IO.write("\n\e[2m[tool] #{truncate(text, 200)}\e[0m\n")
+
+      _ ->
+        :ok
+    end)
+  end
+
+  def handle_event({:user, _other}), do: :ok
+
+  def handle_event({:system_init, sid}) do
+    IO.puts("\e[2m[session #{sid}]\e[0m")
+  end
+
+  def handle_event({:result, _result}) do
+    # The final newline + cost meta is printed by the say/2 caller via
+    # print_meta/1; the printer just stops accumulating text here.
+    IO.puts("")
+  end
+
+  def handle_event(_other), do: :ok
+
+  # --- Private --------------------------------------------------------
+
+  defp print_meta(%Result{} = result) do
+    cost_str =
+      if result.cost_usd, do: "$#{Float.round(result.cost_usd, 4)}", else: "?"
+
+    turns_str = "#{result.num_turns || 1} turn#{plural(result.num_turns || 1)}"
+
+    IO.puts("\e[33m(#{cost_str}, #{turns_str})\e[0m")
+  end
+
+  @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]
+
+  defp split_opts(opts) do
+    Enum.split_with(opts, fn {k, _v} -> k in @config_keys end)
+  end
+
+  defp ensure_permission_mode(extra_args, duplex_opts) do
+    cond do
+      "--permission-mode" in extra_args or "--dangerously-skip-permissions" in extra_args ->
+        extra_args
+
+      Keyword.has_key?(duplex_opts, :on_permission) ->
+        # Caller has provided a callback; let the CLI default to the
+        # mode that prompts (i.e., "default") so the callback fires.
+        ["--permission-mode", "default" | extra_args]
+
+      true ->
+        # No callback and no explicit mode: skip permissions entirely
+        # for REPL ergonomics. This matches the existing IEx test
+        # behavior. Pass --permission-mode "default" + an
+        # :on_permission callback for trustworthy use.
+        ["--dangerously-skip-permissions" | extra_args]
+    end
+  end
+
+  defp truncate(s, max) when byte_size(s) <= max, do: s
+  defp truncate(s, max), do: binary_part(s, 0, max - 1) <> "…"
+
+  defp plural(1), do: ""
+  defp plural(_), do: "s"
+end

--- a/test/claude_wrapper/duplex_iex_test.exs
+++ b/test/claude_wrapper/duplex_iex_test.exs
@@ -1,0 +1,225 @@
+defmodule ClaudeWrapper.DuplexIExTest do
+  # async: false because the helpers stash state in the process
+  # dictionary; running concurrently with other tests in the same
+  # process is fine, but we don't want to share that state across
+  # parallel cases.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias ClaudeWrapper.{Config, DuplexIEx, DuplexSession}
+
+  setup do
+    on_exit(fn -> safely_stop() end)
+    :ok
+  end
+
+  defp safely_stop do
+    DuplexIEx.stop()
+  catch
+    _, _ -> :ok
+  end
+
+  defp start_with_fake_claude(opts \\ []) do
+    config_opts = [binary: System.find_executable("cat")]
+    # args_override bypasses build_args entirely so cat doesn't see
+    # any real --flags. We can't go through DuplexIEx.start/1 with a
+    # broken binary because it would crash; bypass with start_link.
+    duplex_opts =
+      [args_override: []]
+      |> Keyword.merge(opts)
+
+    config = Config.new(config_opts)
+
+    {:ok, pid} = DuplexSession.start_link([config: config] ++ duplex_opts)
+    pid
+  end
+
+  # The tricky bit for these tests: DuplexIEx.start/1 spawns the real
+  # claude binary by default. To exercise the pure-function helpers
+  # without hitting the network, we install a fake session manually
+  # via the stash hook below.
+  defp install_fake_session do
+    pid = start_with_fake_claude()
+    Process.put(:claude_wrapper_duplex_iex_session, pid)
+    pid
+  end
+
+  describe "say/2" do
+    test "prints error when no session is active" do
+      output = capture_io(fn -> assert {:error, :no_session} = DuplexIEx.say("hi") end)
+      assert output =~ "No active session"
+    end
+  end
+
+  describe "interrupt/1" do
+    test "returns :no_session when no session is active" do
+      capture_io(fn -> assert {:error, :no_session} = DuplexIEx.interrupt() end)
+    end
+  end
+
+  describe "stop/0" do
+    test "is a no-op when no session is running" do
+      output = capture_io(fn -> assert :ok = DuplexIEx.stop() end)
+      assert output =~ "Session stopped"
+    end
+
+    test "shuts down a running session and clears state" do
+      pid = install_fake_session()
+      assert Process.alive?(pid)
+
+      capture_io(fn -> assert :ok = DuplexIEx.stop() end)
+
+      refute Process.get(:claude_wrapper_duplex_iex_session)
+      refute Process.alive?(pid)
+    end
+  end
+
+  describe "session_id/0 and pid/0" do
+    test "return nil when no session" do
+      assert is_nil(DuplexIEx.session_id())
+      assert is_nil(DuplexIEx.pid())
+    end
+
+    test "session_id returns whatever the session reports" do
+      _pid = install_fake_session()
+      # Fake claude has no system/init, so session_id is nil.
+      assert is_nil(DuplexIEx.session_id())
+    end
+
+    test "pid/0 returns the underlying DuplexSession pid" do
+      pid = install_fake_session()
+      assert DuplexIEx.pid() == pid
+    end
+  end
+
+  describe "status/0" do
+    test "prints :no_session when no session" do
+      output = capture_io(fn -> assert :no_session = DuplexIEx.status() end)
+      assert output =~ "No active session"
+    end
+
+    test "prints session id and pid when active" do
+      _pid = install_fake_session()
+      output = capture_io(fn -> assert :ok = DuplexIEx.status() end)
+      assert output =~ "Session"
+    end
+  end
+
+  describe "handle_event/1 (stream printing)" do
+    test "prints text deltas to stdout" do
+      output =
+        capture_io(fn ->
+          DuplexIEx.handle_event(
+            {:stream_event, %{"event" => %{"delta" => %{"text" => "hello"}}}}
+          )
+        end)
+
+      assert output == "hello"
+    end
+
+    test "concatenates multiple deltas without newlines" do
+      output =
+        capture_io(fn ->
+          DuplexIEx.handle_event({:stream_event, %{"event" => %{"delta" => %{"text" => "hel"}}}})
+          DuplexIEx.handle_event({:stream_event, %{"event" => %{"delta" => %{"text" => "lo"}}}})
+        end)
+
+      assert output == "hello"
+    end
+
+    test "ignores non-text deltas" do
+      output =
+        capture_io(fn ->
+          DuplexIEx.handle_event(
+            {:stream_event, %{"event" => %{"delta" => %{"partial_json" => "{\"x\":"}}}}
+          )
+        end)
+
+      assert output == ""
+    end
+
+    test "prints a session marker on system_init" do
+      output =
+        capture_io(fn ->
+          DuplexIEx.handle_event({:system_init, "abc-123"})
+        end)
+
+      assert output =~ "abc-123"
+    end
+
+    test "prints a tool result excerpt for user/tool_result events" do
+      event =
+        {:user,
+         %{
+           "message" => %{
+             "content" => [
+               %{
+                 "type" => "tool_result",
+                 "content" => [%{"type" => "text", "text" => "hello world"}]
+               }
+             ]
+           }
+         }}
+
+      output = capture_io(fn -> DuplexIEx.handle_event(event) end)
+      assert output =~ "hello world"
+    end
+
+    test "truncates long tool results" do
+      long_text = String.duplicate("x", 500)
+
+      event =
+        {:user,
+         %{
+           "message" => %{
+             "content" => [
+               %{
+                 "type" => "tool_result",
+                 "content" => [%{"type" => "text", "text" => long_text}]
+               }
+             ]
+           }
+         }}
+
+      output = capture_io(fn -> DuplexIEx.handle_event(event) end)
+      # Truncated to 200 chars + ellipsis, ANSI dim codes around it.
+      refute output =~ String.duplicate("x", 250)
+      assert output =~ "…"
+    end
+
+    test "ignores unknown events" do
+      assert capture_io(fn ->
+               DuplexIEx.handle_event({:other, %{}})
+               DuplexIEx.handle_event(:weird)
+             end) == ""
+    end
+  end
+
+  describe "spawn_printer/1" do
+    test "subscribes to the session and prints arriving events" do
+      pid = start_with_fake_claude()
+
+      output =
+        capture_io(fn ->
+          _printer = DuplexIEx.spawn_printer(pid)
+
+          # Inject a stream_event via the same trick the unit suite
+          # uses for DuplexSession: write JSON to cat's stdin.
+          state = :sys.get_state(pid)
+
+          Port.command(state.port, [
+            Jason.encode!(%{type: "stream_event", event: %{delta: %{text: "hi"}}}),
+            ?\n
+          ])
+
+          # Wait briefly for the printer to receive and write.
+          Process.sleep(100)
+        end)
+
+      assert output =~ "hi"
+
+      DuplexSession.stop(pid)
+    end
+  end
+end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -267,4 +267,34 @@ defmodule ClaudeWrapper.IntegrationTest do
       end
     end
   end
+
+  describe "DuplexIEx" do
+    alias ClaudeWrapper.DuplexIEx
+
+    setup do
+      on_exit(fn ->
+        try do
+          DuplexIEx.stop()
+        catch
+          _, _ -> :ok
+        end
+      end)
+
+      :ok
+    end
+
+    test "start, say, stop full round-trip" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          assert :ok = DuplexIEx.start(working_dir: File.cwd!())
+          assert :ok = DuplexIEx.say("Respond with exactly: hello duplex iex.", timeout: 60_000)
+          assert is_binary(DuplexIEx.session_id())
+          assert :ok = DuplexIEx.stop()
+        end)
+
+      assert output =~ "Claude session started"
+      assert output =~ "hello"
+      assert output =~ "Session stopped"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Capstone for the DuplexSession work (#55). Adds a REPL-friendly
helper module that spawns a long-lived `claude` subprocess, holds it
across many turns, and prints streaming text deltas to stdout as
they arrive.

Sibling to the existing `ClaudeWrapper.IEx`, which uses the simpler
per-call `Query`/`Session` flow. Both are kept; both have valid use
cases. `DuplexIEx` is for when you want the chat-UI feel of partial
tokens streaming in.

```elixir
iex> import ClaudeWrapper.DuplexIEx

iex> start(working_dir: ".")
Claude session started.

iex> say("Explain the README briefly.")
...streams text live...
($0.0123, 1 turn)
:ok

iex> interrupt()
:ok

iex> stop()
:ok
```

## API

- `start/1` -- spawns `DuplexSession` + a printer process, stores
  both in the IEx process dictionary
- `say/2` -- sends a prompt; the printer streams the response live;
  returns `:ok | {:error, reason}`
- `interrupt/1` -- cancels the current turn cleanly
- `stop/0` -- closes the session and shuts down the printer
- `status/0` -- prints session id + pid
- `session_id/0` / `pid/0` -- programmatic access

## Internals worth knowing

- A separate **printer process** subscribes to the session and writes
  text deltas to stdout. Running it in its own process keeps the
  user's IEx mailbox clean and isolates GenServer message flow from
  any IO failure.
- `handle_event/1` emits only text deltas, system_init markers, and
  truncated tool_result excerpts -- not the full event stream. Keeps
  REPL output readable.
- Default permission stance is `--dangerously-skip-permissions` for
  REPL ergonomics, matching the existing `IEx` test behavior. If the
  caller passes `:on_permission`, the default flips to
  `--permission-mode default` so the callback can fire.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- no issues
- [x] `mix dialyzer` -- no errors
- [x] `mix test` -- 152 passing, 0 failures (17 new unit tests for
  `DuplexIEx`)
- [x] `mix test --only integration` for the new
  `DuplexIEx` test -- 1 passing (full start/say/stop round-trip)

Refs #55

Release Notes:

- Added `ClaudeWrapper.DuplexIEx` for interactive REPL sessions
  using the long-lived stream-json duplex protocol, with live
  streaming of assistant text deltas.