### PR TITLE
Rename DuplexIEx.stop/0 to close/0 to avoid Workshop collision

### DIFF
--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -26,7 +26,7 @@ defmodule ClaudeWrapper.DuplexIEx do
       iex> interrupt()
       :ok
 
-      iex> stop()
+      iex> close()
       :ok
 
   ## When to use this vs `ClaudeWrapper.IEx`
@@ -66,11 +66,11 @@ defmodule ClaudeWrapper.DuplexIEx do
 
   Stores the session pid and printer pid in the process dictionary
   for the rest of the helpers to find. If a session is already
-  running for this process, it is stopped first.
+  running for this process, it is closed first.
   """
   @spec start(keyword()) :: :ok | {:error, term()}
   def start(opts \\ []) do
-    if Process.get(@session_key), do: stop()
+    if Process.get(@session_key), do: close()
 
     {config_opts, duplex_opts} = split_opts(opts)
 
@@ -152,10 +152,14 @@ defmodule ClaudeWrapper.DuplexIEx do
   end
 
   @doc """
-  Stop the current session, kill the printer, and clear stored state.
+  Close the current session, kill the printer, and clear stored state.
+
+  Named `close/0` (rather than the more obvious `stop/0`) to avoid
+  colliding with `ClaudeWrapper.Workshop.stop/0` when both modules are
+  imported. Mirrors the underlying `ClaudeWrapper.DuplexSession.close/1`.
   """
-  @spec stop() :: :ok
-  def stop do
+  @spec close() :: :ok
+  def close do
     if printer = Process.delete(@printer_key) do
       Process.exit(printer, :shutdown)
     end
@@ -168,7 +172,7 @@ defmodule ClaudeWrapper.DuplexIEx do
       end
     end
 
-    IO.puts("\e[33mSession stopped.\e[0m")
+    IO.puts("\e[33mSession closed.\e[0m")
     :ok
   end
 

--- a/test/claude_wrapper/duplex_iex_test.exs
+++ b/test/claude_wrapper/duplex_iex_test.exs
@@ -15,7 +15,7 @@ defmodule ClaudeWrapper.DuplexIExTest do
   end
 
   defp safely_stop do
-    DuplexIEx.stop()
+    DuplexIEx.close()
   catch
     _, _ -> :ok
   end
@@ -58,17 +58,17 @@ defmodule ClaudeWrapper.DuplexIExTest do
     end
   end
 
-  describe "stop/0" do
+  describe "close/0" do
     test "is a no-op when no session is running" do
-      output = capture_io(fn -> assert :ok = DuplexIEx.stop() end)
-      assert output =~ "Session stopped"
+      output = capture_io(fn -> assert :ok = DuplexIEx.close() end)
+      assert output =~ "Session closed"
     end
 
     test "shuts down a running session and clears state" do
       pid = install_fake_session()
       assert Process.alive?(pid)
 
-      capture_io(fn -> assert :ok = DuplexIEx.stop() end)
+      capture_io(fn -> assert :ok = DuplexIEx.close() end)
 
       refute Process.get(:claude_wrapper_duplex_iex_session)
       refute Process.alive?(pid)

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -274,7 +274,7 @@ defmodule ClaudeWrapper.IntegrationTest do
     setup do
       on_exit(fn ->
         try do
-          DuplexIEx.stop()
+          DuplexIEx.close()
         catch
           _, _ -> :ok
         end
@@ -283,18 +283,18 @@ defmodule ClaudeWrapper.IntegrationTest do
       :ok
     end
 
-    test "start, say, stop full round-trip" do
+    test "start, say, close full round-trip" do
       output =
         ExUnit.CaptureIO.capture_io(fn ->
           assert :ok = DuplexIEx.start(working_dir: File.cwd!())
           assert :ok = DuplexIEx.say("Respond with exactly: hello duplex iex.", timeout: 60_000)
           assert is_binary(DuplexIEx.session_id())
-          assert :ok = DuplexIEx.stop()
+          assert :ok = DuplexIEx.close()
         end)
 
       assert output =~ "Claude session started"
       assert output =~ "hello"
-      assert output =~ "Session stopped"
+      assert output =~ "Session closed"
     end
   end
 end


### PR DESCRIPTION
## Summary

Quick follow-up to #60. Found in real-IEx use: with `.workshop.exs`
auto-loaded and `import ClaudeWrapper.DuplexIEx`, calling `stop()` is
ambiguous because `ClaudeWrapper.Workshop` also exports `stop/0`.

Renaming to `close/0` mirrors the underlying
`ClaudeWrapper.DuplexSession.close/1` and removes the collision. The
log line changes from \"Session stopped.\" to \"Session closed.\".

The other Workshop name collision (`status/0`) is intentionally left
alone -- it goes away when #36 lands and the Workshop module is
removed.

## Repro

```
iex> import ClaudeWrapper.DuplexIEx
iex> start(working_dir: \".\")
iex> stop()
error: function stop/0 imported from both ClaudeWrapper.DuplexIEx
  and ClaudeWrapper.Workshop, call is ambiguous
```

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- no issues
- [x] `mix test` -- 152 passing, 0 failures

Refs #55

Release Notes:

- Renamed `ClaudeWrapper.DuplexIEx.stop/0` to `close/0` to avoid an
  IEx import collision with `ClaudeWrapper.Workshop`.