### PR TITLE
Extract Query.apply_opts/2 and expose all Query setters via opts

### DIFF
--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -178,29 +178,8 @@ defmodule ClaudeWrapper do
   end
 
   defp build_query(prompt, opts) do
-    query = Query.new(prompt)
-
-    Enum.reduce(opts, query, fn
-      {:model, v}, q -> Query.model(q, v)
-      {:system_prompt, v}, q -> Query.system_prompt(q, v)
-      {:append_system_prompt, v}, q -> Query.append_system_prompt(q, v)
-      {:max_turns, v}, q -> Query.max_turns(q, v)
-      {:max_budget_usd, v}, q -> Query.max_budget_usd(q, v)
-      {:permission_mode, v}, q -> Query.permission_mode(q, v)
-      {:dangerously_skip_permissions, true}, q -> Query.dangerously_skip_permissions(q)
-      {:dangerously_skip_permissions, false}, q -> q
-      {:session_id, v}, q -> Query.session_id(q, v)
-      {:continue_session, true}, q -> Query.continue_session(q)
-      {:continue_session, false}, q -> q
-      {:resume, v}, q -> Query.resume(q, v)
-      {:effort, v}, q -> Query.effort(q, v)
-      {:json_schema, v}, q -> Query.json_schema(q, v)
-      {:agent, v}, q -> Query.agent(q, v)
-      {:brief, true}, q -> Query.brief(q)
-      {:brief, false}, q -> q
-      {:no_session_persistence, true}, q -> Query.no_session_persistence(q)
-      {:no_session_persistence, false}, q -> q
-      _other, q -> q
-    end)
+    prompt
+    |> Query.new()
+    |> Query.apply_opts(opts)
   end
 end

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -268,6 +268,108 @@ defmodule ClaudeWrapper.Query do
   @spec tmux(t()) :: t()
   def tmux(%__MODULE__{} = q), do: %{q | tmux: true}
 
