### PR TITLE
Docs sweep: refocus on DuplexSession as the headline feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,123 +6,195 @@
 
 Elixir wrapper for the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code).
 
-Provides a typed interface for executing queries, streaming responses,
-managing multi-turn sessions, and configuring MCP servers -- all from Elixir.
+`claude_wrapper` gives you two ways to drive `claude` from Elixir:
+
+1. **`DuplexSession`** -- a `GenServer` that holds **one** `claude`
+   subprocess open for the lifetime of a conversation, streams partial
+   tokens as they arrive, lets you interrupt mid-turn, and routes
+   tool-permission prompts back to your code. This is the right fit
+   for chat UIs, agent runtimes, Phoenix-backed interfaces, and any
+   long-running OTP process.
+2. **One-shot `Query`** -- a single subprocess per turn, simple
+   request/response. The right fit for `mix` tasks, escripts, batch
+   jobs, and anything else that runs and exits.
+
+The duplex mode is the same protocol the official
+`@anthropic-ai/claude-agent-sdk` uses internally and that the
+`@agentclientprotocol/claude-agent-acp` bridge relies on for IDE
+integrations like Zed's agent panel. We surface it here so an OTP
+host can use `claude` the same way an IDE backend would.
 
 ## Installation
 
 ```elixir
 def deps do
   [
-    {:claude_wrapper, "~> 0.1.0"}
+    {:claude_wrapper, "~> 0.6"}
   ]
 end
 ```
 
-Requires the `claude` CLI to be installed and on your PATH (or set `CLAUDE_CLI`
-to point at it).
+Requires the `claude` CLI to be installed and on your `PATH` (or set
+`CLAUDE_CLI` to point at it).
 
-## Quick start
+## DuplexSession (long-lived chat-style sessions)
+
+Holds one `claude` subprocess open across many turns. Subscribers
+see assistant messages, partial token deltas, and tool-call results
+as they arrive.
 
 ```elixir
-# One-shot query
+config = ClaudeWrapper.Config.new(working_dir: ".")
+{:ok, pid} = ClaudeWrapper.DuplexSession.start_link(config: config)
+
+# Subscribe to live events.
+:ok = ClaudeWrapper.DuplexSession.subscribe(pid)
+
+# Send a turn; this resolves when the CLI emits its `result` event.
+{:ok, result} = ClaudeWrapper.DuplexSession.send(pid, "Explain this codebase.")
+
+# Inbox now contains:
+#   {:claude, {:system_init, "abc-123"}}
+#   {:claude, {:assistant, %{...}}}
+#   {:claude, {:stream_event, %{...}}}    -- partial token deltas
+#   {:claude, {:user, %{...}}}            -- tool results
+#   {:claude, {:result, %ClaudeWrapper.Result{}}}
+
+# Cancel an in-flight turn cleanly (no SIGKILL):
+ClaudeWrapper.DuplexSession.interrupt(pid)
+
+# Or close the whole session:
+ClaudeWrapper.DuplexSession.close(pid)
+```
+
+### Permission callback
+
+When the CLI wants to run a tool, it routes the prompt back through
+your `:on_permission` callback. The callback can answer synchronously
+or defer to a UI:
+
+```elixir
+on_permission = fn tool_name, _input ->
+  case tool_name do
+    "Bash" -> {:deny, "no shell tools in this session"}
+    _      -> :allow
+  end
+end
+
+{:ok, pid} =
+  ClaudeWrapper.DuplexSession.start_link(
+    config: config,
+    on_permission: on_permission
+  )
+```
+
+For human-in-the-loop UIs, return `:defer` from the callback and
+answer later via `respond_to_permission/3`.
+
+### Pairing with a `DynamicSupervisor`
+
+Each session owns one Port. Pair them with a `DynamicSupervisor`
+for per-conversation isolation, named registration, and standard
+OTP restart semantics:
+
+```elixir
+{:ok, _} =
+  DynamicSupervisor.start_child(
+    MyApp.SessionsSupervisor,
+    {ClaudeWrapper.DuplexSession, [config: config, name: {:via, Registry, ...}]}
+  )
+```
+
+See `ClaudeWrapper.DuplexSession` for the full API and message
+vocabulary.
+
+## DuplexIEx (REPL helpers for the duplex session)
+
+For interactive use, the `DuplexIEx` helpers store one session in
+the IEx process dictionary and stream tokens to stdout as they
+arrive:
+
+```elixir
+iex> import ClaudeWrapper.DuplexIEx
+
+iex> start(working_dir: ".")
+Claude session started.
+
+iex> say("Explain the README briefly.")
+...streams text live...
+($0.0123, 1 turn)
+:ok
+
+iex> say("Now suggest a one-line tagline.")
+...streams text live...
+:ok
+
+iex> close()
+Session closed.
+```
+
+## One-shot queries
+
+For short-lived consumers (mix tasks, escripts, batch jobs, anything
+that does one thing and exits), the simpler request/response surface
+spawns a fresh subprocess per turn:
+
+```elixir
 {:ok, result} = ClaudeWrapper.query("Explain this error: ...")
-IO.puts(result.result)
 
-# With options
-{:ok, result} = ClaudeWrapper.query("Fix the bug in lib/foo.ex",
-  model: "sonnet",
-  working_dir: "/path/to/project",
-  max_turns: 5,
-  permission_mode: :bypass_permissions
-)
+{:ok, result} =
+  ClaudeWrapper.query("Fix the bug in lib/foo.ex",
+    model: "sonnet",
+    working_dir: "/path/to/project",
+    max_turns: 5,
+    permission_mode: :bypass_permissions
+  )
+```
 
