### PR TITLE
feat: add ClaudeWrapper.Auth (env detection + failure classification)

### DIFF
--- a/lib/claude_wrapper/auth.ex
+++ b/lib/claude_wrapper/auth.ex
@@ -1,0 +1,337 @@
+defmodule ClaudeWrapper.Auth.Summary do
+  @moduledoc """
+  Snapshot of auth-relevant environment state.
+
+  Returned by `ClaudeWrapper.Auth.detect/0` and
+  `ClaudeWrapper.Auth.detect_from/1` so callers see both the resolved
+  strategy and the raw signals that drove the decision.
+
+  Mirrors the Rust `AuthSummary` struct from the `claude-wrapper` crate.
+  """
+
+  alias ClaudeWrapper.Auth
+
+  @enforce_keys [
+    :strategy,
+    :has_anthropic_api_key,
+    :has_oauth_token,
+    :bedrock_enabled,
+    :vertex_enabled
+  ]
+  defstruct [
+    :strategy,
+    :has_anthropic_api_key,
+    :has_oauth_token,
+    :bedrock_enabled,
+    :vertex_enabled
+  ]
+
+  @type t :: %__MODULE__{
+          strategy: Auth.strategy(),
+          has_anthropic_api_key: boolean(),
+          has_oauth_token: boolean(),
+          bedrock_enabled: boolean(),
+          vertex_enabled: boolean()
+        }
+end
+
+defmodule ClaudeWrapper.Auth do
+  @moduledoc """
+  Detect which auth strategy the Claude Code CLI will use, and classify
+  auth-related CLI failures.
+
+  This is a standalone, env-only introspection module. It is **distinct**
+  from `ClaudeWrapper.Commands.Auth`, which shells out to `claude auth`
+  (login/logout/status/setup-token). Nothing here spawns a subprocess or
+  reads the filesystem.
+
+  ## Detection
+
+  Claude Code resolves auth at invocation time by inspecting a few
+  environment variables, falling back to credentials stored under
+  `~/.claude/` when none are set. `detect/0` mirrors that precedence as a
+  cheap, synchronous, env-only check so hosts can introspect the active
+  mode before spawning a turn.
+
+  It is **not** a liveness check -- a reported `:subscription` strategy
+  only means "no env auth set"; the user might not have run `claude login`
+  yet. Use `ClaudeWrapper.Commands.Auth.status/1` for that.
+
+  Precedence (first match wins):
+
+    1. `CLAUDE_CODE_USE_BEDROCK` truthy -> `:bedrock`
+    2. `CLAUDE_CODE_USE_VERTEX` truthy -> `:vertex`
+    3. `ANTHROPIC_API_KEY` non-empty -> `:api_key`
+    4. `CLAUDE_CODE_OAUTH_TOKEN` non-empty -> `:oauth_token`
+    5. Otherwise -> `:subscription`
+
+  Cloud-provider strategies (Bedrock, Vertex) take precedence because
+  they redirect ALL traffic regardless of API key presence.
+
+  ## Failure classification
+
+  `classify_failure/3` inspects a failed `claude` invocation and decides
+  whether it looks auth-shaped. It returns the matching
+  `t:auth_error_kind/0` atom, or `nil` when the failure is **not**
+  auth-related. It is conservative on purpose: a false positive turns a
+  legitimate non-auth failure into an "auth error" surprise, so the
+  classifier prefers to miss an auth error rather than misclassify a
+  non-auth one.
+
+  Two recent fixes are preserved from the Rust reference:
+
+    * A model-not-found / model-access failure (a bad `--model` id) must
+      **not** be classified as auth, even when it carries a 403/404 HTTP
+      status. It returns `nil`.
+    * A `--bare` invocation with a missing API key prints
+      "Not logged in" to stdout with empty stderr; that surfaces as
+      `:not_authenticated`.
+
+  ## Example
+
+      summary = ClaudeWrapper.Auth.detect()
+      summary.strategy
+      #=> :subscription
+
+      ClaudeWrapper.Auth.classify_failure(1, "", "HTTP 401 Unauthorized")
+      #=> :invalid_credentials
+
+      ClaudeWrapper.Auth.classify_failure(1, "no match found", "")
+      #=> nil
+  """
+
+  alias ClaudeWrapper.Auth.Summary
+
+  @typedoc """
+  Active auth strategy, as inferred from the host environment.
+
+    * `:bedrock` -- `CLAUDE_CODE_USE_BEDROCK` is truthy. Requests route to
+      AWS Bedrock; AWS credentials are resolved separately by the SDK.
+    * `:vertex` -- `CLAUDE_CODE_USE_VERTEX` is truthy. Requests route to
+      Google Vertex; GCP credentials are resolved separately.
+    * `:api_key` -- `ANTHROPIC_API_KEY` is set. Direct API access.
+    * `:oauth_token` -- `CLAUDE_CODE_OAUTH_TOKEN` is set (typically from
+      `claude setup-token`).
+    * `:subscription` -- no auth env var set. The CLI looks for stored
+      credentials under `~/.claude/`. May or may not actually be
+      authenticated -- this reports "the env doesn't pin anything," not
+      "you are logged in."
+
+  See the module docs for precedence rules.
+  """
+  @type strategy :: :bedrock | :vertex | :api_key | :oauth_token | :subscription
+
+  @typedoc """
+  Best-effort classification of an auth-related CLI failure.
+
+    * `:not_authenticated` -- no credentials at all. Fix: run
+      `claude login` or set one of the auth env vars.
+    * `:expired` -- stored credentials existed but are expired. Fix:
+      re-run `claude login`.
+    * `:invalid_credentials` -- credentials were presented but rejected
+      (wrong/revoked key, stale token).
+    * `:rate_limit` -- authenticated but rejected for rate limit / quota /
+      billing reasons. Different remediation: wait, top up, or switch
+      keys -- not "log in again."
+    * `:provider_error` -- Bedrock or Vertex provider error (cloud creds
+      missing or rejected). The fix lives in the cloud provider's auth.
+    * `:other` -- looked auth-shaped (HTTP 401/403, the word "auth") but
+      did not match a more specific pattern.
+  """
+  @type auth_error_kind ::
+          :not_authenticated
+          | :expired
+          | :invalid_credentials
+          | :rate_limit
+          | :provider_error
+          | :other
+
+  @doc """
+  Detect the active auth strategy from the current process environment.
+
+  Cheap; no subprocess, no filesystem reads. Reads the real process env
+  via `System.get_env/0`.
+  """
+  @spec detect() :: Summary.t()
+  def detect, do: detect_from(System.get_env())
+
+  @doc """
+  Like `detect/0`, but reads from a caller-provided env map.
+
+  Exposed for tests and for hosts that want to introspect a child
+  environment they are about to spawn under. The map is keyed by env-var
+  name, matching the shape of `System.get_env/0`.
+  """
+  @spec detect_from(%{optional(String.t()) => String.t()}) :: Summary.t()
+  def detect_from(env) when is_map(env) do
+    bedrock_enabled = truthy?(Map.get(env, "CLAUDE_CODE_USE_BEDROCK"))
+    vertex_enabled = truthy?(Map.get(env, "CLAUDE_CODE_USE_VERTEX"))
+    has_anthropic_api_key = set?(Map.get(env, "ANTHROPIC_API_KEY"))
+    has_oauth_token = set?(Map.get(env, "CLAUDE_CODE_OAUTH_TOKEN"))
+
+    strategy =
+      cond do
+        bedrock_enabled -> :bedrock
+        vertex_enabled -> :vertex
+        has_anthropic_api_key -> :api_key
+        has_oauth_token -> :oauth_token
+        true -> :subscription
+      end
+
+    %Summary{
+      strategy: strategy,
+      has_anthropic_api_key: has_anthropic_api_key,
+      has_oauth_token: has_oauth_token,
+      bedrock_enabled: bedrock_enabled,
+      vertex_enabled: vertex_enabled
+    }
+  end
+
+  @doc """
+  Inspect a failed `claude` invocation and decide whether it looks
+  auth-shaped.
+
+  Returns the matching `t:auth_error_kind/0` atom only when the patterns
+  are confident enough to risk relabeling, and `nil` otherwise.
+
+  `exit_code` is accepted for parity with the Rust signature and future
+  use; the current heuristics match only against the lowercased
+  `stdout`/`stderr` text. The patterns are intentionally narrow:
+
+    * model-not-found / model-access phrasing -> `nil` (a bad `--model`
+      id is a typo, not a credential problem, even with a 403/404 status)
+    * "not authenticated" / "not logged in" / "claude login" /
+      "run /login" / "no credentials" / "no auth" -> `:not_authenticated`
+    * "expired" / "session has expired" / "token expired" -> `:expired`
+    * "invalid api key" / "invalid token" / "401" / "unauthorized" /
+      "403" / "forbidden" -> `:invalid_credentials`
+    * "rate limit" / "too many requests" / "429" / "quota" -> `:rate_limit`
+    * "bedrock" or "vertex" alongside an auth signal -> `:provider_error`
+    * a bare "auth" / "credential" mention in stderr -> `:other`
+  """
+  @spec classify_failure(integer(), String.t(), String.t()) :: auth_error_kind() | nil
+  def classify_failure(exit_code, stdout, stderr)
+      when is_integer(exit_code) and is_binary(stdout) and is_binary(stderr) do
+    combined = String.downcase("#{stdout}\n#{stderr}")
+
+    # Model-not-found / model-access failures bail before any auth pattern
+    # can fire -- a bad `--model` id is a typo, not a credential problem,
+    # even when it carries a 403/404 status.
+    if mentions_model_problem?(combined) do
+      nil
+    else
+      classify_auth(combined, String.downcase(stderr))
+    end
+  end
+
+  defp classify_auth(combined, stderr_down) do
+    cond do
+      provider_error?(combined) -> :provider_error
+      rate_limit?(combined) -> :rate_limit
+      expired?(combined) -> :expired
+      invalid_credentials?(combined) -> :invalid_credentials
+      not_authenticated?(combined) -> :not_authenticated
+      bare_auth_mention?(stderr_down) -> :other
+      true -> nil
+    end
+  end
+
+  # -- detection helpers ---------------------------------------------
+
+  # Treat any non-empty, non-whitespace value as "set."
+  defp set?(nil), do: false
+  defp set?(value) when is_binary(value), do: String.trim(value) != ""
+
+  # Truthy env var: any non-empty value that isn't a recognized falsy
+  # literal (`0`, `false`, `no`, `off`, case-insensitive). Mirrors the
+  # loose convention most CLI tools follow for `XYZ_USE_FOO` toggles.
+  defp truthy?(nil), do: false
+
+  defp truthy?(value) when is_binary(value) do
+    case value |> String.trim() |> String.downcase() do
+      "" -> false
+      "0" -> false
+      "false" -> false
+      "no" -> false
+      "off" -> false
+      _ -> true
+    end
+  end
+
+  # -- classification helpers ----------------------------------------
+
+  # Model-not-found / model-access failures are NOT auth errors, even
+  # though they can carry a 403/404 HTTP status that the credential
+  # checks would otherwise read as `:invalid_credentials`. A bad
+  # `--model` id is a typo, not a credential problem; this guard must win
+  # over every auth pattern below.
+  defp mentions_model_problem?(combined) do
+    contains_any?(combined, [
+      "may not exist",
+      "may not have access",
+      "not_found_error",
+      "issue with the selected model"
+    ])
+  end
+
+  # Provider hits (Bedrock / Vertex) take precedence when the failure
+  # mentions them alongside an auth signal -- the fix is different (cloud
+  # creds, not `claude login`).
+  defp provider_error?(combined) do
+    mentions_provider? = contains_any?(combined, ["bedrock", "vertex"])
+
+    mentions_auth_signal? =
+      contains_any?(combined, [
+        "auth",
+        "credential",
+        "401",
+        "403",
+        "forbidden",
+        "unauthorized"
+      ])
+
+    mentions_provider? and mentions_auth_signal?
+  end
+
+  defp rate_limit?(combined) do
+    contains_any?(combined, ["rate limit", "too many requests", "429", "quota"])
+  end
+
+  defp expired?(combined) do
+    contains_any?(combined, ["expired", "session has expired", "token expired"])
+  end
+
+  defp invalid_credentials?(combined) do
+    contains_any?(combined, [
+      "invalid api key",
+      "invalid token",
+      "401",
+      "unauthorized",
+      "403",
+      "forbidden"
+    ])
+  end
+
+  defp not_authenticated?(combined) do
+    contains_any?(combined, [
+      "not authenticated",
+      "not logged in",
+      "claude login",
+      "please run /login",
+      "run /login",
+      "no credentials",
+      "no auth"
+    ])
+  end
+
+  # Last-resort bucket: a bare "auth" or "credential" mention without
+  # specifics. Conservative -- only fires on stderr (where these errors
+  # typically land) so we don't catch e.g. `--allowed-tools auth_helper`.
+  defp bare_auth_mention?(stderr_down) do
+    contains_any?(stderr_down, ["auth", "credential"])
+  end
+
+  defp contains_any?(haystack, needles) do
+    Enum.any?(needles, &String.contains?(haystack, &1))
+  end
+end

