### PR TITLE
Fix integer cost_usd crash in IEx printers

### DIFF
--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -295,13 +295,21 @@ defmodule ClaudeWrapper.DuplexIEx do
   # --- Private --------------------------------------------------------
 
   defp print_meta(%Result{} = result) do
-    cost_str =
-      if result.cost_usd, do: "$#{Float.round(result.cost_usd, 4)}", else: "?"
-
+    cost_str = format_cost(result.cost_usd)
     turns_str = "#{result.num_turns || 1} turn#{plural(result.num_turns || 1)}"
 
     IO.puts("\e[33m(#{cost_str}, #{turns_str})\e[0m")
   end
+
+  # Cost arrives from the CLI as either a float (typical) or an integer
+  # zero (when a turn finishes without billing -- e.g. cache-only or
+  # interrupted very early). Float.round/2 raises FunctionClauseError on
+  # an integer; coerce by adding 0.0 so both shapes format the same way.
+  # Reported in #64.
+  @doc false
+  @spec format_cost(number() | nil) :: String.t()
+  def format_cost(nil), do: "?"
+  def format_cost(cost) when is_number(cost), do: "$#{Float.round(cost + 0.0, 4)}"
 
   @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]
 

--- a/lib/claude_wrapper/iex.ex
+++ b/lib/claude_wrapper/iex.ex
@@ -89,7 +89,7 @@ defmodule ClaudeWrapper.IEx do
       session ->
         total = Session.total_cost(session)
         turns = Session.turn_count(session)
-        IO.puts("\e[33m$#{Float.round(total, 4)} across #{turns} turn#{plural(turns)}\e[0m")
+        IO.puts("\e[33m#{format_cost(total)} across #{turns} turn#{plural(turns)}\e[0m")
         total
     end
   end
@@ -174,7 +174,7 @@ defmodule ClaudeWrapper.IEx do
   end
 
   defp print_turn({result, i}) do
-    cost_str = if result.cost_usd, do: " ($#{Float.round(result.cost_usd, 4)})", else: ""
+    cost_str = if result.cost_usd, do: " (#{format_cost(result.cost_usd)})", else: ""
     error_str = if result.is_error, do: " \e[31m[error]\e[0m", else: ""
 
     IO.puts("\e[36m--- Turn #{i}#{cost_str}#{error_str} ---\e[0m")
@@ -202,19 +202,29 @@ defmodule ClaudeWrapper.IEx do
     IO.puts(result.result)
     IO.puts("")
 
-    cost_str = if result.cost_usd, do: "$#{Float.round(result.cost_usd, 4)}", else: "?"
+    cost_str = format_cost(result.cost_usd)
     total = Session.total_cost(session)
     turns = Session.turn_count(session)
 
     meta =
       if turns > 1 do
-        "\e[33m(#{cost_str} this turn, $#{Float.round(total, 4)} total, #{turns} turns)\e[0m"
+        "\e[33m(#{cost_str} this turn, #{format_cost(total)} total, #{turns} turns)\e[0m"
       else
         "\e[33m(#{cost_str}, #{turns} turn)\e[0m"
       end
 
     IO.puts(meta)
   end
+
+  # Cost arrives from the CLI as either a float (typical) or an integer
+  # zero (when a turn finishes without billing -- e.g. cache-only or
+  # interrupted very early). Float.round/2 raises FunctionClauseError on
+  # an integer; coerce by adding 0.0 so both shapes format the same way.
+  # Reported in #64.
+  @doc false
+  @spec format_cost(number() | nil) :: String.t()
+  def format_cost(nil), do: "?"
+  def format_cost(cost) when is_number(cost), do: "$#{Float.round(cost + 0.0, 4)}"
 
   @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]
 

--- a/test/claude_wrapper/duplex_iex_test.exs
+++ b/test/claude_wrapper/duplex_iex_test.exs
@@ -106,6 +106,31 @@ defmodule ClaudeWrapper.DuplexIExTest do
     end
   end
 
