### PR TITLE
feat: DuplexSession on_permission supports 3-arity callback (request_id)

### DIFF
--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -472,16 +472,6 @@ defmodule ClaudeWrapper.DuplexSession do
     state
   end
 
-  # Detect the user's callback arity once and apply with the right
-  # number of arguments. 3-arity gets the request_id so a deferred
-  # handler can correlate respond_to_permission/3 calls later.
-  defp invoke_permission_handler(handler, tool_name, input, request_id) do
-    case :erlang.fun_info(handler, :arity) do
-      {:arity, 3} -> handler.(tool_name, input, request_id)
-      {:arity, 2} -> handler.(tool_name, input)
-    end
-  end
-
   # Reply to an outbound control_request we sent (e.g. interrupt).
   # The CLI may also emit control_responses with no matching pending
   # request_id (e.g. delayed cancellations); those are dropped.
@@ -544,6 +534,16 @@ defmodule ClaudeWrapper.DuplexSession do
   # accumulate inside an active turn so callers that later inspect the
   # turn record can see them, but do not broadcast as a typed event.
   defp dispatch(msg, state), do: accumulate(state, msg)
+
+  # Detect the user's callback arity once and apply with the right
+  # number of arguments. 3-arity gets the request_id so a deferred
+  # handler can correlate respond_to_permission/3 calls later.
+  defp invoke_permission_handler(handler, tool_name, input, request_id) do
+    case :erlang.fun_info(handler, :arity) do
+      {:arity, 3} -> handler.(tool_name, input, request_id)
+      {:arity, 2} -> handler.(tool_name, input)
+    end
+  end
 
   defp accumulate(%{pending_turn: {from, events}} = state, msg) do
     %{state | pending_turn: {from, [msg | events]}}

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -43,8 +43,21 @@ defmodule ClaudeWrapper.DuplexSession do
   ## Permission callback
 
   The optional `:on_permission` callback runs synchronously inside the
-  GenServer when the CLI emits a `can_use_tool` control request. It must
-  return one of:
+  GenServer when the CLI emits a `can_use_tool` control request. Two
+  arities are supported and detected at call time:
+
+    * `(tool_name, input) -> decision` -- when the decision can be made
+      from the tool name and input alone (allow/deny lists, role-based
+      policy, etc.).
+
+    * `(tool_name, input, request_id) -> decision` -- when the handler
+      may return `:defer` and a separate process needs to call
+      `respond_to_permission/3` later. The `request_id` lets the
+      handler correlate the deferred response with the original
+      request (e.g. broadcast `{:permission_request, request_id, ...}`
+      to a UI; the UI eventually answers via `respond_to_permission/3`).
+
+  The decision is one of:
 
     * `:allow` -- allow the tool with the original input
     * `{:allow, updated_input}` -- allow the tool with a modified input
@@ -52,12 +65,10 @@ defmodule ClaudeWrapper.DuplexSession do
     * `{:deny, reason}` -- deny the tool with a reason string the model
       will see
     * `:defer` -- do not respond synchronously; the caller is expected
-      to invoke `respond_to_permission/3` later. Use this when a human
-      decision is required and the GenServer must not block
+      to invoke `respond_to_permission/3` later
 
   The callback runs in the GenServer process, so synchronous decisions
-  must be fast. For slow decisions, return `:defer` and answer later
-  via `respond_to_permission/3`.
+  must be fast. For slow decisions, return `:defer` and answer later.
 
   The default callback is `&deny_all/2`, which denies every tool call.
   Without an explicit callback or one of the CLI's other permission
@@ -91,7 +102,26 @@ defmodule ClaudeWrapper.DuplexSession do
           | {:deny, String.t()}
           | :defer
 
-  @type permission_handler :: (String.t(), tool_input() -> permission_decision())
+  @typedoc """
+  Permission decision callback. Two arities are supported:
+
+    * `(tool_name, input) -> decision` -- the original signature.
+      Use when the decision can be made from the tool name and input
+      alone (allow/deny lists, role-based policy, etc.).
+
+    * `(tool_name, input, request_id) -> decision` -- carries the
+      `request_id` of the inbound `can_use_tool` control request.
+      Required if the handler returns `:defer` and a different
+      process needs to call `respond_to_permission/3` later (chat
+      UI: handler broadcasts the request to a LiveView, which
+      surfaces approve/deny and answers asynchronously).
+
+  Arity is detected at call time so existing 2-arity callbacks keep
+  working unchanged.
+  """
+  @type permission_handler ::
+          (String.t(), tool_input() -> permission_decision())
+          | (String.t(), tool_input(), String.t() -> permission_decision())
 
   @type option ::
           {:config, Config.t()}
