### PR TITLE
test: assert --fork-session flag composition in Query.build_args

### DIFF
--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -83,6 +83,35 @@ defmodule ClaudeWrapperTest do
       refute "--dangerously-skip-permissions" in args
     end
 
+    test "build_args emits --fork-session when fork_session is set" do
+      with_fork =
+        Query.new("p")
+        |> Query.resume("abc-123")
+        |> Query.fork_session()
+        |> Query.build_args()
+
+      assert "--fork-session" in with_fork
+      assert "--resume" in with_fork
+      assert "abc-123" in with_fork
+
+      without_fork =
+        Query.new("p")
+        |> Query.resume("abc-123")
+        |> Query.build_args()
+
+      refute "--fork-session" in without_fork
+    end
+
+    test "build_args emits --fork-session when set via apply_opts" do
+      args =
+        Query.new("p")
+        |> Query.apply_opts(continue_session: true, fork_session: true)
+        |> Query.build_args()
+
+      assert "--fork-session" in args
+      assert "--continue" in args
+    end
+
     test "to_command_string" do
       config = Config.new()
 


### PR DESCRIPTION
## Summary
`--fork-session` was actually already wired end-to-end. PR #62 added the `fork_session` struct field, the `Query.fork_session/1` setter, the `:fork_session` entry in `apply_opts/2`, and the `add_bool(\"--fork-session\", ...)` call in `build_args/1`. The existing apply_opts tests assert the struct field flips, but no test directly asserts that the CLI flag actually shows up in the args list.

This PR fills that gap, which is what issue #75 explicitly asked for (\"Add a test that asserts the flag composition\").

## Test plan
- [x] Added a build_args test that flips the flag via the `Query.fork_session/1` setter alongside `Query.resume/2`, asserting `--fork-session`, `--resume`, and the session id all appear (and that `--fork-session` is absent when not set).
- [x] Added a second build_args test driving the same outcome through `apply_opts/2` alongside `:continue_session`, since that is the path most callers actually use.
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (133 tests, 0 failures)

## Note
No production code changes -- the flag was already callable from `ClaudeWrapper.query/2`, `ClaudeWrapper.stream/2`, `Session.send/3`, and direct `Query` use. No high-level helpers (`fork_from/2` etc.) added per the issue's out-of-scope list.

Closes #75.