### PR TITLE
feat: add ClaudeWrapper.Agents (file-backed agent definitions)

### DIFF
--- a/lib/claude_wrapper/agents.ex
+++ b/lib/claude_wrapper/agents.ex
@@ -1,0 +1,446 @@
+defmodule ClaudeWrapper.Agents.Summary do
+  @moduledoc """
+  Lightweight metadata for one agent definition, returned by
+  `ClaudeWrapper.Agents.list/1`.
+
+  Strips the prompt body and extra frontmatter to keep listings cheap.
+  See `ClaudeWrapper.Agents` for how these are produced.
+  """
+
+  @enforce_keys [:file_stem, :name, :tools, :file_path, :size_bytes]
+  defstruct [:file_stem, :name, :description, :tools, :model, :file_path, :size_bytes]
+
+  @type t :: %__MODULE__{
+          file_stem: String.t(),
+          name: String.t(),
+          description: String.t() | nil,
+          tools: [String.t()],
+          model: String.t() | nil,
+          file_path: String.t(),
+          size_bytes: non_neg_integer()
+        }
+end
+
+defmodule ClaudeWrapper.Agents.Definition do
+  @moduledoc """
+  Full agent definition returned by `ClaudeWrapper.Agents.get/2`.
+
+  Carries the summary fields plus the prompt `body` and any unknown
+  frontmatter keys in `extra`. See `ClaudeWrapper.Agents`.
+  """
+
+  @enforce_keys [:file_stem, :name, :tools, :file_path, :size_bytes, :body, :extra]
+  defstruct [
+    :file_stem,
+    :name,
+    :description,
+    :tools,
+    :model,
+    :file_path,
+    :size_bytes,
+    :body,
+    :extra
+  ]
+
+  @type t :: %__MODULE__{
+          file_stem: String.t(),
+          name: String.t(),
+          description: String.t() | nil,
+          tools: [String.t()],
+          model: String.t() | nil,
+          file_path: String.t(),
+          size_bytes: non_neg_integer(),
+          body: String.t(),
+          extra: %{optional(String.t()) => String.t()}
+        }
+end
+
+defmodule ClaudeWrapper.Agents do
+  @moduledoc """
+  File-backed read/write access to Claude Code's on-disk **agent**
+  definitions.
+
+  Claude Code resolves user-level agents from
+  `~/.claude/agents/<stem>.md`. Each file is plain markdown with a
+  YAML-style frontmatter block delimited by `---` lines. The
+  frontmatter carries the agent's metadata (name, description, optional
+  tool allow-list, optional model); the body is the agent's system
+  prompt.
+
+  This is distinct from `ClaudeWrapper.Commands.Agents`, which shells
+  out to `claude agents`. This module reads and writes the files
+  directly.
+
+  Two levels of granularity for reads:
+
+    * `list/1` -- enumerate every agent at the root with summary
+      metadata (name, description, tools, model, file path).
+    * `get/2` -- read one agent's full record including the prompt body
+      and unknown frontmatter keys.
+
+  Plus `write/3`, `write_new/3`, and `delete/2` for mutations.
+
+  ## Frontmatter format
+
+  Real-world agents look like:
+
+      ---
+      name: auditor
+      description: Multi-line folded description...
+      tools: Read, Glob, Grep, Bash
+      model: sonnet
+      ---
+
+      You are an auditor. ...
+
+  The parser is permissive: only `name`, `description`, `tools`, and
+  `model` are typed. `tools` is a comma-separated list. Any other
+  `key: value` pairs land in `Definition.extra` so unknown future keys
+  survive a round trip. Frontmatter is optional -- a body-only file
+  parses fine, with `name` defaulting to the file stem.
+
+  List-valued and folded frontmatter keys (anything this parser cannot
+  reduce to a single inline scalar) are tolerated by capturing their
+  raw inline value into `extra` rather than failing the parse.
+
+  ## File stem vs name
+
+  By convention an agent's `name` matches its filename stem:
+  `auditor.md` carries `name: auditor`. The two can diverge -- the
+  parser keeps both. Lookup, write, and delete all key on the file
+  stem (that's what the filesystem indexes), not the frontmatter
+  `name`.
+
+  ## Example
+
+      {:ok, root} = ClaudeWrapper.Agents.home()
+      {:ok, summaries} = ClaudeWrapper.Agents.list(root)
+
+      for s <- summaries do
+        IO.puts("\#{s.file_stem}: \#{s.description}")
+      end
+
+      {:ok, agent} = ClaudeWrapper.Agents.get(root, "auditor")
+      IO.puts(agent.body)
+  """
+
+  alias ClaudeWrapper.Agents.{Definition, Summary}
+
+  @enforce_keys [:root]
+  defstruct [:root]
+
+  @type t :: %__MODULE__{root: String.t()}
+
+  @typedoc """
+  Attributes for `write/3` and `write_new/3`.
+
+  A keyword list or map. All keys are optional:
+
+    * `:name` -- frontmatter `name`; defaults to the file stem
+    * `:description` -- frontmatter `description`
+    * `:tools` -- list of tool names, rendered comma-joined
+    * `:model` -- frontmatter `model`
+    * `:body` -- the agent prompt body
+    * `:extra` -- map of additional frontmatter `key => string` pairs,
+      rendered in sorted order after the typed keys
+  """
+  @type attrs :: Enumerable.t()
+
+  @doc """
+  Resolve the default agents root, `~/.claude/agents`.
+
+  Returns `{:error, :no_home}` when the user home cannot be determined.
+  """
+  @spec home() :: {:ok, t()} | {:error, :no_home}
+  def home do
+    case System.user_home() do
+      nil -> {:error, :no_home}
+      home -> {:ok, %__MODULE__{root: Path.join([home, ".claude", "agents"])}}
+    end
+  end
+
+  @doc """
+  Use a specific path as the agents root. Useful for tests (point at a
+  temp dir) and non-default installs.
+  """
+  @spec at(String.t()) :: t()
+  def at(path) when is_binary(path), do: %__MODULE__{root: path}
+
+  @doc "The configured root directory."
+  @spec root(t()) :: String.t()
+  def root(%__MODULE__{root: root}), do: root
+
+  @doc """
+  List every `*.md` agent at the root, sorted by file stem.
+
+  Returns `{:ok, []}` when the root directory does not exist (a fresh
+  install with no user agents). Files that fail to parse are skipped
+  rather than failing the whole listing.
+  """
+  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, term()}
+  def list(%__MODULE__{} = a) do
+    case File.ls(a.root) do
+      {:ok, names} ->
+        summaries =
+          names
+          |> Enum.filter(&String.ends_with?(&1, ".md"))
+          |> Enum.map(&summarize(a, &1))
+          |> Enum.reject(&is_nil/1)
+          |> Enum.sort_by(& &1.file_stem)
+
+        {:ok, summaries}
+
+      {:error, :enoent} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Read one agent by file stem (the basename of `<stem>.md` under the
+  root) into a full `Definition`.
+
+  Returns `{:error, :not_found}` when no such file exists.
+  """
+  @spec get(t(), String.t()) :: {:ok, Definition.t()} | {:error, :not_found | term()}
+  def get(%__MODULE__{} = a, file_stem) when is_binary(file_stem) do
+    path = agent_path(a, file_stem)
+
+    case File.read(path) do
+      {:ok, raw} -> {:ok, parse_agent(raw, file_stem, path)}
+      {:error, :enoent} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Write (create or overwrite) an agent at `<file_stem>.md`.
+
+  Creates the agents root directory if it does not exist. See `t:attrs/0`
+  for the accepted attributes. To fail when the agent already exists
+  instead of overwriting, use `write_new/3`.
+
+  Returns `{:error, {:invalid_stem, stem}}` for empty, `.`, `..`, or
+  stems containing slashes or NUL bytes.
+  """
+  @spec write(t(), String.t(), attrs()) :: :ok | {:error, term()}
+  def write(%__MODULE__{} = a, file_stem, attrs) when is_binary(file_stem) do
+    write_inner(a, file_stem, attrs, true)
+  end
+
+  @doc """
+  Like `write/3` but returns `{:error, :exists}` when the agent already
+  exists. Useful for create-only flows where overwriting would be a bug.
+  """
+  @spec write_new(t(), String.t(), attrs()) :: :ok | {:error, :exists | term()}
+  def write_new(%__MODULE__{} = a, file_stem, attrs) when is_binary(file_stem) do
+    write_inner(a, file_stem, attrs, false)
+  end
+
+  @doc """
+  Remove the `<file_stem>.md` agent.
+
+  Returns `{:error, :not_found}` when no such file exists.
+  """
+  @spec delete(t(), String.t()) :: :ok | {:error, :not_found | term()}
+  def delete(%__MODULE__{} = a, file_stem) when is_binary(file_stem) do
+    with :ok <- validate_stem(file_stem) do
+      case File.rm(agent_path(a, file_stem)) do
+        :ok -> :ok
+        {:error, :enoent} -> {:error, :not_found}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  # -- write helpers -------------------------------------------------
+
+  defp write_inner(%__MODULE__{} = a, file_stem, attrs, allow_overwrite) do
+    fields = normalize_attrs(attrs)
+
+    with :ok <- validate_stem(file_stem),
+         path = agent_path(a, file_stem),
+         :ok <- guard_overwrite(path, allow_overwrite),
+         :ok <- File.mkdir_p(a.root) do
+      File.write(path, render_markdown(file_stem, fields))
+    end
+  end
+
+  defp guard_overwrite(_path, true), do: :ok
+
+  defp guard_overwrite(path, false) do
+    if File.exists?(path), do: {:error, :exists}, else: :ok
+  end
+
+  defp normalize_attrs(attrs) do
+    map = Map.new(attrs)
+
+    %{
+      name: get_attr(map, :name),
+      description: get_attr(map, :description),
+      tools: Map.get(map, :tools) || [],
+      model: get_attr(map, :model),
+      body: get_attr(map, :body) || "",
+      extra: Map.get(map, :extra) || %{}
+    }
+  end
+
+  # Look up an attr by atom or string key, normalizing "" to nil.
+  defp get_attr(map, key) do
+    case Map.get(map, key) || Map.get(map, Atom.to_string(key)) do
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp render_markdown(file_stem, fields) do
+    name = fields.name || file_stem
+
+    frontmatter =
+      ["name: #{name}"]
+      |> append_scalar("description", fields.description)
+      |> append_tools(fields.tools)
+      |> append_scalar("model", fields.model)
+      |> append_extra(fields.extra)
+
+    header = "---\n" <> Enum.join(frontmatter, "\n") <> "\n---\n\n"
+    header <> String.trim(fields.body) <> "\n"
+  end
+
+  defp append_scalar(lines, _key, nil), do: lines
+  defp append_scalar(lines, key, value), do: lines ++ ["#{key}: #{value}"]
+
+  defp append_tools(lines, []), do: lines
+  defp append_tools(lines, tools), do: lines ++ ["tools: #{Enum.join(tools, ", ")}"]
+
+  defp append_extra(lines, extra) do
+    extra
+    |> Enum.sort_by(fn {k, _v} -> to_string(k) end)
+    |> Enum.reduce(lines, fn {k, v}, acc -> acc ++ ["#{k}: #{v}"] end)
+  end
+
+  # -- read helpers --------------------------------------------------
+
+  defp summarize(%__MODULE__{} = a, name) do
+    file_stem = Path.basename(name, ".md")
+    path = agent_path(a, file_stem)
+
+    case File.read(path) do
+      {:ok, raw} -> to_summary(parse_agent(raw, file_stem, path))
+      {:error, _} -> nil
+    end
+  end
+
+  defp to_summary(%Definition{} = d) do
+    %Summary{
+      file_stem: d.file_stem,
+      name: d.name,
+      description: d.description,
+      tools: d.tools,
+      model: d.model,
+      file_path: d.file_path,
+      size_bytes: d.size_bytes
+    }
+  end
+
+  defp parse_agent(raw, file_stem, path) do
+    {frontmatter, body} = split_frontmatter(raw)
+    fields = parse_frontmatter(frontmatter, file_stem)
+
+    %Definition{
+      file_stem: file_stem,
+      name: fields.name,
+      description: fields.description,
+      tools: fields.tools,
+      model: fields.model,
+      file_path: path,
+      size_bytes: byte_size(raw),
+      body: String.trim(body),
+      extra: fields.extra
+    }
+  end
+
+  defp parse_frontmatter(nil, file_stem), do: empty_fields(file_stem)
+
+  defp parse_frontmatter(frontmatter, file_stem) do
+    frontmatter
+    |> String.split("\n")
+    |> Enum.reduce(empty_fields(file_stem), &apply_frontmatter_line/2)
+  end
+
+  defp empty_fields(file_stem) do
+    %{name: file_stem, description: nil, tools: [], model: nil, extra: %{}}
+  end
+
+  defp apply_frontmatter_line(line, fields) do
+    case parse_kv(line) do
+      {key, value} -> apply_kv(fields, key, value)
+      :skip -> fields
+    end
+  end
+
+  # Split a "key: value" line. Skips blank lines, lines without a
+  # colon, and lines whose key is empty.
+  defp parse_kv(line) do
+    trimmed = String.trim(line)
+
+    case String.split(trimmed, ":", parts: 2) do
+      [key, value] -> kv_or_skip(String.trim(key), String.trim(value))
+      _ -> :skip
+    end
+  end
+
+  defp kv_or_skip("", _value), do: :skip
+  defp kv_or_skip(key, value), do: {key, value}
+
+  defp apply_kv(fields, _key, ""), do: fields
+  defp apply_kv(fields, "name", value), do: %{fields | name: value}
+  defp apply_kv(fields, "description", value), do: %{fields | description: value}
+  defp apply_kv(fields, "tools", value), do: %{fields | tools: parse_tools(value)}
+  defp apply_kv(fields, "model", value), do: %{fields | model: value}
+
+  defp apply_kv(fields, key, value) do
+    %{fields | extra: Map.put(fields.extra, key, value)}
+  end
+
+  defp parse_tools(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  # Split a markdown file into `{frontmatter_or_nil, body}`. Frontmatter
+  # is delimited by a leading `---` line and a closing `---` line. An
+  # opening `---` with no matching close is treated conservatively as
+  # no frontmatter, returning `{nil, raw}`.
+  defp split_frontmatter(raw) do
+    case String.split(raw, "\n") do
+      ["---" | rest] -> split_after_open(rest, raw)
+      _ -> {nil, raw}
+    end
+  end
+
+  defp split_after_open(lines, raw) do
+    case Enum.split_while(lines, &(&1 != "---")) do
+      {_fm, []} -> {nil, raw}
+      {fm_lines, ["---" | body_lines]} -> {Enum.join(fm_lines, "\n"), Enum.join(body_lines, "\n")}
+    end
+  end
+
+  defp agent_path(%__MODULE__{root: root}, file_stem) do
+    Path.join(root, file_stem <> ".md")
+  end
+
+  defp validate_stem(stem) when stem in ["", ".", ".."], do: {:error, {:invalid_stem, stem}}
+
+  defp validate_stem(stem) do
+    if String.contains?(stem, ["/", "\\", "\0"]) do
+      {:error, {:invalid_stem, stem}}
+    else
+      :ok
+    end
+  end
+end

--- a/test/claude_wrapper/agents_test.exs
+++ b/test/claude_wrapper/agents_test.exs
@@ -1,0 +1,326 @@
+defmodule ClaudeWrapper.AgentsTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Agents
+  alias ClaudeWrapper.Agents.{Definition, Summary}
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "cwx_agents_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  defp write_agent(dir, file_stem, contents) do
+    File.mkdir_p!(dir)
+    path = Path.join(dir, file_stem <> ".md")
+    File.write!(path, contents)
+    path
+  end
+
+  defp fixture(root) do
+    write_agent(
+      root,
+      "rust-qa",
+      "---\nname: rust-qa\ndescription: Rust quality gate\ntools: Read, Grep, Bash\nmodel: sonnet\n---\n\nYou are a Rust quality gate.\n"
+    )
+
+    write_agent(root, "no-frontmatter", "Just a body, no frontmatter at all.\n")
+
+    write_agent(
+      root,
+      "minimal",
+      "---\nname: minimal\ndescription: Minimal agent\n---\nBody here.\n"
+    )
+
+    write_agent(
+      root,
+      "weird",
+      "---\nname: weird\ndescription: has extras\ncustom_key: custom_value\n---\nbody\n"
+    )
+
+    # Non-md file should be ignored by list/1.
+    File.write!(Path.join(root, "README.txt"), "ignore me")
+    :ok
+  end
+
+  describe "home/0, at/1, root/1" do
+    test "at/1 wraps an explicit root and root/1 reads it back" do
+      a = Agents.at("/tmp/agents")
+      assert a.root == "/tmp/agents"
+      assert Agents.root(a) == "/tmp/agents"
+    end
+
+    test "home/0 resolves ~/.claude/agents" do
+      assert {:ok, %Agents{root: root}} = Agents.home()
+      assert String.ends_with?(root, Path.join([".claude", "agents"]))
+    end
+  end
+
+  describe "list/1" do
+    test "returns only .md files, sorted by file stem", %{root: root} do
+      fixture(root)
+
+      {:ok, summaries} = Agents.list(Agents.at(root))
+
+      assert Enum.map(summaries, & &1.file_stem) == [
+               "minimal",
+               "no-frontmatter",
+               "rust-qa",
+               "weird"
+             ]
+    end
+
+    test "returns empty when the root does not exist" do
+      {:ok, summaries} = Agents.list(Agents.at("/no/such/agents/root"))
+      assert summaries == []
+    end
+
+    test "parses typed metadata into a Summary", %{root: root} do
+      fixture(root)
+
+      {:ok, summaries} = Agents.list(Agents.at(root))
+      rust_qa = Enum.find(summaries, &(&1.file_stem == "rust-qa"))
+
+      assert %Summary{name: "rust-qa", description: "Rust quality gate", model: "sonnet"} =
+               rust_qa
+
+      assert rust_qa.tools == ["Read", "Grep", "Bash"]
+      assert rust_qa.size_bytes > 0
+      assert String.ends_with?(rust_qa.file_path, "rust-qa.md")
+    end
+
+    test "no frontmatter falls back to the file stem as name", %{root: root} do
+      fixture(root)
+
+      {:ok, summaries} = Agents.list(Agents.at(root))
+      nf = Enum.find(summaries, &(&1.file_stem == "no-frontmatter"))
+
+      assert nf.name == "no-frontmatter"
+      assert nf.description == nil
+      assert nf.tools == []
+      assert nf.model == nil
+    end
+  end
+
+  describe "get/2" do
+    test "returns the full Definition with body", %{root: root} do
+      fixture(root)
+
+      {:ok, agent} = Agents.get(Agents.at(root), "rust-qa")
+
+      assert %Definition{name: "rust-qa", model: "sonnet"} = agent
+      assert agent.tools == ["Read", "Grep", "Bash"]
+      assert agent.body == "You are a Rust quality gate."
+    end
+
+    test "no frontmatter returns the whole file as body", %{root: root} do
+      fixture(root)
+
+      {:ok, agent} = Agents.get(Agents.at(root), "no-frontmatter")
+
+      assert agent.body == "Just a body, no frontmatter at all."
+      assert agent.name == "no-frontmatter"
+      assert agent.tools == []
+      assert agent.extra == %{}
+    end
+
+    test "unknown stem returns {:error, :not_found}", %{root: root} do
+      fixture(root)
+      assert Agents.get(Agents.at(root), "nope") == {:error, :not_found}
+    end
+
+    test "extra frontmatter keys round-trip as raw strings", %{root: root} do
+      fixture(root)
+
+      {:ok, agent} = Agents.get(Agents.at(root), "weird")
+      assert agent.extra["custom_key"] == "custom_value"
+    end
+
+    test "empty-valued keys do not overwrite defaults", %{root: root} do
+      write_agent(root, "empty-name", "---\nname:\ndescription: keeps stem as name\n---\nbody\n")
+
+      {:ok, agent} = Agents.get(Agents.at(root), "empty-name")
+      assert agent.name == "empty-name"
+      assert agent.description == "keeps stem as name"
+    end
+
+    test "an opening --- with no close is treated as no frontmatter", %{root: root} do
+      raw = "---\nname: x\nstill no close here\n"
+      write_agent(root, "unclosed", raw)
+
+      {:ok, agent} = Agents.get(Agents.at(root), "unclosed")
+      # Conservative: whole file is the body, name falls back to stem.
+      assert agent.name == "unclosed"
+      assert agent.body == String.trim(raw)
+    end
+
+    test "list-valued frontmatter keys are tolerated via extra", %{root: root} do
+      write_agent(
+        root,
+        "folded",
+        "---\nname: folded\nskills:\n  - sandbox-preflight\n---\nbody\n"
+      )
+
+      {:ok, agent} = Agents.get(Agents.at(root), "folded")
+      # The `skills:` key has no inline value, so it is skipped; the
+      # list item line has no colon, so it is skipped too. Parse must
+      # not fail.
+      assert agent.name == "folded"
+      assert agent.body == "body"
+    end
+  end
+
+  describe "write/3" do
+    test "creates a new agent that round-trips via get/2", %{root: root} do
+      a = Agents.at(root)
+
+      assert :ok =
+               Agents.write(a, "my-agent",
+                 name: "my-agent",
+                 description: "does the thing",
+                 tools: ["Read", "Bash"],
+                 model: "sonnet",
+                 body: "You are an agent."
+               )
+
+      {:ok, agent} = Agents.get(a, "my-agent")
+      assert agent.name == "my-agent"
+      assert agent.description == "does the thing"
+      assert agent.tools == ["Read", "Bash"]
+      assert agent.model == "sonnet"
+      assert agent.body == "You are an agent."
+    end
+
+    test "accepts a map of attrs", %{root: root} do
+      a = Agents.at(root)
+
+      assert :ok = Agents.write(a, "as-map", %{description: "from a map", body: "b"})
+
+      {:ok, agent} = Agents.get(a, "as-map")
+      assert agent.description == "from a map"
+      assert agent.body == "b"
+    end
+
+    test "overwrites an existing agent, replacing the whole file", %{root: root} do
+      fixture(root)
+      a = Agents.at(root)
+
+      assert :ok = Agents.write(a, "rust-qa", description: "rewritten", body: "new body")
+
+      {:ok, agent} = Agents.get(a, "rust-qa")
+      assert agent.description == "rewritten"
+      assert agent.body == "new body"
+      # tools/model from the original are gone -- write replaces the file.
+      assert agent.tools == []
+      assert agent.model == nil
+    end
+
+    test "creates the root directory if missing", %{root: root} do
+      a = Agents.at(Path.join(root, "nested/agents"))
+
+      assert :ok = Agents.write(a, "foo", body: "body")
+      assert {:ok, agent} = Agents.get(a, "foo")
+      assert agent.body == "body"
+    end
+
+    test "defaults name to the file stem when absent", %{root: root} do
+      a = Agents.at(root)
+      assert :ok = Agents.write(a, "my-stem", body: "b")
+
+      {:ok, agent} = Agents.get(a, "my-stem")
+      assert agent.name == "my-stem"
+    end
+
+    test "preserves extra keys, sorted, after the typed keys", %{root: root} do
+      a = Agents.at(root)
+
+      assert :ok =
+               Agents.write(a, "ex",
+                 name: "n",
+                 description: "d",
+                 tools: ["t1", "t2"],
+                 model: "haiku",
+                 body: "body",
+                 extra: %{"zzz_last" => "v", "aaa_first" => "v"}
+               )
+
+      raw = File.read!(Path.join(root, "ex.md"))
+      lines = String.split(raw, "\n")
+
+      assert Enum.at(lines, 0) == "---"
+      assert Enum.at(lines, 1) == "name: n"
+      assert Enum.at(lines, 2) == "description: d"
+      assert Enum.at(lines, 3) == "tools: t1, t2"
+      assert Enum.at(lines, 4) == "model: haiku"
+      assert Enum.at(lines, 5) == "aaa_first: v"
+      assert Enum.at(lines, 6) == "zzz_last: v"
+      assert Enum.at(lines, 7) == "---"
+
+      {:ok, agent} = Agents.get(a, "ex")
+      assert agent.extra == %{"aaa_first" => "v", "zzz_last" => "v"}
+    end
+
+    test "omits optional keys when unset", %{root: root} do
+      a = Agents.at(root)
+      assert :ok = Agents.write(a, "min", body: "body only")
+
+      raw = File.read!(Path.join(root, "min.md"))
+      refute raw =~ "description:"
+      refute raw =~ "tools:"
+      refute raw =~ "model:"
+    end
+
+    test "rejects path-traversal and reserved stems", %{root: root} do
+      a = Agents.at(root)
+
+      for bad <- ["", ".", "..", "a/b", "a\\b", "a\0b"] do
+        assert Agents.write(a, bad, body: "b") == {:error, {:invalid_stem, bad}}
+      end
+    end
+  end
+
+  describe "write_new/3" do
+    test "errors with {:error, :exists} when the agent already exists", %{root: root} do
+      fixture(root)
+      assert Agents.write_new(Agents.at(root), "rust-qa", body: "body") == {:error, :exists}
+    end
+
+    test "succeeds for a fresh stem", %{root: root} do
+      a = Agents.at(root)
+      assert :ok = Agents.write_new(a, "brand-new", body: "hello")
+
+      {:ok, agent} = Agents.get(a, "brand-new")
+      assert agent.body == "hello"
+    end
+
+    test "rejects path-traversal stems before touching the filesystem", %{root: root} do
+      assert Agents.write_new(Agents.at(root), "a/b", body: "b") ==
+               {:error, {:invalid_stem, "a/b"}}
+    end
+  end
+
+  describe "delete/2" do
+    test "removes the file", %{root: root} do
+      fixture(root)
+      a = Agents.at(root)
+
+      assert {:ok, _} = Agents.get(a, "rust-qa")
+      assert :ok = Agents.delete(a, "rust-qa")
+      assert Agents.get(a, "rust-qa") == {:error, :not_found}
+    end
+
+    test "unknown stem returns {:error, :not_found}", %{root: root} do
+      fixture(root)
+      assert Agents.delete(Agents.at(root), "nope") == {:error, :not_found}
+    end
+
+    test "rejects path-traversal stems", %{root: root} do
+      a = Agents.at(root)
+
+      for bad <- ["", ".", "..", "a/b", "a\\b"] do
+        assert Agents.delete(a, bad) == {:error, {:invalid_stem, bad}}
+      end
+    end
+  end
+end


### PR DESCRIPTION
New module `ClaudeWrapper.Agents` for read/write access to `~/.claude/agents/<stem>.md`, ported from the Rust `claude-wrapper` `artifacts` module. Distinct from the CLI-driven `ClaudeWrapper.Commands.Agents`.

### API
- `home/0`, `at/1`, `root/1`
- `list/1` -> `[Agents.Summary]` (sorted by stem; skips unparseable files; empty if dir missing)
- `get/2` -> `{:ok, Agents.Definition}` | `{:error, :not_found}`
- `write/3` (overwrite), `write_new/3` (`{:error, :exists}` on collision), `delete/2`

`Summary`: file_stem, name, description, tools (list), model, file_path, size_bytes. `Definition` adds body + extra.

### Frontmatter
Hand-rolled parse/serialize, **no new dependency**. Typed `name`/`description`/`tools` (comma-split)/`model`, the markdown body, and any other keys preserved in `extra` as raw strings (round-trips deterministically with canonical key order). Folded scalars and list-valued keys are tolerated (kept in/skipped to `extra`) rather than failing.

### Deviations from Rust (intentional)
- Tagged-atom errors (`:not_found` / `:exists`) per repo convention, vs Rust's string messages.
- Plain `File.write` (no temp-file rename); no in-repo precedent for atomic writes and the issue didn't require it.

27 module tests; full suite 208 passing; credo/dialyzer clean.

Closes #91