### PR TITLE
docs: bump README install hint to 0.7 and clarify deferred :allow contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ host can use `claude` the same way an IDE backend would.
 ```elixir
 def deps do
   [
-    {:claude_wrapper, "~> 0.6"}
+    {:claude_wrapper, "~> 0.7"}
   ]
 end
 ```
@@ -226,7 +226,7 @@ implements its `Backend` behaviour. Use it alongside
 ```elixir
 def deps do
   [
-    {:claude_wrapper, "~> 0.6"},
+    {:claude_wrapper, "~> 0.7"},
     {:agent_workshop, "~> 0.1"}
   ]
 end

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -220,6 +220,17 @@ defmodule ClaudeWrapper.DuplexSession do
   no record of is a no-op (returns `:ok`). The `decision` accepts the
   same shape as a synchronous handler return value, except `:defer`,
   which is rejected with `{:error, :cannot_defer_again}`.
+
+  > #### `:allow` and `updatedInput` {: .info}
+  >
+  > A synchronous handler returning plain `:allow` has its `updatedInput`
+  > defaulted to the original tool input automatically, since the
+  > dispatch site has the input in scope. The deferred path does not --
+  > the session does not retain per-request input across the defer
+  > boundary. If you need `updatedInput` populated (Claude's permission
+  > protocol requires it for `behavior: "allow"`), capture the input
+  > when the handler defers and pass `{:allow, input}` here rather than
+  > plain `:allow`.
   """
   @spec respond_to_permission(GenServer.server(), String.t(), permission_decision()) ::
           :ok | {:error, :cannot_defer_again}


### PR DESCRIPTION
## Summary
- README installation snippets pointed at `~> 0.6`; the current line is 0.7 (0.7.1 just released).
- `DuplexSession.respond_to_permission/3` docstring said the decision shape was identical to a synchronous handler return value. After #71/#76 that is subtly inaccurate: the sync dispatch defaults `:allow` to `{:allow, input}` automatically, but the deferred path can't (the session does not retain per-request input across the defer boundary). The new admonition spells out that callers using the deferred path should pass `{:allow, input}` if they need `updatedInput` populated.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix docs` (no warnings)
- [x] `mix credo --strict`
- [x] `mix test` (136 tests, 0 failures)