+  # --- Bulk option application ---
+
+  @doc """
+  Apply a keyword list of options to a query, calling the equivalent
+  `Query` setter for each known key. Unknown keys are silently ignored.
+
+  This is the shared mapping used by `ClaudeWrapper.query/2`,
+  `ClaudeWrapper.stream/2`, and `ClaudeWrapper.Session.send/3`. It
+  exists so the opt-to-setter mapping lives in one place rather than
+  being duplicated across each surface.
+
+  Boolean opts (e.g. `:worktree`, `:dangerously_skip_permissions`)
+  are applied when the value is `true` and ignored when `false`. List
+  opts (e.g. `:allowed_tools`, `:add_dir`) reduce over their list,
+  applying the per-item setter for each entry.
+
+  ## Examples
+
+      iex> q = ClaudeWrapper.Query.new("hi")
+      iex> q = ClaudeWrapper.Query.apply_opts(q, model: "sonnet", max_turns: 3, worktree: true)
+      iex> q.model
+      "sonnet"
+      iex> q.max_turns
+      3
+      iex> q.worktree
+      true
+  """
+  @spec apply_opts(t(), keyword()) :: t()
+  def apply_opts(%__MODULE__{} = query, opts) when is_list(opts) do
+    Enum.reduce(opts, query, &apply_opt/2)
+  end
+
+  defp apply_opt({:model, v}, q), do: model(q, v)
+  defp apply_opt({:system_prompt, v}, q), do: system_prompt(q, v)
+  defp apply_opt({:append_system_prompt, v}, q), do: append_system_prompt(q, v)
+  defp apply_opt({:max_turns, v}, q), do: max_turns(q, v)
+  defp apply_opt({:max_budget_usd, v}, q), do: max_budget_usd(q, v)
+  defp apply_opt({:permission_mode, v}, q), do: permission_mode(q, v)
+  defp apply_opt({:effort, v}, q), do: effort(q, v)
+  defp apply_opt({:json_schema, v}, q), do: json_schema(q, v)
+  defp apply_opt({:agent, v}, q), do: agent(q, v)
+  defp apply_opt({:agents_json, v}, q), do: agents_json(q, v)
+  defp apply_opt({:session_id, v}, q), do: session_id(q, v)
+  defp apply_opt({:resume, v}, q), do: resume(q, v)
+  defp apply_opt({:fallback_model, v}, q), do: fallback_model(q, v)
+  defp apply_opt({:output_format, v}, q), do: output_format(q, v)
+  defp apply_opt({:input_format, v}, q), do: input_format(q, v)
+  defp apply_opt({:settings, v}, q), do: settings(q, v)
+  defp apply_opt({:debug_filter, v}, q), do: debug_filter(q, v)
+  defp apply_opt({:debug_file, v}, q), do: debug_file(q, v)
+  defp apply_opt({:betas, v}, q), do: betas(q, v)
+  defp apply_opt({:setting_sources, v}, q), do: setting_sources(q, v)
+
+  # Boolean flags: only apply on true.
+  defp apply_opt({:dangerously_skip_permissions, true}, q), do: dangerously_skip_permissions(q)
+  defp apply_opt({:dangerously_skip_permissions, _}, q), do: q
+  defp apply_opt({:continue_session, true}, q), do: continue_session(q)
+  defp apply_opt({:continue_session, _}, q), do: q
+  defp apply_opt({:no_session_persistence, true}, q), do: no_session_persistence(q)
+  defp apply_opt({:no_session_persistence, _}, q), do: q
+  defp apply_opt({:worktree, true}, q), do: worktree(q)
+  defp apply_opt({:worktree, _}, q), do: q
+  defp apply_opt({:brief, true}, q), do: brief(q)
+  defp apply_opt({:brief, _}, q), do: q
+  defp apply_opt({:fork_session, true}, q), do: fork_session(q)
+  defp apply_opt({:fork_session, _}, q), do: q
+  defp apply_opt({:strict_mcp_config, true}, q), do: strict_mcp_config(q)
+  defp apply_opt({:strict_mcp_config, _}, q), do: q
+  defp apply_opt({:include_partial_messages, true}, q), do: include_partial_messages(q)
+  defp apply_opt({:include_partial_messages, _}, q), do: q
+  defp apply_opt({:tmux, true}, q), do: tmux(q)
+  defp apply_opt({:tmux, _}, q), do: q
+
+  # List opts (or single value, where it makes sense).
+  defp apply_opt({:allowed_tools, tools}, q) when is_list(tools),
+    do: Enum.reduce(tools, q, &allowed_tool(&2, &1))
+
+  defp apply_opt({:disallowed_tools, tools}, q) when is_list(tools),
+    do: Enum.reduce(tools, q, &disallowed_tool(&2, &1))
+
+  defp apply_opt({:tools, tools}, q) when is_list(tools),
+    do: Enum.reduce(tools, q, &tool(&2, &1))
+
+  defp apply_opt({:add_dir, dirs}, q) when is_list(dirs),
+    do: Enum.reduce(dirs, q, &add_dir(&2, &1))
+
+  defp apply_opt({:add_dir, dir}, q) when is_binary(dir), do: add_dir(q, dir)
+
+  defp apply_opt({:files, files}, q) when is_list(files),
+    do: Enum.reduce(files, q, &file(&2, &1))
+
+  defp apply_opt({:plugin_dirs, dirs}, q) when is_list(dirs),
+    do: Enum.reduce(dirs, q, &plugin_dir(&2, &1))
+
+  defp apply_opt({:mcp_config, paths}, q) when is_list(paths),
+    do: Enum.reduce(paths, q, &mcp_config(&2, &1))
+
+  defp apply_opt({:mcp_config, path}, q) when is_binary(path), do: mcp_config(q, path)
+
+  # Unknown option: ignore. Documented above.
+  defp apply_opt(_other, q), do: q
+
   # --- Execution ---
 
   @doc """

--- a/lib/claude_wrapper/session.ex
+++ b/lib/claude_wrapper/session.ex
@@ -155,54 +155,16 @@ defmodule ClaudeWrapper.Session do
 
   defp build_query(session, prompt, per_call_opts) do
     merged_opts = Keyword.merge(session.query_opts, per_call_opts)
-    query = Query.new(prompt)
 
     query =
-      Enum.reduce(merged_opts, query, fn
-        {:model, v}, q ->
-          Query.model(q, v)
+      prompt
+      |> Query.new()
+      |> Query.apply_opts(merged_opts)
 
-        {:system_prompt, v}, q ->
-          Query.system_prompt(q, v)
-
-        {:max_turns, v}, q ->
-          Query.max_turns(q, v)
-
-        {:permission_mode, v}, q ->
-          Query.permission_mode(q, v)
-
-        {:max_budget_usd, v}, q ->
-          Query.max_budget_usd(q, v)
-
-        {:effort, v}, q ->
-          Query.effort(q, v)
-
-        {:allowed_tools, tools}, q when is_list(tools) ->
-          Enum.reduce(tools, q, fn tool, acc -> Query.allowed_tool(acc, tool) end)
-
-        {:disallowed_tools, tools}, q when is_list(tools) ->
-          Enum.reduce(tools, q, fn tool, acc -> Query.disallowed_tool(acc, tool) end)
-
-        {:mcp_config, paths}, q when is_list(paths) ->
-          Enum.reduce(paths, q, fn path, acc -> Query.mcp_config(acc, path) end)
-
-        {:mcp_config, path}, q when is_binary(path) ->
-          Query.mcp_config(q, path)
-
-        {:dangerously_skip_permissions, true}, q ->
-          Query.dangerously_skip_permissions(q)
-
-        {:worktree, true}, q ->
-          Query.worktree(q)
-
-        {:no_session_persistence, true}, q ->
-          Query.no_session_persistence(q)
-
-        _other, q ->
-          q
-      end)
-
-    # Thread session continuity
+    # Thread session continuity. We do this AFTER apply_opts so that
+    # an explicit `:resume` in opts does not override an established
+    # session_id from a prior turn -- the established id wins, which
+    # matches the multi-turn intent of `Session`.
     case session.session_id do
       nil -> query
       sid when is_binary(sid) -> Query.resume(query, sid)

--- a/test/claude_wrapper/query_test.exs
+++ b/test/claude_wrapper/query_test.exs
@@ -1,0 +1,218 @@
+defmodule ClaudeWrapper.QueryTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Query
+
+  describe "apply_opts/2 -- scalar opts" do
+    test "applies all scalar string/value opts" do
+      q =
+        "p"
+        |> Query.new()
+        |> Query.apply_opts(
+          model: "sonnet",
+          system_prompt: "be terse",
+          append_system_prompt: "use british english",
+          max_turns: 7,
+          max_budget_usd: 1.5,
+          permission_mode: :plan,
+          effort: :high,
+          json_schema: ~s({"type":"object"}),
+          agent: "reviewer",
+          agents_json: ~s({"reviewer":{}}),
+          session_id: "fixed-session",
+          resume: "prior-session",
+          fallback_model: "haiku",
+          output_format: :json,
+          input_format: :stream_json,
+          settings: ~s({"foo":"bar"}),
+          debug_filter: "api,hooks",
+          debug_file: "/tmp/dbg.log",
+          betas: "feature-x",
+          setting_sources: "user,project"
+        )
+
+      assert q.model == "sonnet"
+      assert q.system_prompt == "be terse"
+      assert q.append_system_prompt == "use british english"
+      assert q.max_turns == 7
+      assert q.max_budget_usd == 1.5
+      assert q.permission_mode == :plan
+      assert q.effort == :high
+      assert q.json_schema =~ "object"
+      assert q.agent == "reviewer"
+      assert q.agents_json =~ "reviewer"
+      assert q.session_id == "fixed-session"
+      assert q.resume == "prior-session"
+      assert q.fallback_model == "haiku"
+      assert q.output_format == :json
+      assert q.input_format == :stream_json
+      assert q.settings =~ "bar"
+      assert q.debug_filter == "api,hooks"
+      assert q.debug_file == "/tmp/dbg.log"
+      assert q.betas == "feature-x"
+      assert q.setting_sources == "user,project"
+    end
+  end
+
+  describe "apply_opts/2 -- boolean flags" do
+    test "true applies the flag" do
+      q =
+        "p"
+        |> Query.new()
+        |> Query.apply_opts(
+          dangerously_skip_permissions: true,
+          continue_session: true,
+          no_session_persistence: true,
+          worktree: true,
+          brief: true,
+          fork_session: true,
+          strict_mcp_config: true,
+          include_partial_messages: true,
+          tmux: true
+        )
+
+      assert q.dangerously_skip_permissions
+      assert q.continue_session
+      assert q.no_session_persistence
+      assert q.worktree
+      assert q.brief
+      assert q.fork_session
+      assert q.strict_mcp_config
+      assert q.include_partial_messages
+      assert q.tmux
+    end
+
+    test "false (or any non-true) leaves the flag unchanged" do
+      q =
+        "p"
+        |> Query.new()
+        |> Query.apply_opts(
+          dangerously_skip_permissions: false,
+          worktree: false,
+          brief: nil,
+          fork_session: 0
+        )
+
+      refute q.dangerously_skip_permissions
+      refute q.worktree
+      refute q.brief
+      refute q.fork_session
+    end
+  end
+
+  describe "apply_opts/2 -- list opts" do
+    test "allowed_tools and disallowed_tools accept lists" do
+      q =
+        "p"
+        |> Query.new()
+        |> Query.apply_opts(
+          allowed_tools: ["Read", "Bash"],
+          disallowed_tools: ["WebFetch", "Edit"]
+        )
+
+      assert q.allowed_tools == ["Read", "Bash"]
+      assert q.disallowed_tools == ["WebFetch", "Edit"]
+    end
+
+    test "tools, files, plugin_dirs accept lists" do
+      q =
+        "p"
+        |> Query.new()
+        |> Query.apply_opts(
+          tools: ["Read", "Edit"],
+          files: ["doc.txt", "img.png"],
+          plugin_dirs: ["/p1", "/p2"]
+        )
+
+      assert q.tools == ["Read", "Edit"]
+      assert q.files == ["doc.txt", "img.png"]
+      assert q.plugin_dirs == ["/p1", "/p2"]
+    end
+
+    test "add_dir accepts a list or a single binary" do
+      q1 = Query.apply_opts(Query.new("p"), add_dir: ["/a", "/b"])
+      assert q1.add_dir == ["/a", "/b"]
+
+      q2 = Query.apply_opts(Query.new("p"), add_dir: "/a")
+      assert q2.add_dir == ["/a"]
+    end
+
+    test "mcp_config accepts a list or a single binary" do
+      q1 = Query.apply_opts(Query.new("p"), mcp_config: ["/a.json", "/b.json"])
+      assert q1.mcp_config == ["/a.json", "/b.json"]
+
+      q2 = Query.apply_opts(Query.new("p"), mcp_config: "/single.json")
+      assert q2.mcp_config == ["/single.json"]
+    end
+  end
+
+  describe "apply_opts/2 -- robustness" do
+    test "unknown opts are silently ignored" do
+      q =
+        "p"
+        |> Query.new()
+        |> Query.apply_opts(
+          unknown_thing: 42,
+          some_future_opt: "value",
+          model: "sonnet"
+        )
+
+      # Known ones still apply.
+      assert q.model == "sonnet"
+      # Struct integrity preserved.
+      assert %Query{} = q
+    end
+
+    test "empty opts list is a no-op" do
+      q = Query.new("p")
+      assert Query.apply_opts(q, []) == q
+    end
+
+    test "options applied left-to-right; later wins" do
+      q =
+        "p"
+        |> Query.new()
+        |> Query.apply_opts(model: "haiku", model: "sonnet")
+
+      assert q.model == "sonnet"
+    end
+  end
+
+  describe "regression coverage for #40" do
+    test "all opts the issue called out as missing now apply" do
+      missing = [
+        worktree: true,
+        allowed_tools: ["Read"],
+        disallowed_tools: ["Bash"],
+        add_dir: ["/path"],
+        mcp_config: ["/mcp.json"],
+        settings: "{}",
+        files: ["x"],
+        tools: ["Read"],
+        append_system_prompt: "appended",
+        fallback_model: "haiku",
+        output_format: :json,
+        agents_json: "{}",
+        fork_session: true,
+        strict_mcp_config: true
+      ]
+
+      q = "p" |> Query.new() |> Query.apply_opts(missing)
+
+      assert q.worktree
+      assert q.allowed_tools == ["Read"]
+      assert q.disallowed_tools == ["Bash"]
+      assert q.add_dir == ["/path"]
+      assert q.mcp_config == ["/mcp.json"]
+      assert q.settings == "{}"
+      assert q.files == ["x"]
+      assert q.tools == ["Read"]
+      assert q.append_system_prompt == "appended"
+      assert q.fallback_model == "haiku"
+      assert q.output_format == :json
+      assert q.agents_json == "{}"
+      assert q.fork_session
+      assert q.strict_mcp_config
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #40.

`ClaudeWrapper.build_query/2` and `Session.build_query/3` each had
their own reduce-block mapping keyword opts to `Query` setter calls.
The two had drifted apart -- some opts were in one and not the other,
and several opts the `Query` module supported were unreachable from
either, silently dropped by the catch-all clause.

User-facing impact: `agent_workshop` forwards `query_opts` to
`start_session/2`, so any opt missing from the build_query mapping
was effectively unsupported through Workshop even though `Query`
itself supported it.

## What changed

Extract the opt-to-setter mapping into a single `Query.apply_opts/2`
on the `Query` module. Both call sites now delegate:

```elixir
Query.new(prompt) |> Query.apply_opts(opts)
```

`apply_opts/2` covers:

- **Scalar setters** -- model, system_prompt, append_system_prompt,
  max_turns, max_budget_usd, permission_mode, effort, json_schema,
  agent, agents_json, session_id, resume, fallback_model,
  output_format, input_format, settings, debug_filter, debug_file,
  betas, setting_sources
- **Boolean flags** -- dangerously_skip_permissions,
  continue_session, no_session_persistence, worktree, brief,
  fork_session, strict_mcp_config, include_partial_messages, tmux.
  `true` applies; anything else (`false` / `nil` / `0`) ignores
- **List-shaped opts** -- allowed_tools, disallowed_tools, tools,
  files, plugin_dirs; `add_dir` and `mcp_config` additionally accept
  a single binary for ergonomics
- **Unknown opts** are silently ignored (preserves the prior
  catch-all behavior, non-breaking)

The `Session.build_query/3` post-processing that threads `session_id`
via `Query.resume/2` is preserved -- it runs **after** `apply_opts`,
so an established session id from a prior turn wins over an explicit
`:resume` opt, matching the multi-turn intent of `Session`.

## Diff stats

- `+331 / -70` across 4 files
- `lib/claude_wrapper.ex`: 27 lines down to 6 (delegation)
- `lib/claude_wrapper/session.ex`: 54 lines down to 9 (delegation)
- `lib/claude_wrapper/query.ex`: +102 lines (the new function)
- `test/claude_wrapper/query_test.exs`: +218 lines (new test file)

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- no issues
- [x] `mix dialyzer` -- no errors
- [x] `mix test` -- **163 passing, 0 failures** (was 152; 11 new
  unit tests for `apply_opts/2`)

The new `query_test.exs` covers:
- Scalar opts (one big test, all 20 of them)
- Boolean flags: `true` applies all 9 of them
- Boolean flags: `false` / `nil` / `0` leave the flag unchanged
- All list opts (allowed_tools, disallowed_tools, tools, files,
  plugin_dirs)
- `add_dir` and `mcp_config` accepting both list and single binary
- Unknown opts ignored
- Empty opts list is a no-op
- Left-to-right reduction (last wins on conflicts)
- A regression test that explicitly verifies all 14 opts the issue
  called out as missing now apply

Closes #40

Release Notes:

- Added \`ClaudeWrapper.Query.apply_opts/2\` and routed
  \`ClaudeWrapper.query/2\`, \`ClaudeWrapper.stream/2\`, and
  \`ClaudeWrapper.Session.send/3\` through it. \`worktree\`,
  \`allowed_tools\`, \`disallowed_tools\`, \`add_dir\`, \`mcp_config\`,
  \`settings\`, \`files\`, \`tools\`, \`append_system_prompt\`,
  \`fallback_model\`, \`output_format\`, \`agents_json\`,
  \`fork_session\`, and \`strict_mcp_config\` are now reachable
  through opts on all surfaces.