### PR TITLE
fix: DuplexSession :allow defaults updatedInput to original input

### DIFF
--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -466,7 +466,7 @@ defmodule ClaudeWrapper.DuplexSession do
 
     case decision do
       :defer -> :ok
-      _ -> write_permission_response(state.port, id, decision)
+      _ -> write_permission_response(state.port, id, default_allow_input(decision, input))
     end
 
     state
@@ -630,6 +630,15 @@ defmodule ClaudeWrapper.DuplexSession do
 
   defp decision_to_permission_response({:deny, reason}) when is_binary(reason),
     do: %{behavior: "deny", message: reason}
+
+  # Plain `:allow` is ambiguous over the wire: Claude's permission
+  # protocol validates the response with Zod and requires
+  # `updatedInput` even when the input is unmodified. We default it to
+  # the original `input` so callers don't have to thread it back
+  # through their state just to say "yes, run the tool as-is".
+  @doc false
+  def default_allow_input(:allow, input) when is_map(input), do: {:allow, input}
+  def default_allow_input(decision, _input), do: decision
 
   # 16 random bytes -> 32-char lowercase hex. Plenty of entropy to
   # avoid collisions in our pending_control map and matches the SDK's

--- a/test/claude_wrapper/duplex_session_test.exs
+++ b/test/claude_wrapper/duplex_session_test.exs
@@ -96,6 +96,24 @@ defmodule ClaudeWrapper.DuplexSessionTest do
     end
   end
 
+  describe "default_allow_input/2" do
+    test "plain :allow is rewritten to {:allow, input} so updatedInput round-trips" do
+      input = %{"command" => "ls"}
+      assert DuplexSession.default_allow_input(:allow, input) == {:allow, input}
+    end
+
+    test "{:allow, custom} is left alone (caller already supplied updatedInput)" do
+      custom = %{"command" => "ls -la"}
+      original = %{"command" => "ls"}
+      assert DuplexSession.default_allow_input({:allow, custom}, original) == {:allow, custom}
+    end
+
+    test "{:deny, reason} is left alone" do
+      assert DuplexSession.default_allow_input({:deny, "nope"}, %{"command" => "ls"}) ==
+               {:deny, "nope"}
+    end
+  end
+
   describe "subscribe / unsubscribe (with fake claude)" do
     test "broadcasts assistant events to subscribers" do
       pid = start_with_fake_claude()


### PR DESCRIPTION
## Summary
- Plain `:allow` from an `on_permission` handler used to wire-serialize as `%{behavior: "allow"}`, but Claude's permission protocol validates the response with Zod and requires `updatedInput` even when the input is unmodified. Callers had to thread the original input back as `{:allow, input}` purely to satisfy serialization.
- Dispatch now rewrites `:allow` to `{:allow, input}` so the existing `{:allow, updated_input}` serializer handles it. `{:allow, custom}` and `{:deny, reason}` are unchanged.

## Scope
The fix is in the sync dispatch site (where `input` is in scope from the inbound `can_use_tool` request). The async path (`respond_to_permission/3`) still requires the caller to pass `{:allow, input}` since the wrapper doesn't track per-request inputs; that's out of scope per the issue.

## Test plan
- [x] Added unit tests for the new `default_allow_input/2` helper covering plain `:allow`, `{:allow, custom}`, and `{:deny, reason}`.
- [x] \`mix format --check-formatted\`
- [x] \`mix compile --warnings-as-errors\`
- [x] \`mix credo --strict\`
- [x] \`mix test\` (134 tests, 0 failures)

Closes #71.