### PR TITLE
feat: add ClaudeWrapper.Jobs (read background job state)

### DIFF
--- a/lib/claude_wrapper/jobs.ex
+++ b/lib/claude_wrapper/jobs.ex
@@ -1,0 +1,349 @@
+defmodule ClaudeWrapper.Jobs.Summary do
+  @moduledoc """
+  Cheap metadata view of one background job, returned by
+  `ClaudeWrapper.Jobs.list/1`. Stripped of the timeline.
+
+  See `ClaudeWrapper.Jobs` for how these are produced and where each
+  field comes from in the on-disk `state.json`.
+  """
+
+  @enforce_keys [:short_id, :state]
+  defstruct [
+    :short_id,
+    :state,
+    :daemon_short,
+    :backend,
+    :name,
+    :detail,
+    :intent,
+    :session_id,
+    :session_path,
+    :cwd,
+    :origin_cwd,
+    :created_at,
+    :updated_at,
+    :first_terminal_at,
+    :cli_version,
+    :state_mtime_secs
+  ]
+
+  @type t :: %__MODULE__{
+          short_id: String.t(),
+          state: String.t(),
+          daemon_short: String.t() | nil,
+          backend: String.t() | nil,
+          name: String.t() | nil,
+          detail: String.t() | nil,
+          intent: String.t() | nil,
+          session_id: String.t() | nil,
+          session_path: String.t() | nil,
+          cwd: String.t() | nil,
+          origin_cwd: String.t() | nil,
+          created_at: String.t() | nil,
+          updated_at: String.t() | nil,
+          first_terminal_at: String.t() | nil,
+          cli_version: String.t() | nil,
+          state_mtime_secs: non_neg_integer() | nil
+        }
+end
+
+defmodule ClaudeWrapper.Jobs.Event do
+  @moduledoc """
+  One timeline event from a job's `timeline.jsonl`.
+
+  All typed fields are optional because the daemon may emit partial
+  events (e.g. without `text`); `extra` carries the verbatim decoded
+  line so future daemon fields survive without a wrapper update. See
+  `ClaudeWrapper.Jobs`.
+  """
+
+  @enforce_keys [:extra]
+  defstruct [:at, :state, :detail, :text, :extra]
+
+  @type t :: %__MODULE__{
+          at: String.t() | nil,
+          state: String.t() | nil,
+          detail: String.t() | nil,
+          text: String.t() | nil,
+          extra: map()
+        }
+end
+
+defmodule ClaudeWrapper.Jobs.Job do
+  @moduledoc """
+  Full job record returned by `ClaudeWrapper.Jobs.get/2`.
+
+  Carries the summary, the parsed timeline, and the raw `state.json`
+  map for callers that want to drill into fields this module does not
+  type explicitly (e.g. `inFlight`, `respawnFlags`, `tempo`). See
+  `ClaudeWrapper.Jobs`.
+  """
+
+  alias ClaudeWrapper.Jobs.{Event, Summary}
+
+  @enforce_keys [:summary, :timeline, :raw_state]
+  defstruct [:summary, :timeline, :raw_state]
+
+  @type t :: %__MODULE__{
+          summary: Summary.t(),
+          timeline: [Event.t()],
+          raw_state: map()
+        }
+end
+
+defmodule ClaudeWrapper.Jobs do
+  @moduledoc """
+  Read-side access to Claude Code's on-disk **background-job** state.
+
+  Claude Code ships a supervisor daemon (`claude daemon run`) that
+  orchestrates background agent tasks launched via the `claude agents`
+  TUI. Per-task state lives under `~/.claude/jobs/<short_id>/`:
+
+    * `state.json` -- current snapshot: state, intent (original
+      prompt), session id, link to the session JSONL, timestamps,
+      auto-generated name, etc.
+    * `timeline.jsonl` -- append-only event log: at each state
+      transition the daemon writes a line carrying timestamp, new
+      state, a one-line detail, and (often) the full text body.
+
+  The session content itself is a normal
+  `~/.claude/projects/<slug>/<session_id>.jsonl` -- the same format
+  `ClaudeWrapper.History` parses. Each summary's `session_path` points
+  at it for direct cross-linking.
+
+  This module is read-only on purpose. The dispatch protocol (how the
+  TUI launches new tasks) is undocumented and version-sensitive;
+  mirroring it would defeat the drift defenses the wrapper relies on.
+
+  ## Liberal parsing
+
+  Like `ClaudeWrapper.History`, parsing is forgiving. `list/1` skips
+  entries that are not directories (e.g. the daemon's `pins.json`),
+  that carry no `state.json` (a spare worker dir), or whose
+  `state.json` fails to parse -- malformed jobs are dropped rather
+  than failing the whole listing. The timeline parser skips blank and
+  malformed lines.
+
+  ## Example
+
+      {:ok, root} = ClaudeWrapper.Jobs.home()
+      {:ok, summaries} = ClaudeWrapper.Jobs.list(root)
+
+      for s <- summaries do
+        IO.puts("\#{s.short_id}  [\#{s.state}]  \#{s.intent}")
+      end
+
+      {:ok, job} = ClaudeWrapper.Jobs.get(root, "90c961c7")
+
+      for event <- job.timeline do
+        IO.puts("\#{event.at}  \#{event.state}")
+      end
+  """
+
+  alias ClaudeWrapper.Jobs.{Event, Job, Summary}
+
+  @enforce_keys [:root]
+  defstruct [:root]
+
+  @type t :: %__MODULE__{root: String.t()}
+
+  @doc """
+  Resolve the default jobs root, `~/.claude/jobs`.
+
+  Returns `{:error, :no_home}` when the user home cannot be determined.
+  """
+  @spec home() :: {:ok, t()} | {:error, :no_home}
+  def home do
+    case System.user_home() do
+      nil -> {:error, :no_home}
+      home -> {:ok, %__MODULE__{root: Path.join([home, ".claude", "jobs"])}}
+    end
+  end
+
+  @doc """
+  Use a specific path as the jobs root. Useful for tests (point at a
+  temp dir) and non-default installs.
+  """
+  @spec at(String.t()) :: t()
+  def at(path) when is_binary(path), do: %__MODULE__{root: path}
+
+  @doc "The configured root directory."
+  @spec root(t()) :: String.t()
+  def root(%__MODULE__{root: root}), do: root
+
+  @doc """
+  List every job directory at the root, sorted by `short_id`.
+
+  Returns `{:ok, []}` when the root directory does not exist (no
+  background agents have been launched on this machine yet). Skips
+  entries that are not directories, that carry no `state.json`, or
+  whose `state.json` fails to parse.
+  """
+  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, term()}
+  def list(%__MODULE__{} = jobs) do
+    case File.ls(jobs.root) do
+      {:ok, names} ->
+        summaries =
+          names
+          |> Enum.map(&summarize(jobs, &1))
+          |> Enum.reject(&is_nil/1)
+          |> Enum.sort_by(& &1.short_id)
+
+        {:ok, summaries}
+
+      {:error, :enoent} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Read one job by short id (its `~/.claude/jobs/<short_id>/` directory
+  name) into a full `ClaudeWrapper.Jobs.Job`, including the parsed
+  `timeline.jsonl` and the raw `state.json` map.
+
+  Returns `{:error, :not_found}` when no such directory exists or its
+  `state.json` is missing.
+  """
+  @spec get(t(), String.t()) :: {:ok, Job.t()} | {:error, :not_found | term()}
+  def get(%__MODULE__{} = jobs, short_id) when is_binary(short_id) do
+    dir = Path.join(jobs.root, short_id)
+    state_path = Path.join(dir, "state.json")
+
+    case File.read(state_path) do
+      {:ok, raw} -> read_job(state_path, raw, dir, short_id)
+      {:error, :enoent} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # -- read helpers --------------------------------------------------
+
+  defp read_job(state_path, raw, dir, short_id) do
+    case decode_state(raw) do
+      {:ok, map} ->
+        {:ok,
+         %Job{
+           summary: build_summary(map, short_id, state_mtime_secs(state_path)),
+           timeline: parse_timeline(Path.join(dir, "timeline.jsonl")),
+           raw_state: map
+         }}
+
+      :error ->
+        {:error, :not_found}
+    end
+  end
+
+  # Summarize one top-level entry. Returns nil when the entry is not a
+  # directory, carries no state.json, or its state.json fails to parse.
+  defp summarize(%__MODULE__{} = jobs, short_id) do
+    dir = Path.join(jobs.root, short_id)
+
+    if File.dir?(dir) do
+      summarize_dir(dir, short_id)
+    end
+  end
+
+  defp summarize_dir(dir, short_id) do
+    state_path = Path.join(dir, "state.json")
+
+    case File.read(state_path) do
+      {:ok, raw} -> summary_from_state(state_path, raw, short_id)
+      {:error, _} -> nil
+    end
+  end
+
+  defp summary_from_state(state_path, raw, short_id) do
+    case decode_state(raw) do
+      {:ok, map} -> build_summary(map, short_id, state_mtime_secs(state_path))
+      :error -> nil
+    end
+  end
+
+  defp build_summary(map, short_id, state_mtime_secs) do
+    %Summary{
+      short_id: short_id,
+      state: str(map, "state") || "unknown",
+      daemon_short: str(map, "daemonShort"),
+      backend: str(map, "backend"),
+      name: str(map, "name"),
+      detail: str(map, "detail"),
+      intent: str(map, "intent"),
+      session_id: str(map, "sessionId"),
+      session_path: str(map, "linkScanPath"),
+      cwd: str(map, "cwd"),
+      origin_cwd: str(map, "originCwd"),
+      created_at: str(map, "createdAt"),
+      updated_at: str(map, "updatedAt"),
+      first_terminal_at: str(map, "firstTerminalAt"),
+      cli_version: str(map, "cliVersion"),
+      state_mtime_secs: state_mtime_secs
+    }
+  end
+
+  defp parse_timeline(path) do
+    case File.read(path) do
+      {:ok, raw} ->
+        raw
+        |> String.split("\n")
+        |> Enum.flat_map(&parse_timeline_line/1)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp parse_timeline_line(line) do
+    case decode_line(line) do
+      {:ok, map} -> [build_event(map)]
+      :error -> []
+    end
+  end
+
+  defp build_event(map) do
+    %Event{
+      at: str(map, "at"),
+      state: str(map, "state"),
+      detail: str(map, "detail"),
+      text: str(map, "text"),
+      extra: map
+    }
+  end
+
+  # -- io / decode helpers -------------------------------------------
+
+  defp decode_state(raw) do
+    case Jason.decode(raw) do
+      {:ok, map} when is_map(map) -> {:ok, map}
+      _ -> :error
+    end
+  end
+
+  defp decode_line(line) do
+    case String.trim(line) do
+      "" -> :error
+      trimmed -> trimmed |> Jason.decode() |> normalize_decode()
+    end
+  end
+
+  defp normalize_decode({:ok, map}) when is_map(map), do: {:ok, map}
+  defp normalize_decode(_), do: :error
+
+  # Read a string-valued field, returning nil for missing or non-string
+  # values (mirrors the Rust `Value::as_str` accessors).
+  defp str(map, key) do
+    case Map.get(map, key) do
+      value when is_binary(value) -> value
+      _ -> nil
+    end
+  end
+
+  defp state_mtime_secs(path) do
+    case File.stat(path, time: :posix) do
+      {:ok, %File.Stat{mtime: mtime}} when is_integer(mtime) and mtime >= 0 -> mtime
+      _ -> nil
+    end
+  end
+end

--- a/test/claude_wrapper/jobs_test.exs
+++ b/test/claude_wrapper/jobs_test.exs
@@ -1,0 +1,219 @@
+defmodule ClaudeWrapper.JobsTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Jobs
+  alias ClaudeWrapper.Jobs.{Event, Job, Summary}
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "cwx_jobs_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  # Write a job dir at <root>/<short_id>/ with the given state.json body
+  # and optional timeline.jsonl lines.
+  defp write_job(root, short_id, state_json, timeline_lines \\ []) do
+    dir = Path.join(root, short_id)
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "state.json"), state_json)
+
+    if timeline_lines != [] do
+      File.write!(Path.join(dir, "timeline.jsonl"), Enum.join(timeline_lines, "\n") <> "\n")
+    end
+
+    dir
+  end
+
+  defp fixture(root) do
+    # A done job with full state + timeline.
+    write_job(
+      root,
+      "aaaaaaaa",
+      ~s({"state":"done","detail":"42","intent":"meaning of life","sessionId":"sess-aaa","linkScanPath":"/p/sess-aaa.jsonl","cwd":"/work","createdAt":"2026-05-15T01:00:00Z","updatedAt":"2026-05-15T01:01:00Z","firstTerminalAt":"2026-05-15T01:00:55Z","name":"meaning of life","backend":"daemon","cliVersion":"2.1.143","daemonShort":"aaaaaaaa","originCwd":"/work"}),
+      [
+        ~s({"at":"2026-05-15T01:00:30Z","state":"running","detail":"thinking"}),
+        ~s({"at":"2026-05-15T01:00:55Z","state":"done","detail":"42","text":"the answer is 42"})
+      ]
+    )
+
+    # A still-running job.
+    write_job(
+      root,
+      "bbbbbbbb",
+      ~s({"state":"running","intent":"compute primes","sessionId":"sess-bbb"}),
+      [~s({"at":"2026-05-15T02:00:00Z","state":"running","detail":"started"})]
+    )
+
+    # A job dir with no state.json (spare worker leftover); list/1 skips it.
+    File.mkdir_p!(Path.join(root, "cccccccc"))
+
+    # A non-directory top-level file (the daemon's pins.json); list/1 skips it.
+    File.write!(Path.join(root, "pins.json"), "[]")
+
+    # A job whose state.json is malformed; list/1 skips it.
+    write_job(root, "deadbeef", "not valid json {{")
+    :ok
+  end
+
+  describe "home/0, at/1, root/1" do
+    test "at/1 wraps an explicit root and root/1 reads it back" do
+      jobs = Jobs.at("/tmp/jobs")
+      assert jobs.root == "/tmp/jobs"
+      assert Jobs.root(jobs) == "/tmp/jobs"
+    end
+
+    test "home/0 resolves ~/.claude/jobs" do
+      assert {:ok, %Jobs{root: root}} = Jobs.home()
+      assert String.ends_with?(root, Path.join([".claude", "jobs"]))
+    end
+  end
+
+  describe "list/1" do
+    test "returns only well-formed jobs, sorted by short_id", %{root: root} do
+      fixture(root)
+
+      {:ok, jobs} = Jobs.list(Jobs.at(root))
+      assert Enum.map(jobs, & &1.short_id) == ["aaaaaaaa", "bbbbbbbb"]
+    end
+
+    test "returns empty when the root does not exist" do
+      {:ok, jobs} = Jobs.list(Jobs.at("/no/such/jobs/root"))
+      assert jobs == []
+    end
+
+    test "summary carries typed fields", %{root: root} do
+      fixture(root)
+
+      {:ok, jobs} = Jobs.list(Jobs.at(root))
+      s = Enum.find(jobs, &(&1.short_id == "aaaaaaaa"))
+
+      assert %Summary{state: "done", intent: "meaning of life"} = s
+      assert s.session_id == "sess-aaa"
+      assert s.session_path == "/p/sess-aaa.jsonl"
+      assert s.cwd == "/work"
+      assert s.name == "meaning of life"
+      assert s.backend == "daemon"
+      assert s.cli_version == "2.1.143"
+      assert s.daemon_short == "aaaaaaaa"
+      assert s.origin_cwd == "/work"
+      assert s.created_at == "2026-05-15T01:00:00Z"
+      assert s.updated_at == "2026-05-15T01:01:00Z"
+      assert s.first_terminal_at == "2026-05-15T01:00:55Z"
+      assert is_integer(s.state_mtime_secs)
+    end
+
+    test "running job has no first_terminal_at", %{root: root} do
+      fixture(root)
+
+      {:ok, jobs} = Jobs.list(Jobs.at(root))
+      s = Enum.find(jobs, &(&1.short_id == "bbbbbbbb"))
+
+      assert s.state == "running"
+      assert s.first_terminal_at == nil
+    end
+
+    test "missing state field defaults to unknown", %{root: root} do
+      write_job(root, "nostate", ~s({"intent":"x"}))
+
+      {:ok, [summary]} = Jobs.list(Jobs.at(root))
+      assert summary.state == "unknown"
+    end
+
+    test "unknown state string passes through", %{root: root} do
+      write_job(root, "weirdstate", ~s({"state":"some-future-state","intent":"x"}))
+
+      {:ok, [summary]} = Jobs.list(Jobs.at(root))
+      assert summary.state == "some-future-state"
+    end
+  end
+
+  describe "get/2" do
+    test "returns the full record with timeline", %{root: root} do
+      fixture(root)
+
+      {:ok, job} = Jobs.get(Jobs.at(root), "aaaaaaaa")
+
+      assert %Job{} = job
+      assert job.summary.state == "done"
+      assert length(job.timeline) == 2
+
+      assert [%Event{state: "running"}, %Event{state: "done", text: "the answer is 42"}] =
+               job.timeline
+
+      assert is_map(job.raw_state)
+      assert job.raw_state["state"] == "done"
+    end
+
+    test "no timeline file yields an empty list", %{root: root} do
+      write_job(root, "ffffffff", ~s({"state":"queued","intent":"x","sessionId":"y"}))
+
+      {:ok, job} = Jobs.get(Jobs.at(root), "ffffffff")
+      assert job.timeline == []
+    end
+
+    test "unknown id returns {:error, :not_found}", %{root: root} do
+      fixture(root)
+      assert Jobs.get(Jobs.at(root), "nope") == {:error, :not_found}
+    end
+
+    test "dir present but state.json missing returns {:error, :not_found}", %{root: root} do
+      File.mkdir_p!(Path.join(root, "cccccccc"))
+      assert Jobs.get(Jobs.at(root), "cccccccc") == {:error, :not_found}
+    end
+
+    test "malformed state.json returns {:error, :not_found}", %{root: root} do
+      write_job(root, "deadbeef", "not valid json {{")
+      assert Jobs.get(Jobs.at(root), "deadbeef") == {:error, :not_found}
+    end
+
+    test "timeline skips blank and malformed lines without failing", %{root: root} do
+      write_job(
+        root,
+        "mixed",
+        ~s({"state":"done","intent":"x","sessionId":"y"}),
+        [
+          ~s({"at":"t1","state":"running"}),
+          "NOT VALID JSON",
+          "",
+          ~s({"at":"t2","state":"done","text":"final"})
+        ]
+      )
+
+      {:ok, job} = Jobs.get(Jobs.at(root), "mixed")
+
+      assert length(job.timeline) == 2
+      assert Enum.at(job.timeline, 0).at == "t1"
+      assert Enum.at(job.timeline, 1).at == "t2"
+      assert Enum.at(job.timeline, 1).text == "final"
+    end
+
+    test "event carries the verbatim decoded line in extra", %{root: root} do
+      write_job(
+        root,
+        "extraline",
+        ~s({"state":"done","intent":"x","sessionId":"y"}),
+        [~s({"at":"t1","state":"running","customField":{"nested":7}})]
+      )
+
+      {:ok, job} = Jobs.get(Jobs.at(root), "extraline")
+      [event] = job.timeline
+
+      assert event.extra["customField"]["nested"] == 7
+      assert event.extra["at"] == "t1"
+    end
+
+    test "raw_state preserves unknown fields", %{root: root} do
+      write_job(
+        root,
+        "extras",
+        ~s({"state":"done","intent":"x","sessionId":"y","futureField":{"nested":42},"tempo":"idle"})
+      )
+
+      {:ok, job} = Jobs.get(Jobs.at(root), "extras")
+
+      assert job.raw_state["futureField"]["nested"] == 42
+      assert job.raw_state["tempo"] == "idle"
+    end
+  end
+end


### PR DESCRIPTION
New module `ClaudeWrapper.Jobs`, ported from the Rust `claude-wrapper` `jobs` module. Read-side introspection of `~/.claude/jobs/`.

### On-disk layout parsed
```
<root>/<short_id>/state.json      # current snapshot
<root>/<short_id>/timeline.jsonl  # append-only event log
<root>/pins.json                  # top-level file, skipped
```

### API
- `home/0`, `at/1`, `root/1`
- `list/1` -> `[Jobs.Summary]` (sorted by short_id; skips non-dirs / missing-or-unparseable state.json; empty if root missing)
- `get/2` -> `{:ok, Jobs.Job}` | `{:error, :not_found}`

`Summary`: short_id, state, daemon_short, backend, name, detail, intent, session_id, session_path, cwd, origin_cwd, created_at, updated_at, first_terminal_at, cli_version, state_mtime_secs. `Job`: summary + timeline ([Event]) + raw_state. `Event`: at, state, detail, text, extra. Liberal parsing throughout.

16 module tests; full suite 253 passing; credo/dialyzer clean.

Closes #88