### PR TITLE
feat: add ClaudeWrapper.Settings (read on-disk settings layers)

### DIFF
--- a/lib/claude_wrapper/settings.ex
+++ b/lib/claude_wrapper/settings.ex
@@ -1,0 +1,162 @@
+defmodule ClaudeWrapper.Settings do
+  @moduledoc """
+  Read-side access to Claude Code's on-disk **settings** files.
+
+  Claude Code reads up to four JSON files in increasing order of
+  precedence (later layers override earlier ones):
+
+    1. `~/.claude/settings.json` -- user defaults
+    2. `~/.claude/settings.local.json` -- user-private overrides
+    3. `<project>/.claude/settings.json` -- project-shared
+    4. `<project>/.claude/settings.local.json` -- project-private
+
+  This module reads each layer as an opaque decoded JSON value and
+  returns them side by side, **without merging**. Claude Code's merge
+  semantics are non-trivial and not fully documented, so reproducing
+  them here would risk diverging from the binary. Callers who want an
+  "effective" view can merge with full knowledge of which layer produced
+  which value -- the per-layer split makes that attribution possible.
+
+  ## Secrets
+
+  The `env` block of a settings file often contains secrets
+  (`ANTHROPIC_API_KEY`, tokens). Use `redact_env_values/1` before
+  forwarding a layer to a less-trusted consumer.
+
+  ## Example
+
+      {:ok, settings} = ClaudeWrapper.Settings.load(project_root: "/path/to/repo")
+
+      case ClaudeWrapper.Settings.get(settings, :user) do
+        nil -> IO.puts("no user settings")
+        user -> IO.inspect(Map.keys(user))
+      end
+  """
+
+  @enforce_keys [:user, :user_local, :project, :project_local, :paths]
+  defstruct [:user, :user_local, :project, :project_local, :paths]
+
+  @typedoc "One of the four settings layers, low-to-high precedence."
+  @type layer :: :user | :user_local | :project | :project_local
+
+  @typedoc "Absolute paths the loader checked, whether or not the files exist."
+  @type paths :: %{
+          user: String.t(),
+          user_local: String.t(),
+          project: String.t() | nil,
+          project_local: String.t() | nil
+        }
+
+  @type t :: %__MODULE__{
+          user: map() | nil,
+          user_local: map() | nil,
+          project: map() | nil,
+          project_local: map() | nil,
+          paths: paths()
+        }
+
+  @doc """
+  Load all four settings layers.
+
+  Options:
+
+    * `:user_root` -- the `.claude` directory to read user layers from
+      (default: `~/.claude`)
+    * `:project_root` -- the project directory whose `.claude/` holds the
+      project layers (default: none, so the project layers stay `nil`)
+
+  Missing files become `nil`; a malformed JSON file returns
+  `{:error, {:invalid_settings_json, path, reason}}`. Returns
+  `{:error, :no_home}` when `:user_root` is omitted and the home
+  directory cannot be determined.
+  """
+  @spec load(keyword()) :: {:ok, t()} | {:error, term()}
+  def load(opts \\ []) do
+    with {:ok, user_root} <- resolve_user_root(opts) do
+      paths = build_paths(user_root, Keyword.get(opts, :project_root))
+
+      with {:ok, user} <- read_layer(paths.user),
+           {:ok, user_local} <- read_layer(paths.user_local),
+           {:ok, project} <- read_layer(paths.project),
+           {:ok, project_local} <- read_layer(paths.project_local) do
+        {:ok,
+         %__MODULE__{
+           user: user,
+           user_local: user_local,
+           project: project,
+           project_local: project_local,
+           paths: paths
+         }}
+      end
+    end
+  end
+
+  @doc "Return the loaded value for one `t:layer/0`, or `nil` if absent."
+  @spec get(t(), layer()) :: map() | nil
+  def get(%__MODULE__{} = s, :user), do: s.user
+  def get(%__MODULE__{} = s, :user_local), do: s.user_local
+  def get(%__MODULE__{} = s, :project), do: s.project
+  def get(%__MODULE__{} = s, :project_local), do: s.project_local
+
+  @doc "All four layers, low-to-high precedence."
+  @spec layers() :: [layer(), ...]
+  def layers, do: [:user, :user_local, :project, :project_local]
+
+  @doc "The filename component (after `.claude/`) for a layer."
+  @spec filename(layer()) :: String.t()
+  def filename(layer) when layer in [:user, :project], do: "settings.json"
+  def filename(layer) when layer in [:user_local, :project_local], do: "settings.local.json"
+
+  @doc """
+  Replace every value under the top-level `env` object with
+  `"<redacted>"`, keeping the keys visible. A no-op on values that are
+  not maps or that have no map-valued `env` field.
+  """
+  @spec redact_env_values(map()) :: map()
+  def redact_env_values(%{"env" => env} = map) when is_map(env) do
+    Map.put(map, "env", Map.new(env, fn {k, _v} -> {k, "<redacted>"} end))
+  end
+
+  def redact_env_values(value), do: value
+
+  # -- helpers -------------------------------------------------------
+
+  defp resolve_user_root(opts) do
+    case Keyword.get(opts, :user_root) do
+      nil ->
+        case System.user_home() do
+          nil -> {:error, :no_home}
+          home -> {:ok, Path.join(home, ".claude")}
+        end
+
+      root ->
+        {:ok, root}
+    end
+  end
+
+  defp build_paths(user_root, project_root) do
+    %{
+      user: Path.join(user_root, "settings.json"),
+      user_local: Path.join(user_root, "settings.local.json"),
+      project: project_root && Path.join([project_root, ".claude", "settings.json"]),
+      project_local: project_root && Path.join([project_root, ".claude", "settings.local.json"])
+    }
+  end
+
+  defp read_layer(nil), do: {:ok, nil}
+
+  defp read_layer(path) do
+    case File.read(path) do
+      {:ok, raw} -> decode_layer(path, raw)
+      {:error, :enoent} -> {:ok, nil}
+      {:error, reason} -> {:error, {:settings_read_error, path, reason}}
+    end
+  end
+
+  defp decode_layer(path, raw) do
+    case Jason.decode(raw) do
+      {:ok, value} -> {:ok, value}
+      {:error, reason} -> {:error, {:invalid_settings_json, path, reason}}
+    end
+  end
+end

