### PR TITLE
fix: emit correct CLI flag names in Query.build_args

### DIFF
--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -505,8 +505,8 @@ defmodule ClaudeWrapper.Query do
     |> add_bool("--no-session-persistence", q.no_session_persistence)
     |> add_bool("--dangerously-skip-permissions", q.dangerously_skip_permissions)
     |> add_opt("--agent", q.agent)
-    |> add_opt("--agents-json", q.agents_json)
-    |> add_list("--tool", q.tools)
+    |> add_opt("--agents", q.agents_json)
+    |> add_variadic("--tools", q.tools)
     |> add_list("--file", q.files)
     |> add_bool("--include-partial-messages", q.include_partial_messages)
     |> add_opt("--input-format", format_input_format(q.input_format))
@@ -530,6 +530,12 @@ defmodule ClaudeWrapper.Query do
   defp add_bool(args, flag, true), do: args ++ [flag]
   defp add_list(args, _flag, []), do: args
   defp add_list(args, flag, values), do: args ++ Enum.flat_map(values, &[flag, &1])
+
+  # Variadic list flag: emit the flag once followed by all values, matching the
+  # CLI's `<tools...>` contract (e.g. `--tools Read Bash`). Use this for flags
+  # the CLI declares variadic rather than repeatable.
+  defp add_variadic(args, _flag, []), do: args
+  defp add_variadic(args, flag, values), do: args ++ [flag | values]
 
   defp format_output_format(nil), do: nil
   defp format_output_format(:text), do: "text"

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -153,6 +153,44 @@ defmodule ClaudeWrapperTest do
     end
   end
 
+  describe "build_args -- CLI flag names (#82)" do
+    test "emits --agents (not --agents-json) for agents_json" do
+      args =
+        Query.new("p")
+        |> Query.agents_json(~s({"reviewer":{}}))
+        |> Query.build_args()
+
+      assert "--agents" in args
+      refute "--agents-json" in args
+
+      idx = Enum.find_index(args, &(&1 == "--agents"))
+      assert Enum.at(args, idx + 1) == ~s({"reviewer":{}})
+    end
+
+    test "emits a single variadic --tools (not repeated --tool)" do
+      args =
+        Query.new("p")
+        |> Query.tool("Read")
+        |> Query.tool("Bash")
+        |> Query.build_args()
+
+      refute "--tool" in args
+      assert Enum.count(args, &(&1 == "--tools")) == 1
+
+      idx = Enum.find_index(args, &(&1 == "--tools"))
+      assert Enum.slice(args, idx, 3) == ["--tools", "Read", "Bash"]
+    end
+
+    test "omits --tools and --agents when unset" do
+      args = Query.new("p") |> Query.build_args()
+
+      refute "--tools" in args
+      refute "--tool" in args
+      refute "--agents" in args
+      refute "--agents-json" in args
+    end
+  end
+
   describe "Result" do
     test "from_json parses standard fields" do
       data = %{


### PR DESCRIPTION
Fixes two flag names `Query.build_args/1` emitted that the current `claude` CLI (2.1.x) rejects:

- `agents_json/2` emitted `--agents-json`; the CLI flag is `--agents <json>`.
- the `:tools` list emitted repeated `--tool X --tool Y`; the CLI flag is `--tools <tools...>` (one flag, variadic).

Now emits `--agents` and a single variadic `--tools` (flag once + all values), matching the CLI contract and the Rust `claude-wrapper` reference (`src/command/query.rs`). Setter/opt names (`agents_json`, `:tools`) are unchanged, so this is **not** an API break.

### Tests
- `--agents` emitted (not `--agents-json`), value follows the flag
- single variadic `--tools Read Bash` (not repeated `--tool`)
- both omitted when unset

Verified against `claude` CLI 2.1.173.

Related (out of scope here): `--allowed-tools`/`--disallowed-tools`/`--file` are also variadic but still emitted repeated -- tracked in #105.

Closes #82