-# Streaming
-ClaudeWrapper.stream("Implement the feature described in issue #42",
+Streaming events from a one-shot query:
+
+```elixir
+ClaudeWrapper.stream("Implement the feature in issue #42",
   working_dir: "/path/to/project"
 )
 |> Stream.each(fn event -> IO.inspect(event.type) end)
 |> Stream.run()
 ```
 
-## Multi-turn sessions
-
-```elixir
-config = ClaudeWrapper.Config.new(working_dir: "/path/to/project")
-session = ClaudeWrapper.Session.new(config, model: "sonnet")
-
-{:ok, session, result} = ClaudeWrapper.Session.send(session, "What files are here?")
-{:ok, session, result} = ClaudeWrapper.Session.send(session, "Add tests for lib/foo.ex")
-
-ClaudeWrapper.Session.total_cost(session)
-#=> 0.12
-```
-
-## IEx REPL
-
-Use Claude conversationally from IEx:
+For a per-call REPL, use `ClaudeWrapper.IEx`:
 
 ```elixir
 iex> import ClaudeWrapper.IEx
-
-iex> chat("explain this codebase", working_dir: ".", model: "sonnet")
-# => prints response
-# ($0.07, 1 turn)
-
+iex> chat("explain this codebase", working_dir: ".")
 iex> say("now add tests for the retry module")
-# => continues the conversation
-# ($0.04 this turn, $0.11 total, 2 turns)
-
 iex> cost()
-# $0.11 across 2 turns
-
-iex> history()
-# prints full conversation
-
-iex> session_id()
-# "abc-123" -- save this to resume later
-
 iex> reset()
-# start fresh
 ```
 
-## Multi-agent coordination
+### When to use `Session` vs `DuplexSession`
 
-Multi-agent coordination has moved to a separate package,
-[**agent_workshop**](https://hex.pm/packages/agent_workshop). It is
-backend-agnostic and can drive Claude, Codex, or any agent that
-implements its `Backend` behaviour. Use it alongside `claude_wrapper`:
+`ClaudeWrapper.Session` threads `--resume <session_id>` across one-
+shot calls so you get multi-turn continuity without holding a
+subprocess open. Use it when:
+
+- You're outside an OTP host (no GenServer to own a long-lived port)
+- You want a simple struct-passing API rather than a process API
+- Each turn is far apart in wall time and the cold-start cost
+  doesn't matter
 
 ```elixir
-# in mix.exs
-{:claude_wrapper, "~> 0.6"},
-{:agent_workshop, "~> 0.1"}
+session = ClaudeWrapper.Session.new(config, model: "sonnet")
+{:ok, session, result} = ClaudeWrapper.Session.send(session, "What files are here?")
+{:ok, session, result} = ClaudeWrapper.Session.send(session, "Add tests for lib/foo.ex")
 ```
 
-## Long-lived sessions (DuplexSession)
-
-For chat-UI-style usage where you want partial tokens streaming in
-and the ability to interrupt mid-turn, use `DuplexSession`. It holds
-one `claude` subprocess open across many turns:
-
-```elixir
-config = ClaudeWrapper.Config.new(working_dir: ".")
-{:ok, pid} = ClaudeWrapper.DuplexSession.start_link(config: config)
-
-ClaudeWrapper.DuplexSession.subscribe(pid)
-{:ok, result} = ClaudeWrapper.DuplexSession.send(pid, "Explain this codebase.")
-
-# Receives {:claude, {:assistant, msg}}, {:claude, {:stream_event, ...}},
-# {:claude, {:result, %Result{}}} as the turn unfolds.
-
-ClaudeWrapper.DuplexSession.close(pid)
-```
-
-`DuplexIEx` wraps it for REPL use (live streaming text, `start/say/close`).
+When in doubt: a long-running host (Phoenix server, agent runtime,
+chat UI backend) wants `DuplexSession`; everything else wants
+`Query` or `Session`.
 
 ## Query builder
 
-For full control, use the `Query` struct directly:
+For full control over flags, build a `Query` directly:
 
 ```elixir
 alias ClaudeWrapper.{Config, Query}
@@ -137,6 +209,81 @@ Query.new("Fix the tests")
 |> Query.allowed_tool("Write")
 |> Query.execute(config)
 ```
+
+`Query.apply_opts/2` accepts a keyword list version of any of these
+setters; `ClaudeWrapper.query/2`, `ClaudeWrapper.stream/2`, and
+`Session.send/3` all delegate to it, so you can pass any of those
+opts uniformly.
+
+## Multi-agent coordination
+
+Multi-agent coordination has moved to a separate package,
+[**agent_workshop**](https://hex.pm/packages/agent_workshop). It is
+backend-agnostic and can drive Claude, Codex, or any agent that
+implements its `Backend` behaviour. Use it alongside
+`claude_wrapper`:
+
+```elixir
+def deps do
+  [
+    {:claude_wrapper, "~> 0.6"},
+    {:agent_workshop, "~> 0.1"}
+  ]
+end
+```
+
+## Telemetry
+
+ClaudeWrapper emits `:telemetry` events around its core exec paths
+so downstream applications can observe query/session/stream
+lifecycle with a single handler. Events use the `:telemetry.span/3`
+shape with `:start`, `:stop`, and `:exception` suffixes:
+
+| Event | Emitted by |
+|---|---|
+| `[:claude_wrapper, :exec, _]` | `Query.execute/2` (one-shot query) |
+| `[:claude_wrapper, :stream, _]` | `Query.stream/2` (NDJSON streaming) |
+| `[:claude_wrapper, :session, :turn, _]` | `Session.send/3` (single turn) |
+
+Stop metadata adds `:cost_usd`, `:exit_code`, and the usual
+`:duration`. Subscribe with:
+
+```elixir
+:telemetry.attach_many(
+  "claude-wrapper-observer",
+  [
+    [:claude_wrapper, :exec, :stop],
+    [:claude_wrapper, :stream, :stop],
+    [:claude_wrapper, :session, :turn, :stop]
+  ],
+  fn event, measurements, metadata, _config ->
+    IO.inspect({event, measurements.duration, metadata})
+  end,
+  nil
+)
+```
+
+See `ClaudeWrapper.Telemetry` for the full event reference.
+
+## SessionServer (supervised one-shot sessions)
+
+For OTP applications that want a supervised process around the
+per-call `Session` flow:
+
+```elixir
+{:ok, pid} =
+  ClaudeWrapper.SessionServer.start_link(
+    config: config,
+    query_opts: [model: "sonnet", max_turns: 5]
+  )
+
+{:ok, result} = ClaudeWrapper.SessionServer.send_message(pid, "Fix the tests")
+ClaudeWrapper.SessionServer.total_cost(pid)
+```
+
+`SessionServer` wraps `Session` (one subprocess per turn). For chat-
+UI-style flows where partial-token streaming matters, prefer
+`DuplexSession` instead.
 
 ## MCP config builder
 
@@ -161,97 +308,17 @@ ClaudeWrapper.Retry.execute(query, config,
 )
 ```
 
-## SessionServer (GenServer)
-
-For OTP applications that need a supervised, process-based session:
+## Plugin and marketplace management
 
 ```elixir
-{:ok, pid} = ClaudeWrapper.SessionServer.start_link(
-  config: config,
-  query_opts: [model: "sonnet", max_turns: 5]
-)
-
-{:ok, result} = ClaudeWrapper.SessionServer.send_message(pid, "Fix the tests")
-ClaudeWrapper.SessionServer.total_cost(pid)
-```
-
-Works with supervision trees:
-
-```elixir
-children = [
-  {ClaudeWrapper.SessionServer,
-   name: :my_agent, config: config, query_opts: [model: "sonnet"]}
-]
-```
-
-## Plugin management
-
-```elixir
-alias ClaudeWrapper.Commands.Plugin
+alias ClaudeWrapper.Commands.{Plugin, Marketplace}
 
 {:ok, plugins} = Plugin.list(config)
 {:ok, _} = Plugin.install(config, "my-plugin", scope: :project)
-{:ok, _} = Plugin.enable(config, "my-plugin")
-{:ok, _} = Plugin.disable(config, "my-plugin")
-{:ok, _} = Plugin.uninstall(config, "my-plugin")
-```
-
-## Marketplace management
-
-```elixir
-alias ClaudeWrapper.Commands.Marketplace
 
 {:ok, marketplaces} = Marketplace.list(config)
 {:ok, _} = Marketplace.add(config, "https://github.com/org/marketplace")
-{:ok, _} = Marketplace.remove(config, "my-marketplace")
-{:ok, _} = Marketplace.update(config)
 ```
-
-## Telemetry
-
-ClaudeWrapper emits `:telemetry` events around its core exec paths
-so downstream applications can observe query/session/stream lifecycle
-with a single handler.
-
-Events (all use the `:telemetry.span/3` shape with `:start`, `:stop`,
-and `:exception` suffixes):
-
-| Event | Emitted by |
-|---|---|
-| `[:claude_wrapper, :exec, _]` | `ClaudeWrapper.Query.execute/2` (one-shot query) |
-| `[:claude_wrapper, :stream, _]` | `ClaudeWrapper.Query.stream/2` (NDJSON streaming) |
-| `[:claude_wrapper, :session, :turn, _]` | `ClaudeWrapper.Session.send/3` (single turn) |
-
-Start metadata:
-
-- `:command` -- atom (`:query`, `:stream`, `:session_turn`)
-- `:session_id` -- when known (resumed or provided)
-- `:model` -- from the query's `model` field
-- `:resume?` -- boolean, whether this call threads a previous session
-
-Stop metadata adds:
-
-- `:cost_usd` -- parsed from the final NDJSON result when available
-- `:exit_code` -- `0` on success, non-zero when the CLI exited with an error
-
-Subscribe with:
-
-```elixir
-:telemetry.attach_many(
-  "claude-wrapper-observer",
-  [
-    [:claude_wrapper, :exec, :stop],
-    [:claude_wrapper, :stream, :stop],
-    [:claude_wrapper, :session, :turn, :stop]
-  ],
-  fn event, measurements, metadata, _config ->
-    IO.inspect({event, measurements.duration, metadata})
-  end,
-  nil
-)
-```
-
-See `ClaudeWrapper.Telemetry` for the full event reference.
 
 ## Raw CLI escape hatch
 
@@ -263,21 +330,38 @@ ClaudeWrapper.raw(["config", "list"])
 
 ## Modules
 
+**Long-lived sessions (the headline feature)**
+
 | Module | Description |
 |---|---|
-| `ClaudeWrapper` | Convenience API |
-| `ClaudeWrapper.Config` | Shared client config |
+| `ClaudeWrapper.DuplexSession` | Long-lived stream-json session over a single `claude` subprocess |
+| `ClaudeWrapper.DuplexIEx` | REPL helpers for `DuplexSession` |
+
+**One-shot / per-call**
+
+| Module | Description |
+|---|---|
+| `ClaudeWrapper` | Convenience API (`query/2`, `stream/2`) |
 | `ClaudeWrapper.Query` | Query builder + execute/stream |
-| `ClaudeWrapper.Result` | Parsed JSON result |
+| `ClaudeWrapper.Session` | Multi-turn continuity over per-call subprocesses |
+| `ClaudeWrapper.SessionServer` | Supervised wrapper for `Session` |
+| `ClaudeWrapper.IEx` | REPL helpers for one-shot/per-call mode |
+
+**Shared infrastructure**
+
+| Module | Description |
+|---|---|
+| `ClaudeWrapper.Config` | Shared client config (binary, working_dir, env, timeout) |
+| `ClaudeWrapper.Result` | Parsed result struct |
 | `ClaudeWrapper.StreamEvent` | NDJSON streaming event |
-| `ClaudeWrapper.Session` | Multi-turn session management |
-| `ClaudeWrapper.SessionServer` | GenServer wrapper for sessions |
 | `ClaudeWrapper.McpConfig` | `.mcp.json` builder |
 | `ClaudeWrapper.Retry` | Exponential backoff retry |
 | `ClaudeWrapper.Telemetry` | `:telemetry` spans for exec/stream/session |
-| `ClaudeWrapper.IEx` | Interactive REPL helpers (per-call) |
-| `ClaudeWrapper.DuplexSession` | Long-lived stream-json session |
-| `ClaudeWrapper.DuplexIEx` | REPL helpers for `DuplexSession` |
+
+**CLI subcommand wrappers**
+
+| Module | Description |
+|---|---|
 | `ClaudeWrapper.Commands.Auth` | Auth management |
 | `ClaudeWrapper.Commands.Mcp` | MCP server CRUD |
 | `ClaudeWrapper.Commands.Plugin` | Plugin install/enable/disable/update |
@@ -287,4 +371,4 @@ ClaudeWrapper.raw(["config", "list"])
 
 ## License
 
-MIT -- see [LICENSE](LICENSE).
+MIT. See the `LICENSE` file in the source repo for the full text.

--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -2,10 +2,42 @@ defmodule ClaudeWrapper do
   @moduledoc """
   Elixir wrapper for the Claude Code CLI.
 
-  Provides a typed interface for executing queries against the `claude` CLI,
-  with support for one-shot execution and streaming NDJSON output.
+  Two ways to drive `claude` from Elixir:
 
-  ## Quick start
+  1. `ClaudeWrapper.DuplexSession` -- a `GenServer` that holds **one**
+     `claude` subprocess open for the lifetime of a conversation.
+     Streams partial tokens as they arrive, supports clean mid-turn
+     cancellation, and routes tool-permission prompts back to the
+     host. The right fit for chat UIs, agent runtimes, Phoenix
+     servers, and any long-running OTP host.
+  2. The convenience `ClaudeWrapper.query/2` and `ClaudeWrapper.stream/2`
+     functions in this module -- one subprocess per turn, simple
+     request/response. The right fit for `mix` tasks, escripts, batch
+     jobs, and anything else that runs and exits.
+
+  Both modes are first-class. Pick whichever matches the lifecycle
+  of the host using `claude_wrapper`.
+
+  ## Long-lived chat-style sessions (DuplexSession)
+
+      config = ClaudeWrapper.Config.new(working_dir: ".")
+      {:ok, pid} = ClaudeWrapper.DuplexSession.start_link(config: config)
+
+      ClaudeWrapper.DuplexSession.subscribe(pid)
+      {:ok, result} = ClaudeWrapper.DuplexSession.send(pid, "Explain this codebase.")
+
+      # Subscriber inbox now holds streaming events:
+      #   {:claude, {:assistant, msg}}
+      #   {:claude, {:stream_event, msg}}    -- partial token deltas
+      #   {:claude, {:result, %ClaudeWrapper.Result{}}}
+
+      ClaudeWrapper.DuplexSession.close(pid)
+
+  See `ClaudeWrapper.DuplexSession` for the permission callback,
+  interrupt API, and full event vocabulary. `ClaudeWrapper.DuplexIEx`
+  wraps it with REPL helpers that stream tokens to stdout live.
+
+  ## One-shot queries
 
       # One-shot query (convenience -- uses default config)
       {:ok, result} = ClaudeWrapper.query("Explain this error: ...")
@@ -34,17 +66,27 @@ defmodule ClaudeWrapper do
       |> ClaudeWrapper.Query.max_turns(10)
       |> ClaudeWrapper.Query.execute(config)
 
-  ## Commands
+  ## Multi-turn continuity for one-shot mode (Session)
 
-    * `ClaudeWrapper.Query` -- the main query/prompt interface
-    * `ClaudeWrapper.Commands.Auth` -- login, logout, status, token
-    * `ClaudeWrapper.Commands.Mcp` -- MCP server management
-    * `ClaudeWrapper.Commands.Doctor` -- CLI health check
-    * `ClaudeWrapper.Commands.Version` -- CLI version
+  `ClaudeWrapper.Session` threads `--resume <session_id>` across
+  one-shot calls so you can have a multi-turn conversation without
+  holding a subprocess open. Use it when you want a struct-passing
+  API rather than a process API, or when turns are far enough apart
+  that cold-start cost doesn't matter.
+
+  ## Other modules
+
+    * `ClaudeWrapper.Query` -- the query builder
+    * `ClaudeWrapper.SessionServer` -- supervised wrapper for `Session`
+    * `ClaudeWrapper.McpConfig` -- programmatic `.mcp.json` builder
+    * `ClaudeWrapper.Retry` -- exponential backoff
+    * `ClaudeWrapper.Telemetry` -- `:telemetry` spans for exec/stream/session
+    * `ClaudeWrapper.Commands.{Auth, Mcp, Plugin, Marketplace, Doctor, Version}` -- CLI subcommand wrappers
 
   ## Binary discovery
 
   The `claude` binary is found via (in order):
+
   1. `:binary` option passed directly
   2. `CLAUDE_CLI` environment variable
   3. System PATH lookup

--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -49,7 +49,7 @@ defmodule ClaudeWrapper.DuplexIEx do
     not safe** for prompts you do not control. For trustworthy use,
     pass `permission_mode: "default"` and an `on_permission` callback
   - All `ClaudeWrapper.Config` options (`:binary`, `:env`, `:timeout`,
-    etc.) are accepted and forwarded to `Config.new/1`
+    etc.) are accepted and forwarded to `ClaudeWrapper.Config.new/1`
   - All `ClaudeWrapper.DuplexSession` options (`:on_permission`,
     `:extra_args`) are forwarded as well
   """

--- a/mix.exs
+++ b/mix.exs
@@ -37,8 +37,40 @@ defmodule ClaudeWrapper.MixProject do
 
   defp docs do
     [
-      main: "ClaudeWrapper",
-      source_url: @source_url
+      main: "readme",
+      source_url: @source_url,
+      extras: ["README.md", "CHANGELOG.md"],
+      groups_for_modules: [
+        "Long-lived sessions": [
+          ClaudeWrapper.DuplexSession,
+          ClaudeWrapper.DuplexIEx
+        ],
+        "One-shot / per-call": [
+          ClaudeWrapper,
+          ClaudeWrapper.Query,
+          ClaudeWrapper.Session,
+          ClaudeWrapper.SessionServer,
+          ClaudeWrapper.IEx
+        ],
+        "Shared infrastructure": [
+          ClaudeWrapper.Config,
+          ClaudeWrapper.Result,
+          ClaudeWrapper.StreamEvent,
+          ClaudeWrapper.McpConfig,
+          ClaudeWrapper.Retry,
+          ClaudeWrapper.Telemetry
+        ],
+        "CLI subcommand wrappers": [
+          ClaudeWrapper.Command,
+          ClaudeWrapper.Commands.Auth,
+          ClaudeWrapper.Commands.Agents,
+          ClaudeWrapper.Commands.Doctor,
+          ClaudeWrapper.Commands.Mcp,
+          ClaudeWrapper.Commands.Plugin,
+          ClaudeWrapper.Commands.Marketplace,
+          ClaudeWrapper.Commands.Version
+        ]
+      ]
     ]
   end
 
@@ -46,7 +78,7 @@ defmodule ClaudeWrapper.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      files: ~w(lib mix.exs README.md LICENSE .formatter.exs),
+      files: ~w(lib mix.exs README.md CHANGELOG.md LICENSE .formatter.exs),
       maintainers: ["Josh Rotenberg"]
     ]
   end


### PR DESCRIPTION
## Summary

After the four-PR DuplexSession rollout (#56-#59), the DuplexIEx
capstone (#60), and the Workshop removal (#63), the README still led
with one-shot queries -- which understated what the package is now
about. This rewrite refocuses the docs so the visual hierarchy
matches the feature priority.

## What changed

### `README.md` (~330 line rewrite)

- New lead paragraph names the two modes and when to use each:
  - **DuplexSession** -- the right fit for chat UIs, agent runtimes,
    Phoenix backends, long-running OTP hosts. The same stream-json
    duplex protocol `@anthropic-ai/claude-agent-sdk` uses internally
  - **One-shot** -- the right fit for mix tasks, escripts, batch
    jobs, anything that runs and exits
- DuplexSession example moved to position 1 (right after
  Installation), with subsections covering the permission callback
  and pairing with a `DynamicSupervisor`
- DuplexIEx promoted to its own section, immediately following
- One-shot queries moved down; `Session.send` is reframed as
  \"multi-turn continuity for one-shot mode\" so its purpose vs
  `DuplexSession` is obvious
- Modules table reorganized into four groups matching the priority:
  **Long-lived sessions** / **One-shot / per-call** /
  **Shared infrastructure** / **CLI subcommand wrappers**
- Installation snippet bumped to `~> 0.6`

### `lib/claude_wrapper.ex` moduledoc

- Replaced the per-call-only Quick Start with a dual lead-in matching
  the README. DuplexSession example shown first; one-shot second
- \"Other modules\" list updated

### `mix.exs`

- `main: \"readme\"` so hexdocs lands on the README (the most useful
  entry point now)
- `extras: [\"README.md\", \"CHANGELOG.md\"]` so they render in
  hexdocs alongside the API reference
- `groups_for_modules:` mirrors the README's four-group organization
  in the hexdocs sidebar
- `package.files:` adds `CHANGELOG.md` so the extras dependency
  doesn't break package builds

### Cleanup

- Fixed an ExDoc warning by fully qualifying
  `ClaudeWrapper.Config.new/1` in `DuplexIEx.moduledoc`
- Removed the `[LICENSE](LICENSE)` link from the README to avoid an
  ExDoc relative-link warning. License text remains in the source
  repo's `LICENSE` file

## Workshop residue check

No Workshop residue remains in the docs we ship. The only mention
in README is a pointer to the standalone `agent_workshop` hex
package, which is correct. The `CHANGELOG.md` retains its
historical Workshop entries -- those describe what was true at the
time of those releases and shouldn't be rewritten.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` -- no issues
- [x] `mix dialyzer` -- no errors
- [x] `mix test` -- 130 passing, 0 failures
- [x] `mix docs` -- builds with **zero warnings**; the four module
  groups appear in `doc/api-reference.md` in the expected order
  (verified by grep)

Release Notes:

- N/A