--- a/test/claude_wrapper/auth_test.exs
+++ b/test/claude_wrapper/auth_test.exs
@@ -1,0 +1,220 @@
+defmodule ClaudeWrapper.AuthTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Auth
+  alias ClaudeWrapper.Auth.Summary
+
+  describe "detect/0" do
+    test "reads the real process env and returns a summary" do
+      assert %Summary{strategy: strategy} = Auth.detect()
+      assert strategy in [:bedrock, :vertex, :api_key, :oauth_token, :subscription]
+    end
+  end
+
+  describe "detect_from/1 -- strategies and precedence" do
+    test "empty env is subscription with all flags false" do
+      s = Auth.detect_from(%{})
+
+      assert s.strategy == :subscription
+      refute s.has_anthropic_api_key
+      refute s.has_oauth_token
+      refute s.bedrock_enabled
+      refute s.vertex_enabled
+    end
+
+    test "api key takes precedence over oauth token" do
+      s =
+        Auth.detect_from(%{
+          "ANTHROPIC_API_KEY" => "sk-abc",
+          "CLAUDE_CODE_OAUTH_TOKEN" => "tok-xyz"
+        })
+
+      assert s.strategy == :api_key
+      assert s.has_anthropic_api_key
+      assert s.has_oauth_token
+    end
+
+    test "oauth token alone picks oauth_token" do
+      s = Auth.detect_from(%{"CLAUDE_CODE_OAUTH_TOKEN" => "tok-xyz"})
+
+      assert s.strategy == :oauth_token
+      refute s.has_anthropic_api_key
+      assert s.has_oauth_token
+    end
+
+    test "bedrock overrides api key" do
+      s =
+        Auth.detect_from(%{
+          "CLAUDE_CODE_USE_BEDROCK" => "1",
+          "ANTHROPIC_API_KEY" => "sk-abc"
+        })
+
+      assert s.strategy == :bedrock
+      assert s.bedrock_enabled
+      assert s.has_anthropic_api_key
+    end
+
+    test "vertex overrides oauth token" do
+      s =
+        Auth.detect_from(%{
+          "CLAUDE_CODE_USE_VERTEX" => "true",
+          "CLAUDE_CODE_OAUTH_TOKEN" => "tok-xyz"
+        })
+
+      assert s.strategy == :vertex
+      assert s.vertex_enabled
+    end
+
+    test "bedrock takes precedence over vertex when both set" do
+      s =
+        Auth.detect_from(%{
+          "CLAUDE_CODE_USE_BEDROCK" => "1",
+          "CLAUDE_CODE_USE_VERTEX" => "1"
+        })
+
+      assert s.strategy == :bedrock
+      assert s.bedrock_enabled
+      assert s.vertex_enabled
+    end
+
+    test "empty / whitespace string does not count as set" do
+      s =
+        Auth.detect_from(%{
+          "ANTHROPIC_API_KEY" => "",
+          "CLAUDE_CODE_OAUTH_TOKEN" => "   "
+        })
+
+      assert s.strategy == :subscription
+      refute s.has_anthropic_api_key
+      refute s.has_oauth_token
+    end
+
+    test "explicit falsy disables provider flags" do
+      s =
+        Auth.detect_from(%{
+          "CLAUDE_CODE_USE_BEDROCK" => "0",
+          "CLAUDE_CODE_USE_VERTEX" => "false",
+          "ANTHROPIC_API_KEY" => "sk-abc"
+        })
+
+      assert s.strategy == :api_key
+      refute s.bedrock_enabled
+      refute s.vertex_enabled
+    end
+
+    test "truthy values are recognized" do
+      for v <- ["1", "true", "TRUE", "yes", "on", "anything"] do
+        s = Auth.detect_from(%{"CLAUDE_CODE_USE_BEDROCK" => v})
+        assert s.strategy == :bedrock, "value #{inspect(v)}"
+        assert s.bedrock_enabled, "value #{inspect(v)}"
+      end
+    end
+
+    test "falsy values are recognized" do
+      for v <- ["0", "false", "FALSE", "no", "off"] do
+        s = Auth.detect_from(%{"CLAUDE_CODE_USE_BEDROCK" => v})
+        assert s.strategy == :subscription, "value #{inspect(v)}"
+        refute s.bedrock_enabled, "value #{inspect(v)}"
+      end
+    end
+  end
+
+  describe "classify_failure/3 -- negative cases" do
+    test "returns nil for an unrelated failure" do
+      assert Auth.classify_failure(1, "no match found", "") == nil
+      assert Auth.classify_failure(2, "", "syntax error near unexpected token") == nil
+    end
+
+    test "model-not-found is not auth (a model typo must not halt fleets)" do
+      # Mirrors real `claude --output-format json` output for a bad --model.
+      bad_model =
+        ~s|{"type":"result","is_error":true,"api_error_status":404,| <>
+          ~s|"result":"There's an issue with the selected model (totally-not-a-model-xyz). | <>
+          ~s|It may not exist or you may not have access to it. Run --model to pick a different model."}|
+
+      assert Auth.classify_failure(1, bad_model, "") == nil
+    end
+
+    test "model-access 403/404 wins over invalid_credentials" do
+      assert Auth.classify_failure(
+               1,
+               "",
+               "API Error: 403 Forbidden permission_error: you may not have access to model claude-x"
+             ) == nil
+
+      assert Auth.classify_failure(
+               1,
+               "",
+               "404 not_found_error: model claude-x does not exist"
+             ) == nil
+    end
+
+    test "bare auth mention in stdout only is not classified" do
+      assert Auth.classify_failure(0, "auth_helper enabled, all clear", "") == nil
+    end
+  end
+
+  describe "classify_failure/3 -- positive cases" do
+    test "not authenticated from stderr hint" do
+      assert Auth.classify_failure(
+               1,
+               "",
+               "Not authenticated. Run `claude login` to sign in."
+             ) == :not_authenticated
+
+      assert Auth.classify_failure(1, "", "no credentials configured") == :not_authenticated
+    end
+
+    test "--bare missing key (stdout-only, empty stderr) -> not_authenticated" do
+      assert Auth.classify_failure(1, "Not logged in · Please run /login", "") ==
+               :not_authenticated
+    end
+
+    test "expired session" do
+      assert Auth.classify_failure(
+               1,
+               "",
+               "Your session has expired. Please log in again."
+             ) == :expired
+
+      assert Auth.classify_failure(1, "", "token expired at 2025-01-01T00:00:00Z") == :expired
+    end
+
+    test "invalid api key / 401 / 403" do
+      assert Auth.classify_failure(1, "", "Invalid API key. Check ANTHROPIC_API_KEY.") ==
+               :invalid_credentials
+
+      assert Auth.classify_failure(1, "", "HTTP 401 Unauthorized") == :invalid_credentials
+      assert Auth.classify_failure(1, "", "403 Forbidden") == :invalid_credentials
+    end
+
+    test "rate limit takes precedence over invalid credentials wording" do
+      assert Auth.classify_failure(1, "", "Rate limit exceeded. Please wait.") == :rate_limit
+      assert Auth.classify_failure(1, "", "HTTP 429 Too Many Requests") == :rate_limit
+      assert Auth.classify_failure(1, "", "quota exceeded for this account") == :rate_limit
+    end
+
+    test "provider error when bedrock/vertex appears alongside an auth signal" do
+      assert Auth.classify_failure(
+               1,
+               "",
+               "Bedrock auth failed: AWS credentials not found in chain"
+             ) == :provider_error
+
+      assert Auth.classify_failure(
+               1,
+               "",
+               "Vertex unauthorized -- check GOOGLE_APPLICATION_CREDENTIALS"
+             ) == :provider_error
+    end
+
+    test "falls back to :other for a bare auth mention in stderr" do
+      assert Auth.classify_failure(1, "", "auth subsystem returned an unexpected error") ==
+               :other
+    end
+
+    test "specific patterns match in stdout too" do
+      assert Auth.classify_failure(1, "Invalid API key", "") == :invalid_credentials
+    end
+  end
+end


### PR DESCRIPTION
New standalone module `ClaudeWrapper.Auth`, ported from the Rust `claude-wrapper` `auth` module. Distinct from the CLI-driven `ClaudeWrapper.Commands.Auth`.

### API
- `detect/0` -> `Auth.Summary` (reads real env)
- `detect_from/1` -> `Auth.Summary` (pure; takes an env map)
- `classify_failure/3` (exit_code, stdout, stderr) -> `auth_error_kind()` | `nil` (nil when not auth-related)

`Summary`: strategy + has_anthropic_api_key / has_oauth_token / bedrock_enabled / vertex_enabled.
`@type strategy :: :bedrock | :vertex | :api_key | :oauth_token | :subscription`
`@type auth_error_kind :: :not_authenticated | :expired | :invalid_credentials | :rate_limit | :provider_error | :other`

Faithful port incl. the recent fixes: **model-404 returns nil** (not auth), and **`--bare` missing key -> `:not_authenticated`**.

**Scope:** standalone module only; wiring into command-failure handling is deferred to #92 (typed errors).

23 module tests; full suite 276 passing; credo/dialyzer clean.

Closes #93