### PR TITLE
feat: add Query.from_pr/2 (resume a PR-linked session)

### DIFF
--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -51,6 +51,7 @@ defmodule ClaudeWrapper.Query do
           resume: String.t() | nil,
           session_id: String.t() | nil,
           fallback_model: String.t() | nil,
+          from_pr: String.t() | nil,
           no_session_persistence: boolean(),
           dangerously_skip_permissions: boolean(),
           agent: String.t() | nil,
@@ -92,6 +93,7 @@ defmodule ClaudeWrapper.Query do
     :resume,
     :session_id,
     :fallback_model,
+    :from_pr,
     :agent,
     :agents_json,
     :input_format,
@@ -202,6 +204,15 @@ defmodule ClaudeWrapper.Query do
   @doc "Set a fallback model."
   @spec fallback_model(t(), String.t()) :: t()
   def fallback_model(%__MODULE__{} = q, model), do: %{q | fallback_model: model}
+
+  @doc """
+  Resume a session linked to a PR (`--from-pr <number|url>`).
+
+  Analogous to `resume/2` but keyed on a pull request rather than a
+  session id. The value is a PR number or URL.
+  """
+  @spec from_pr(t(), String.t()) :: t()
+  def from_pr(%__MODULE__{} = q, pr), do: %{q | from_pr: pr}
 
   @doc "Disable session persistence."
   @spec no_session_persistence(t()) :: t()
@@ -350,6 +361,7 @@ defmodule ClaudeWrapper.Query do
   defp apply_opt({:session_id, v}, q), do: session_id(q, v)
   defp apply_opt({:resume, v}, q), do: resume(q, v)
   defp apply_opt({:fallback_model, v}, q), do: fallback_model(q, v)
+  defp apply_opt({:from_pr, v}, q), do: from_pr(q, v)
   defp apply_opt({:output_format, v}, q), do: output_format(q, v)
   defp apply_opt({:input_format, v}, q), do: input_format(q, v)
   defp apply_opt({:settings, v}, q), do: settings(q, v)
@@ -554,6 +566,7 @@ defmodule ClaudeWrapper.Query do
     |> add_opt("--resume", q.resume)
     |> add_opt("--session-id", q.session_id)
     |> add_opt("--fallback-model", q.fallback_model)
+    |> add_opt("--from-pr", q.from_pr)
     |> add_bool("--no-session-persistence", q.no_session_persistence)
     |> add_bool("--dangerously-skip-permissions", q.dangerously_skip_permissions)
     |> add_opt("--agent", q.agent)

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -271,6 +271,26 @@ defmodule ClaudeWrapperTest do
     end
   end
 
+  describe "from_pr (#85)" do
+    test "emits --from-pr with the PR value" do
+      args =
+        Query.new("review this")
+        |> Query.from_pr("123")
+        |> Query.build_args()
+
+      assert "--from-pr" in args
+      idx = Enum.find_index(args, &(&1 == "--from-pr"))
+      assert Enum.at(args, idx + 1) == "123"
+    end
+
+    test "settable via apply_opts; absent by default" do
+      q = Query.new("p") |> Query.apply_opts(from_pr: "https://github.com/o/r/pull/7")
+      assert q.from_pr == "https://github.com/o/r/pull/7"
+
+      refute "--from-pr" in (Query.new("p") |> Query.build_args())
+    end
+  end
+
   describe "Result" do
     test "from_json parses standard fields" do
       data = %{


### PR DESCRIPTION
Adds `Query.from_pr/2`, analogous to `resume/2`, emitting `--from-pr <number|url>` to resume a session linked to a pull request. Matches the CLI (`--from-pr [value]`, 2.1.173) and the Rust `claude-wrapper` reference (`from_pr/1`).

### Scope change: `from_file` dropped
The issue title also mentioned `from_file`/`--prompt-file`, but **neither the current CLI (2.1.173) nor the Rust reference has a `--prompt-file` flag** -- `claude --help` has no such option and the Rust source has no `from_file`. The original parity audit over-reported it (same as the phantom `max_tokens`). Implementing it would emit an invalid flag, so it is intentionally omitted.

### Tests
- `--from-pr` emitted with the value; settable via `apply_opts`; absent by default.

Closes #85