@@ -424,11 +454,11 @@ defmodule ClaudeWrapper.DuplexSession do
 
     decision =
       try do
-        state.on_permission.(tool_name, input)
+        invoke_permission_handler(state.on_permission, tool_name, input, id)
       rescue
         e ->
           Logger.error(
-            "DuplexSession: on_permission/2 raised for #{inspect(tool_name)}: #{inspect(e)}"
+            "DuplexSession: on_permission raised for #{inspect(tool_name)}: #{inspect(e)}"
           )
 
           {:deny, "permission handler raised: #{Exception.message(e)}"}
@@ -440,6 +470,16 @@ defmodule ClaudeWrapper.DuplexSession do
     end
 
     state
+  end
+
+  # Detect the user's callback arity once and apply with the right
+  # number of arguments. 3-arity gets the request_id so a deferred
+  # handler can correlate respond_to_permission/3 calls later.
+  defp invoke_permission_handler(handler, tool_name, input, request_id) do
+    case :erlang.fun_info(handler, :arity) do
+      {:arity, 3} -> handler.(tool_name, input, request_id)
+      {:arity, 2} -> handler.(tool_name, input)
+    end
   end
 
   # Reply to an outbound control_request we sent (e.g. interrupt).

--- a/test/claude_wrapper/duplex_session_test.exs
+++ b/test/claude_wrapper/duplex_session_test.exs
@@ -317,6 +317,41 @@ defmodule ClaudeWrapper.DuplexSessionTest do
       end
     end
 
+    test "3-arity callback receives request_id" do
+      pid = start_with_fake_claude()
+      parent = self()
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | on_permission: fn tool, input, request_id ->
+              Kernel.send(parent, {:asked3, tool, input, request_id})
+              :defer
+            end
+        }
+      end)
+
+      try do
+        inject(pid, %{
+          type: "control_request",
+          request_id: "abc-3-arity",
+          request: %{
+            subtype: "can_use_tool",
+            tool_name: "Bash",
+            input: %{"command" => "echo hi"}
+          }
+        })
+
+        assert_receive {:asked3, "Bash", %{"command" => "echo hi"}, "abc-3-arity"}, 1_000
+
+        # The handler returned :defer, so respond_to_permission/3 with
+        # the captured id closes the cycle.
+        assert :ok = DuplexSession.respond_to_permission(pid, "abc-3-arity", :allow)
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
     test "raising callback defaults to deny without crashing the session" do
       pid = start_with_fake_claude()
 


### PR DESCRIPTION
Closes #68.

## Summary
Existing 2-arity \`on_permission\` couldn't compose with \`:defer\` from a different process: the handler had no way to learn the \`request_id\` it needed to pass to \`respond_to_permission/3\` later.

Add a 3-arity overload \`(tool_name, input, request_id)\`. Arity detected at call time via \`:erlang.fun_info/2\`; existing 2-arity callbacks keep working unchanged.

## Why
Chat-UI integration: the handler returns \`:defer\` immediately, broadcasts the request to a separate UI process (LiveView, IEx, anything), and the UI later answers via \`respond_to_permission/3\` with the captured id.

Without this, the 2-arity defer flow was effectively unusable for human-in-the-loop unless the caller serialized everything through one process.

## Diff shape
- \`@type permission_handler\` widened to a union of the 2-arity and 3-arity shapes
- Module + option docs updated
- Single internal helper \`invoke_permission_handler/4\` does the arity dispatch
- Existing tests still pass (29 total; one new test covers the 3-arity flow end-to-end)

## Test plan
- [x] \`mix format --check-formatted\` clean
- [x] \`mix credo --strict\` clean
- [x] \`mix test\` 29 tests pass
- [ ] Smoke: a chat-UI consumer wiring this in a Phoenix LiveView (Finestra Phase 3, immediate downstream)