### PR TITLE
feat: add ClaudeWrapper.Worktrees (git worktree introspection)

### DIFF
--- a/lib/claude_wrapper/worktrees.ex
+++ b/lib/claude_wrapper/worktrees.ex
@@ -1,0 +1,215 @@
+defmodule ClaudeWrapper.Worktrees.Worktree do
+  @moduledoc """
+  One git worktree as reported by `git worktree list --porcelain`.
+
+  See `ClaudeWrapper.Worktrees` for how these are produced.
+  """
+
+  @enforce_keys [:path]
+  defstruct [
+    :path,
+    :head,
+    :branch,
+    :lock_reason,
+    :prune_reason,
+    is_main?: false,
+    is_detached?: false,
+    is_bare?: false,
+    is_locked?: false,
+    is_prunable?: false
+  ]
+
+  @type t :: %__MODULE__{
+          path: String.t(),
+          head: String.t() | nil,
+          branch: String.t() | nil,
+          lock_reason: String.t() | nil,
+          prune_reason: String.t() | nil,
+          is_main?: boolean(),
+          is_detached?: boolean(),
+          is_bare?: boolean(),
+          is_locked?: boolean(),
+          is_prunable?: boolean()
+        }
+end
+
+defmodule ClaudeWrapper.Worktrees do
+  @moduledoc """
+  Read-side introspection for git worktrees.
+
+  Claude Code's `--worktree [name]` flag (and its `DuplexSession`
+  equivalent) creates fresh git worktrees so an agent's writes can land
+  somewhere other than the current working tree. Hosts that orchestrate
+  worktree-isolated chats need a way to enumerate the worktrees that
+  exist for a given repo, see what branches they're on, and notice when
+  one is locked or prunable.
+
+  This module is a thin Elixir API over `git worktree list --porcelain`.
+  It is read-only on purpose; mutations (pruning, removing worktrees) are
+  out of scope so consumers that only want to introspect don't opt into
+  write semantics.
+
+  ## Why shell out
+
+  Reading `.git/worktrees/` directly is brittle: git tracks `locked`,
+  `prunable`, detached-HEAD, and bare-repo state in ways that have
+  evolved across releases. Asking git itself is the cheap, correct
+  option, and `git` is already a transitive dependency of any
+  worktree-using workflow.
+
+  ## Example
+
+      {:ok, root} = ClaudeWrapper.Worktrees.for_repo(".")
+      {:ok, worktrees} = ClaudeWrapper.Worktrees.list(root)
+
+      for wt <- worktrees do
+        IO.puts("\#{wt.path}  \#{wt.branch || "(detached)"}")
+      end
+  """
+
+  alias ClaudeWrapper.Worktrees.Worktree
+
+  @enforce_keys [:repo_path]
+  defstruct [:repo_path]
+
+  @type t :: %__MODULE__{repo_path: String.t()}
+
+  @doc """
+  Address worktrees for the repository containing `path`.
+
+  `path` can be any directory inside the repo; git's `-C` handling
+  resolves the `.git` itself. Runs `git worktree list --porcelain` once
+  to validate that `path` is in fact inside a git repository.
+
+  Returns `{:error, {:not_a_git_repo, path}}` when `path` is not inside a
+  repository, `{:error, {:git_failed, exit_status, stderr}}` for other
+  non-zero git exits, and `{:error, {:git_unavailable, reason}}` when the
+  `git` binary cannot be spawned.
+  """
+  @spec for_repo(String.t()) :: {:ok, t()} | {:error, term()}
+  def for_repo(path) when is_binary(path) do
+    root = %__MODULE__{repo_path: path}
+
+    case run_porcelain(root) do
+      {:ok, _stdout} -> {:ok, root}
+      {:error, _reason} = err -> err
+    end
+  end
+
+  @doc "The configured repository path."
+  @spec path(t()) :: String.t()
+  def path(%__MODULE__{repo_path: repo_path}), do: repo_path
+
+  @doc """
+  List every worktree git knows about for this repository.
+
+  Spawns `git -C <repo_path> worktree list --porcelain` and parses the
+  output. The first entry is the main worktree (`is_main? == true`).
+
+  Returns the same error shapes as `for_repo/1`.
+  """
+  @spec list(t()) :: {:ok, [Worktree.t()]} | {:error, term()}
+  def list(%__MODULE__{} = root) do
+    case run_porcelain(root) do
+      {:ok, stdout} -> {:ok, parse_porcelain(stdout)}
+      {:error, _reason} = err -> err
+    end
+  end
+
+  # -- git invocation ------------------------------------------------
+
+  defp run_porcelain(%__MODULE__{repo_path: repo_path}) do
+    args = ["-C", repo_path, "worktree", "list", "--porcelain"]
+
+    case safe_cmd(args) do
+      {:ok, {output, 0}} -> {:ok, output}
+      {:ok, {output, status}} -> {:error, classify_failure(repo_path, status, output)}
+      {:error, _reason} = err -> err
+    end
+  end
+
+  # Wrap System.cmd so a missing `git` binary becomes a tagged error
+  # instead of an :enoent ErlangError escaping the module.
+  defp safe_cmd(args) do
+    {:ok, System.cmd("git", args, stderr_to_stdout: true)}
+  rescue
+    e in ErlangError -> {:error, {:git_unavailable, e.original}}
+  end
+
+  defp classify_failure(repo_path, status, output) do
+    if String.contains?(output, "not a git repository") do
+      {:not_a_git_repo, repo_path}
+    else
+      {:git_failed, status, String.trim(output)}
+    end
+  end
+
+  # -- porcelain parsing ---------------------------------------------
+
+  defp parse_porcelain(input) do
+    input
+    |> split_paragraphs()
+    |> Enum.map(&parse_paragraph/1)
+    |> mark_first_as_main()
+  end
+
+  # Split on blank lines into paragraphs of non-empty lines, tolerating
+  # CRLF and a trailing block with no closing blank line.
+  defp split_paragraphs(input) do
+    input
+    |> String.split("\n")
+    |> Enum.map(&String.trim_trailing(&1, "\r"))
+    |> Enum.chunk_by(&(&1 == ""))
+    |> Enum.reject(&blank_chunk?/1)
+  end
+
+  defp blank_chunk?(lines), do: Enum.all?(lines, &(&1 == ""))
+
+  defp parse_paragraph(lines) do
+    Enum.reduce(lines, %Worktree{path: ""}, &apply_line/2)
+  end
+
+  defp apply_line(line, wt) do
+    {key, value} = split_key_value(line)
+    apply_field(wt, key, value)
+  end
+
+  # Each porcelain line is either `key value` or a bare `key` flag.
+  defp split_key_value(line) do
+    case String.split(line, " ", parts: 2) do
+      [key, value] -> {key, value}
+      [key] -> {key, nil}
+    end
+  end
+
+  defp apply_field(wt, "worktree", value), do: %{wt | path: value || ""}
+  defp apply_field(wt, "HEAD", value), do: %{wt | head: value}
+  defp apply_field(wt, "branch", value), do: %{wt | branch: strip_branch_prefix(value)}
+  defp apply_field(wt, "detached", _value), do: %{wt | is_detached?: true}
+  defp apply_field(wt, "bare", _value), do: %{wt | is_bare?: true}
+
+  defp apply_field(wt, "locked", value) do
+    %{wt | is_locked?: true, lock_reason: present_or_nil(value)}
+  end
+
+  defp apply_field(wt, "prunable", value) do
+    %{wt | is_prunable?: true, prune_reason: present_or_nil(value)}
+  end
+
+  # Unknown keys are ignored, keeping the parser forward-compatible with
+  # future porcelain fields.
+  defp apply_field(wt, _key, _value), do: wt
+
+  defp mark_first_as_main([]), do: []
+  defp mark_first_as_main([first | rest]), do: [%{first | is_main?: true} | rest]
+
+  defp strip_branch_prefix(nil), do: nil
+
+  defp strip_branch_prefix(branch) do
+    String.replace_prefix(branch, "refs/heads/", "")
+  end
+
+  defp present_or_nil(nil), do: nil
+  defp present_or_nil(""), do: nil
+  defp present_or_nil(value), do: value
+end