+  describe "format_cost/1 (regression: #64)" do
+    test "integer 0 does not raise (the original bug)" do
+      # The CLI sometimes reports cost as an integer 0 -- e.g. cache-only
+      # turns, or turns interrupted before billing. Float.round/2 is
+      # strictly typed and raises FunctionClauseError on an integer.
+      assert DuplexIEx.format_cost(0) == "$0.0"
+    end
+
+    test "non-zero integer cost is coerced and formatted" do
+      assert DuplexIEx.format_cost(2) == "$2.0"
+    end
+
+    test "float cost is rounded to 4 decimals" do
+      assert DuplexIEx.format_cost(0.123456789) == "$0.1235"
+    end
+
+    test "nil cost is rendered as ?" do
+      assert DuplexIEx.format_cost(nil) == "?"
+    end
+
+    test "small float survives round-trip" do
+      assert DuplexIEx.format_cost(0.0123) == "$0.0123"
+    end
+  end
+
   describe "handle_event/1 (stream printing)" do
     test "prints text deltas to stdout" do
       output =

--- a/test/claude_wrapper/iex_test.exs
+++ b/test/claude_wrapper/iex_test.exs
@@ -1,0 +1,26 @@
+defmodule ClaudeWrapper.IExTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.IEx, as: CIEx
+
+  describe "format_cost/1 (regression: #64)" do
+    test "integer 0 does not raise" do
+      # ClaudeWrapper.IEx had the same Float.round/2 callsites that
+      # crashed in DuplexIEx, in printf paths invoked by `chat`/`say`.
+      # Same fix; same regression coverage.
+      assert CIEx.format_cost(0) == "$0.0"
+    end
+
+    test "non-zero integer cost is coerced and formatted" do
+      assert CIEx.format_cost(7) == "$7.0"
+    end
+
+    test "float cost is rounded to 4 decimals" do
+      assert CIEx.format_cost(0.123456789) == "$0.1235"
+    end
+
+    test "nil cost is rendered as ?" do
+      assert CIEx.format_cost(nil) == "?"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #64.

`ClaudeWrapper.DuplexIEx.print_meta/1` crashed with
`FunctionClauseError` when the CLI's `result` reported `cost_usd` as
an integer `0` -- e.g. cache-only turns, or turns interrupted before
billing. `Float.round/2` is strictly typed and refuses integer
arguments.

## Reproduction (from #64)

\`\`\`
iex> say(\"tell me what files are in this directory\")
[session dd1c05b8-...]

** (FunctionClauseError) no function clause matching in Float.round/2

    The following arguments were given to Float.round/2:
        # 1
        0
        # 2
        4
\`\`\`

## Fix

Extract a `format_cost/1` helper that:
- Coerces integer values via `cost + 0.0` before `Float.round/2`
- Returns `\"?\"` for `nil`
- Lives on **both** `DuplexIEx` and the older sibling `IEx` module,
  since `IEx` had the same latent bug at 4 callsites (it just hadn't
  tripped because the per-call CLI surface always emits float costs)

All 5 prior `Float.round/2` callsites in the IEx printers now go
through the helper:
- `DuplexIEx.print_meta/1`
- `IEx.cost/0`
- `IEx.print_turn/1`
- `IEx.print_result/2` (twice -- per-turn and total cost)

## Scope of impact

Reminder per the issue: only the IEx display path was affected. The
duplex turn itself completed successfully; non-IEx consumers calling
`DuplexSession.send/3` directly were never broken.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- no issues
- [x] `mix dialyzer` -- no errors
- [x] `mix test` -- **130 passing, 0 failures** (9 new tests):
  - `duplex_iex_test.exs`: 5 new tests including the exact issue
    reproduction (integer 0)
  - new `iex_test.exs`: 4 parallel tests for the older module

Closes #64

Release Notes:

- Fixed a crash in \`ClaudeWrapper.DuplexIEx\` (and the latent
  equivalent in \`ClaudeWrapper.IEx\`) when the Claude CLI reported
  turn cost as an integer instead of a float (#64).