--- a/test/claude_wrapper/settings_test.exs
+++ b/test/claude_wrapper/settings_test.exs
@@ -1,0 +1,137 @@
+defmodule ClaudeWrapper.SettingsTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Settings
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "cwx_settings_#{System.unique_integer([:positive])}")
+    user_root = Path.join(base, "user")
+    project_root = Path.join(base, "project")
+    File.mkdir_p!(user_root)
+    File.mkdir_p!(project_root)
+    on_exit(fn -> File.rm_rf!(base) end)
+    {:ok, user_root: user_root, project_root: project_root}
+  end
+
+  defp write_json(path, value) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, Jason.encode!(value))
+  end
+
+  describe "load/1" do
+    test "loads only the user layer when others are absent", %{user_root: user_root} do
+      write_json(Path.join(user_root, "settings.json"), %{"env" => %{"FOO" => "bar"}})
+
+      {:ok, s} = Settings.load(user_root: user_root)
+
+      assert s.user["env"]["FOO"] == "bar"
+      assert s.user_local == nil
+      assert s.project == nil
+      assert s.project_local == nil
+    end
+
+    test "loads all four layers", %{user_root: user_root, project_root: project_root} do
+      write_json(Path.join(user_root, "settings.json"), %{"layer" => "user"})
+      write_json(Path.join(user_root, "settings.local.json"), %{"layer" => "user_local"})
+      write_json(Path.join([project_root, ".claude", "settings.json"]), %{"layer" => "project"})
+
+      write_json(Path.join([project_root, ".claude", "settings.local.json"]), %{
+        "layer" => "project_local"
+      })
+
+      {:ok, s} = Settings.load(user_root: user_root, project_root: project_root)
+
+      assert s.user["layer"] == "user"
+      assert s.user_local["layer"] == "user_local"
+      assert s.project["layer"] == "project"
+      assert s.project_local["layer"] == "project_local"
+    end
+
+    test "missing files are not errors", %{user_root: user_root} do
+      {:ok, s} = Settings.load(user_root: user_root)
+      assert s.user == nil
+      assert s.user_local == nil
+    end
+
+    test "no project_root means no project layers and nil project paths", %{user_root: user_root} do
+      write_json(Path.join(user_root, "settings.json"), %{"x" => 1})
+
+      {:ok, s} = Settings.load(user_root: user_root)
+
+      assert s.user != nil
+      assert s.project == nil
+      assert s.project_local == nil
+      assert s.paths.project == nil
+      assert s.paths.project_local == nil
+    end
+
+    test "malformed JSON returns an error", %{user_root: user_root} do
+      File.write!(Path.join(user_root, "settings.json"), "{not json")
+
+      assert {:error, {:invalid_settings_json, path, _reason}} =
+               Settings.load(user_root: user_root)
+
+      assert path == Path.join(user_root, "settings.json")
+    end
+
+    test "paths reflect the configured roots", %{user_root: user_root, project_root: project_root} do
+      {:ok, s} = Settings.load(user_root: user_root, project_root: project_root)
+
+      assert s.paths.user == Path.join(user_root, "settings.json")
+      assert s.paths.project == Path.join([project_root, ".claude", "settings.json"])
+    end
+  end
+
+  describe "get/2, layers/0, filename/1" do
+    test "get/2 indexes by layer", %{user_root: user_root} do
+      write_json(Path.join(user_root, "settings.json"), %{"k" => "user"})
+      write_json(Path.join(user_root, "settings.local.json"), %{"k" => "user_local"})
+
+      {:ok, s} = Settings.load(user_root: user_root)
+
+      assert Settings.get(s, :user)["k"] == "user"
+      assert Settings.get(s, :user_local)["k"] == "user_local"
+      assert Settings.get(s, :project) == nil
+    end
+
+    test "layers/0 lists all four in precedence order" do
+      assert Settings.layers() == [:user, :user_local, :project, :project_local]
+    end
+
+    test "filename/1 maps layers to filenames" do
+      assert Settings.filename(:user) == "settings.json"
+      assert Settings.filename(:project) == "settings.json"
+      assert Settings.filename(:user_local) == "settings.local.json"
+      assert Settings.filename(:project_local) == "settings.local.json"
+    end
+  end
+
+  describe "redact_env_values/1" do
+    test "replaces env values but keeps keys and other fields" do
+      v = %{
+        "env" => %{"ANTHROPIC_API_KEY" => "sk-xxx", "DEBUG" => "1"},
+        "permissions" => %{"allow" => ["Bash(ls *)"]}
+      }
+
+      redacted = Settings.redact_env_values(v)
+
+      assert redacted["env"]["ANTHROPIC_API_KEY"] == "<redacted>"
+      assert redacted["env"]["DEBUG"] == "<redacted>"
+      assert redacted["permissions"]["allow"] == ["Bash(ls *)"]
+    end
+
+    test "is a no-op without an env field" do
+      v = %{"permissions" => %{"allow" => []}}
+      assert Settings.redact_env_values(v) == v
+    end
+
+    test "is a no-op on non-map input" do
+      assert Settings.redact_env_values(["not", "a", "map"]) == ["not", "a", "map"]
+    end
+
+    test "is a no-op when env is not a map" do
+      v = %{"env" => "weird-but-tolerated"}
+      assert Settings.redact_env_values(v) == v
+    end
+  end
+end


### PR DESCRIPTION
New read-side module `ClaudeWrapper.Settings`, ported from the Rust `claude-wrapper` `settings` module.

Reads the four Claude Code settings layers as raw decoded JSON, **without merging** (precedence is a caller concern, and the binary's merge semantics aren't fully documented):

1. `~/.claude/settings.json`
2. `~/.claude/settings.local.json`
3. `<project>/.claude/settings.json`
4. `<project>/.claude/settings.local.json`

### API
- `load/1` -- opts `:user_root` (default `~/.claude`), `:project_root`. Missing files -> `nil`; malformed JSON -> `{:error, {:invalid_settings_json, path, reason}}`; no home -> `{:error, :no_home}`.
- `get/2` -- index a loaded struct by `:user | :user_local | :project | :project_local`
- `layers/0` -- the four layers in precedence order
- `filename/1` -- the on-disk filename for a layer
- `redact_env_values/1` -- scrub the `env` block (which often holds secrets) before forwarding

The struct also carries `:paths` (the absolute paths checked) for diagnostics.

15 module tests; full suite 181 passing; credo/dialyzer clean.

Closes #86