--- a/test/claude_wrapper/worktrees_test.exs
+++ b/test/claude_wrapper/worktrees_test.exs
@@ -1,0 +1,202 @@
+defmodule ClaudeWrapper.WorktreesTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Worktrees
+  alias ClaudeWrapper.Worktrees.Worktree
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "cwx_worktrees_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf!(base) end)
+    {:ok, base: base}
+  end
+
+  # Run git in `dir`, asserting success. Identity + an initial commit are
+  # set inline so the suite does not depend on the developer's global
+  # git config.
+  defp git!(dir, args) do
+    {out, status} =
+      System.cmd("git", ["-C", dir | args],
+        stderr_to_stdout: true,
+        env: [
+          {"GIT_AUTHOR_NAME", "t"},
+          {"GIT_AUTHOR_EMAIL", "t@example.com"},
+          {"GIT_COMMITTER_NAME", "t"},
+          {"GIT_COMMITTER_EMAIL", "t@example.com"}
+        ]
+      )
+
+    assert status == 0, "git #{Enum.join(args, " ")} failed: #{out}"
+    out
+  end
+
+  # A fresh repo at <base>/repo with one empty commit on `main`.
+  defp init_repo(base) do
+    repo = Path.join(base, "repo")
+    File.mkdir_p!(repo)
+    git!(repo, ["init", "-q", "-b", "main"])
+    git!(repo, ["commit", "-q", "--allow-empty", "-m", "init"])
+    repo
+  end
+
+  defp find(worktrees, leaf) do
+    Enum.find(worktrees, fn wt -> Path.basename(wt.path) == leaf end)
+  end
+
+  describe "for_repo/1 and path/1" do
+    test "establishes a root for a real repo and path/1 reads it back", %{base: base} do
+      repo = init_repo(base)
+
+      assert {:ok, %Worktrees{} = root} = Worktrees.for_repo(repo)
+      assert Worktrees.path(root) == repo
+    end
+
+    test "errors with {:not_a_git_repo, path} for a plain directory", %{base: base} do
+      plain = Path.join(base, "plain")
+      File.mkdir_p!(plain)
+
+      assert {:error, {:not_a_git_repo, ^plain}} = Worktrees.for_repo(plain)
+    end
+  end
+
+  describe "list/1 -- main worktree" do
+    test "a single repo reports exactly the main worktree", %{base: base} do
+      repo = init_repo(base)
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, [wt]} = Worktrees.list(root)
+
+      assert %Worktree{is_main?: true, is_detached?: false, is_bare?: false} = wt
+      assert wt.branch == "main"
+      assert is_binary(wt.head) and wt.head != ""
+      assert Path.basename(wt.path) == "repo"
+      refute wt.is_locked?
+      refute wt.is_prunable?
+    end
+
+    test "the main worktree is always first even with siblings added", %{base: base} do
+      repo = init_repo(base)
+      git!(repo, ["worktree", "add", "-q", Path.join(base, "wt-a"), "-b", "a"])
+      git!(repo, ["worktree", "add", "-q", Path.join(base, "wt-b"), "-b", "b"])
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, [main | rest]} = Worktrees.list(root)
+
+      assert main.is_main?
+      assert Path.basename(main.path) == "repo"
+      assert Enum.all?(rest, &(&1.is_main? == false))
+    end
+  end
+
+  describe "list/1 -- added worktrees on a branch" do
+    test "reports the branch name without the refs/heads/ prefix", %{base: base} do
+      repo = init_repo(base)
+      git!(repo, ["worktree", "add", "-q", Path.join(base, "wt-feature"), "-b", "feature"])
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, worktrees} = Worktrees.list(root)
+      feature = find(worktrees, "wt-feature")
+
+      assert %Worktree{branch: "feature", is_detached?: false} = feature
+      refute feature.is_main?
+    end
+
+    test "preserves slashes in nested branch names", %{base: base} do
+      repo = init_repo(base)
+
+      git!(repo, [
+        "worktree",
+        "add",
+        "-q",
+        Path.join(base, "wt-nested"),
+        "-b",
+        "feature/long/path"
+      ])
+
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, worktrees} = Worktrees.list(root)
+      assert find(worktrees, "wt-nested").branch == "feature/long/path"
+    end
+  end
+
+  describe "list/1 -- detached HEAD" do
+    test "flags a detached worktree with no branch", %{base: base} do
+      repo = init_repo(base)
+      head = String.trim(git!(repo, ["rev-parse", "HEAD"]))
+      git!(repo, ["worktree", "add", "-q", "--detach", Path.join(base, "wt-detached"), head])
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, worktrees} = Worktrees.list(root)
+      detached = find(worktrees, "wt-detached")
+
+      assert %Worktree{is_detached?: true, branch: nil} = detached
+      assert detached.head == head
+    end
+  end
+
+  describe "list/1 -- locked worktrees" do
+    test "captures the lock reason when one is given", %{base: base} do
+      repo = init_repo(base)
+      path = Path.join(base, "wt-locked")
+      git!(repo, ["worktree", "add", "-q", path, "-b", "locked"])
+      git!(repo, ["worktree", "lock", "--reason", "cutting v2", path])
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, worktrees} = Worktrees.list(root)
+      locked = find(worktrees, "wt-locked")
+
+      assert %Worktree{is_locked?: true, lock_reason: "cutting v2"} = locked
+    end
+
+    test "leaves lock_reason nil when locked without a reason", %{base: base} do
+      repo = init_repo(base)
+      path = Path.join(base, "wt-wedged")
+      git!(repo, ["worktree", "add", "-q", path, "-b", "wedged"])
+      git!(repo, ["worktree", "lock", path])
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, worktrees} = Worktrees.list(root)
+      wedged = find(worktrees, "wt-wedged")
+
+      assert %Worktree{is_locked?: true, lock_reason: nil} = wedged
+    end
+  end
+
+  describe "list/1 -- bare and prunable" do
+    test "flags a bare repository worktree with no head or branch", %{base: base} do
+      bare = Path.join(base, "bare.git")
+      git!(base, ["init", "-q", "--bare", "bare.git"])
+      {:ok, root} = Worktrees.for_repo(bare)
+
+      {:ok, [wt]} = Worktrees.list(root)
+
+      assert %Worktree{is_bare?: true, is_main?: true, head: nil, branch: nil} = wt
+    end
+
+    test "flags a worktree as prunable once its directory is gone", %{base: base} do
+      repo = init_repo(base)
+      gone = Path.join(base, "wt-gone")
+      git!(repo, ["worktree", "add", "-q", gone, "-b", "gone"])
+      File.rm_rf!(gone)
+      {:ok, root} = Worktrees.for_repo(repo)
+
+      {:ok, worktrees} = Worktrees.list(root)
+      prunable = find(worktrees, "wt-gone")
+
+      assert %Worktree{is_prunable?: true} = prunable
+      assert is_binary(prunable.prune_reason)
+      assert prunable.prune_reason =~ "non-existent"
+    end
+  end
+
+  describe "list/1 -- error path" do
+    test "errors with {:not_a_git_repo, path} for a non-repo directory", %{base: base} do
+      plain = Path.join(base, "plain")
+      File.mkdir_p!(plain)
+      root = %Worktrees{repo_path: plain}
+
+      assert {:error, {:not_a_git_repo, ^plain}} = Worktrees.list(root)
+    end
+  end
+end


### PR DESCRIPTION
New module `ClaudeWrapper.Worktrees`, ported from the Rust `claude-wrapper` `worktrees` module. Parses `git worktree list --porcelain` via `System.cmd("git", ...)` (no new dependency).

### API
- `for_repo/1` -> `{:ok, t()}` | `{:error, term()}` (validates the path is in a repo)
- `path/1`, `list/1` -> `[Worktrees.Worktree]`

`Worktree` fields: `path`, `head`, `branch` (refs/heads/ stripped), `lock_reason`, `prune_reason`, and booleans `is_main?` / `is_detached?` / `is_bare?` / `is_locked?` / `is_prunable?`. First porcelain entry is the main worktree. Unknown keys ignored for forward-compat.

Errors: `{:not_a_git_repo, path}`, `{:git_failed, status, stderr}`, `{:git_unavailable, reason}`.

12 module tests using real temp git repos (main, branch, detached, locked w/ + w/o reason, bare, prunable, non-repo); full suite 220 passing; credo/dialyzer clean.

Closes #90