### PR TITLE
feat: add ClaudeWrapper.ToolPattern (typed tool-spec builder)

### DIFF
--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -160,12 +160,29 @@ defmodule ClaudeWrapper.Query do
   @spec permission_mode(t(), permission_mode()) :: t()
   def permission_mode(%__MODULE__{} = q, mode), do: %{q | permission_mode: mode}
 
-  @doc "Add an allowed tool."
-  @spec allowed_tool(t(), String.t()) :: t()
+  @doc """
+  Add an allowed tool.
+
+  Accepts either a plain CLI-format string (`"Bash(git log:*)"`) or a
+  `t:ClaudeWrapper.ToolPattern.t/0`, which is rendered to its string
+  form. The stored field stays a list of strings.
+  """
+  @spec allowed_tool(t(), String.t() | ClaudeWrapper.ToolPattern.t()) :: t()
+  def allowed_tool(%__MODULE__{} = q, %ClaudeWrapper.ToolPattern{} = pattern),
+    do: allowed_tool(q, ClaudeWrapper.ToolPattern.to_string(pattern))
+
   def allowed_tool(%__MODULE__{} = q, tool), do: %{q | allowed_tools: q.allowed_tools ++ [tool]}
 
-  @doc "Add a disallowed tool."
-  @spec disallowed_tool(t(), String.t()) :: t()
+  @doc """
+  Add a disallowed tool.
+
+  Accepts either a plain CLI-format string or a
+  `t:ClaudeWrapper.ToolPattern.t/0`, mirroring `allowed_tool/2`.
+  """
+  @spec disallowed_tool(t(), String.t() | ClaudeWrapper.ToolPattern.t()) :: t()
+  def disallowed_tool(%__MODULE__{} = q, %ClaudeWrapper.ToolPattern{} = pattern),
+    do: disallowed_tool(q, ClaudeWrapper.ToolPattern.to_string(pattern))
+
   def disallowed_tool(%__MODULE__{} = q, tool),
     do: %{q | disallowed_tools: q.disallowed_tools ++ [tool]}
 

--- a/lib/claude_wrapper/tool_pattern.ex
+++ b/lib/claude_wrapper/tool_pattern.ex
@@ -1,0 +1,203 @@
+defmodule ClaudeWrapper.ToolPattern do
+  @moduledoc """
+  Tool permission patterns for `--allowed-tools` / `--disallowed-tools`.
+
+  The Claude CLI accepts three pattern shapes in its tool lists:
+
+    * Bare name: `Bash`, `Read`, `Write`.
+    * Name with argument glob: `Bash(git log:*)`, `Write(src/*.ex)`.
+    * MCP pattern: `mcp__server__tool` or `mcp__server__*`.
+
+  This struct models all three. The typed constructors (`tool/1`,
+  `tool_with_args/2`, `all/1`, `mcp/2`) always produce well-formed
+  output. `parse/1` validates the shape of a raw string and returns a
+  `t:pattern_error/0` on malformed input.
+
+  For back-compat, the loose constructors (and the string clauses on
+  `ClaudeWrapper.Query.allowed_tool/2` / `disallowed_tool/2`) accept any
+  string and store it verbatim, so callers passing raw CLI strings keep
+  working without changes. Use `parse/1` directly when you want to catch
+  typos before the CLI invocation.
+
+  This is the Elixir port of the Rust crate's `ToolPattern` /
+  `PatternError` (`../claude-wrapper/src/tool_pattern.rs`). Validation
+  is shape-level only: tool names are not checked against any allowlist
+  because the CLI's tool inventory evolves independently.
+
+  ## Example
+
+      iex> ClaudeWrapper.ToolPattern.tool_with_args("Bash", "git log:*") |> to_string()
+      "Bash(git log:*)"
+
+      iex> ClaudeWrapper.ToolPattern.all("Write") |> to_string()
+      "Write(*)"
+
+      iex> ClaudeWrapper.ToolPattern.mcp("my-server", "*") |> to_string()
+      "mcp__my-server__*"
+  """
+
+  @enforce_keys [:value]
+  defstruct [:value]
+
+  @type t :: %__MODULE__{value: String.t()}
+
+  @typedoc """
+  Errors from `parse/1`.
+
+    * `:empty` -- input was empty or all whitespace.
+    * `:missing_name` -- the tool-name part was empty (e.g. `(args)`
+      with nothing before the `(`).
+    * `{:unbalanced_parens, original}` -- parentheses were unbalanced or
+      appeared out of order. Carries the trimmed input.
+    * `{:illegal_char, original}` -- contained a comma (splits the argv)
+      or a control char (can break the shell). Carries the trimmed
+      input.
+  """
+  @type pattern_error ::
+          :empty
+          | :missing_name
+          | {:unbalanced_parens, String.t()}
+          | {:illegal_char, String.t()}
+
+  @doc """
+  A bare tool name, e.g. `tool("Bash")` -> `Bash`.
+
+  No validation beyond trimming whitespace; the CLI is the source of
+  truth for which tool names exist. Use `parse/1` when you want shape
+  validation.
+
+      iex> ClaudeWrapper.ToolPattern.tool("  Bash  ") |> to_string()
+      "Bash"
+  """
+  @spec tool(String.t()) :: t()
+  def tool(name) when is_binary(name) do
+    %__MODULE__{value: String.trim(name)}
+  end
+
+  @doc """
+  A tool with an argument glob, rendered `Name(args)`.
+
+      iex> ClaudeWrapper.ToolPattern.tool_with_args("Bash", "git log:*") |> to_string()
+      "Bash(git log:*)"
+  """
+  @spec tool_with_args(String.t(), String.t()) :: t()
+  def tool_with_args(name, args) when is_binary(name) and is_binary(args) do
+    %__MODULE__{value: "#{String.trim(name)}(#{args})"}
+  end
+
+  @doc """
+  Shorthand for `tool_with_args/2` with `*` as the argument pattern --
+  "any args to this tool."
+
+      iex> ClaudeWrapper.ToolPattern.all("Write") |> to_string()
+      "Write(*)"
+  """
+  @spec all(String.t()) :: t()
+  def all(name) when is_binary(name) do
+    tool_with_args(name, "*")
+  end
+
+  @doc """
+  An MCP pattern: `mcp__{server}__{tool}`. Pass `"*"` as the tool to
+  match any tool from the server.
+
+      iex> ClaudeWrapper.ToolPattern.mcp("my-server", "do_thing") |> to_string()
+      "mcp__my-server__do_thing"
+
+      iex> ClaudeWrapper.ToolPattern.mcp("my-server", "*") |> to_string()
+      "mcp__my-server__*"
+  """
+  @spec mcp(String.t(), String.t()) :: t()
+  def mcp(server, tool) when is_binary(server) and is_binary(tool) do
+    %__MODULE__{value: "mcp__#{server}__#{tool}"}
+  end
+
+  @doc """
+  Parse and validate a raw CLI-format pattern string.
+
+  Validation is shape-level only (non-empty, balanced parens, no comma
+  or control chars). Tool names are not checked against any allowlist
+  because the CLI's tool inventory evolves independently. Surrounding
+  whitespace is trimmed before validation, so leading/trailing control
+  characters do not trip `{:illegal_char, _}`.
+
+  Returns `{:ok, t}` or `{:error, t:pattern_error/0}`.
+
+      iex> ClaudeWrapper.ToolPattern.parse("Bash(git log:*)")
+      {:ok, %ClaudeWrapper.ToolPattern{value: "Bash(git log:*)"}}
+
+      iex> ClaudeWrapper.ToolPattern.parse("")
+      {:error, :empty}
+
+      iex> ClaudeWrapper.ToolPattern.parse("(args)")
+      {:error, :missing_name}
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, pattern_error()}
+  def parse(input) when is_binary(input) do
+    trimmed = String.trim(input)
+
+    with :ok <- check_non_empty(trimmed),
+         :ok <- check_legal_chars(trimmed),
+         :ok <- check_parens(trimmed) do
+      {:ok, %__MODULE__{value: trimmed}}
+    end
+  end
+
+  defp check_non_empty(""), do: {:error, :empty}
+  defp check_non_empty(_trimmed), do: :ok
+
+  defp check_legal_chars(trimmed) do
+    if String.contains?(trimmed, ",") or has_control_char?(trimmed) do
+      {:error, {:illegal_char, trimmed}}
+    else
+      :ok
+    end
+  end
+
+  # Control chars are U+0000..U+001F and U+007F..U+009F, mirroring
+  # Rust's `char::is_control`.
+  defp has_control_char?(trimmed) do
+    String.to_charlist(trimmed)
+    |> Enum.any?(fn cp -> cp <= 0x1F or (cp >= 0x7F and cp <= 0x9F) end)
+  end
+
+  defp check_parens(trimmed) do
+    opens = count_char(trimmed, "(")
+    closes = count_char(trimmed, ")")
+
+    cond do
+      opens == 0 and closes == 0 -> :ok
+      opens == 0 and closes > 0 -> {:error, {:unbalanced_parens, trimmed}}
+      true -> check_balanced_parens(trimmed, opens, closes)
+    end
+  end
+
+  defp check_balanced_parens(trimmed, opens, closes) do
+    cond do
+      not String.ends_with?(trimmed, ")") -> {:error, {:unbalanced_parens, trimmed}}
+      opens != 1 or closes != 1 -> {:error, {:unbalanced_parens, trimmed}}
+      String.starts_with?(trimmed, "(") -> {:error, :missing_name}
+      true -> :ok
+    end
+  end
+
+  defp count_char(string, char) do
+    string |> String.graphemes() |> Enum.count(&(&1 == char))
+  end
+
+  @doc """
+  Render the pattern as the string it will become in the CLI arg.
+
+  The `String.Chars` protocol is also implemented, so the kernel
+  `to_string/1` and string interpolation work too.
+
+      iex> ClaudeWrapper.ToolPattern.to_string(ClaudeWrapper.ToolPattern.tool("Read"))
+      "Read"
+  """
+  @spec to_string(t()) :: String.t()
+  def to_string(%__MODULE__{value: value}), do: value
+
+  defimpl String.Chars do
+    def to_string(pattern), do: ClaudeWrapper.ToolPattern.to_string(pattern)
+  end
+end

--- a/test/claude_wrapper/tool_pattern_test.exs
+++ b/test/claude_wrapper/tool_pattern_test.exs
@@ -1,0 +1,104 @@
+defmodule ClaudeWrapper.ToolPatternTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.ToolPattern
+
+  doctest ToolPattern
+
+  describe "constructors" do
+    test "tool/1 strips surrounding whitespace" do
+      assert ToolPattern.tool("  Bash  ") |> ToolPattern.to_string() == "Bash"
+    end
+
+    test "tool_with_args/2 renders Name(args)" do
+      pattern = ToolPattern.tool_with_args("Bash", "git log:*")
+      assert ToolPattern.to_string(pattern) == "Bash(git log:*)"
+    end
+
+    test "tool_with_args/2 trims the name but not the args" do
+      pattern = ToolPattern.tool_with_args("  Bash  ", "git log:*")
+      assert ToolPattern.to_string(pattern) == "Bash(git log:*)"
+    end
+
+    test "all/1 wildcards the args" do
+      assert ToolPattern.all("Write") |> ToolPattern.to_string() == "Write(*)"
+    end
+
+    test "mcp/2 renders mcp__server__tool" do
+      assert ToolPattern.mcp("srv", "do_it") |> ToolPattern.to_string() == "mcp__srv__do_it"
+      assert ToolPattern.mcp("srv", "*") |> ToolPattern.to_string() == "mcp__srv__*"
+    end
+
+    test "constructors build a %ToolPattern{} struct holding the canonical string" do
+      assert %ToolPattern{value: "Read"} = ToolPattern.tool("Read")
+    end
+  end
+
+  describe "parse/1 valid input" do
+    test "accepts a bare name" do
+      assert {:ok, %ToolPattern{value: "Bash"}} = ToolPattern.parse("Bash")
+    end
+
+    test "accepts a name with args" do
+      assert {:ok, %ToolPattern{value: "Bash(git log:*)"}} = ToolPattern.parse("Bash(git log:*)")
+    end
+
+    test "accepts an mcp pattern" do
+      assert {:ok, %ToolPattern{value: "mcp__srv__*"}} = ToolPattern.parse("mcp__srv__*")
+    end
+
+    test "trims surrounding whitespace" do
+      assert {:ok, %ToolPattern{value: "Read"}} = ToolPattern.parse("  Read  ")
+    end
+
+    test "round-trips a constructed pattern" do
+      built = ToolPattern.tool_with_args("Bash", "git log:*")
+      assert {:ok, parsed} = ToolPattern.parse(ToolPattern.to_string(built))
+      assert parsed == built
+    end
+  end
+
+  describe "parse/1 errors" do
+    test "rejects empty input" do
+      assert ToolPattern.parse("") == {:error, :empty}
+      assert ToolPattern.parse("   ") == {:error, :empty}
+    end
+
+    test "rejects unbalanced parens" do
+      assert {:error, {:unbalanced_parens, "Bash(git log"}} = ToolPattern.parse("Bash(git log")
+      assert {:error, {:unbalanced_parens, "Bashgit log)"}} = ToolPattern.parse("Bashgit log)")
+
+      assert {:error, {:unbalanced_parens, "Bash((nested))"}} =
+               ToolPattern.parse("Bash((nested))")
+    end
+
+    test "rejects a missing name before the args" do
+      assert ToolPattern.parse("(args)") == {:error, :missing_name}
+    end
+
+    test "rejects a comma" do
+      assert {:error, {:illegal_char, "Bash,Read"}} = ToolPattern.parse("Bash,Read")
+    end
+
+    test "rejects a mid-string control char" do
+      # Leading/trailing whitespace is trimmed, so the control char must
+      # be in the interior to trip the check.
+      assert {:error, {:illegal_char, "Ba\nsh"}} = ToolPattern.parse("Ba\nsh")
+    end
+  end
+
+  describe "to_string/1 and String.Chars" do
+    test "to_string/1 returns the rendered value" do
+      assert ToolPattern.to_string(ToolPattern.tool("Read")) == "Read"
+    end
+
+    test "String.Chars matches to_string/1" do
+      pattern = ToolPattern.tool_with_args("Bash", "ls")
+      assert Kernel.to_string(pattern) == ToolPattern.to_string(pattern)
+    end
+
+    test "is usable in string interpolation" do
+      assert "#{ToolPattern.mcp("srv", "*")}" == "mcp__srv__*"
+    end
+  end
+end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -9,7 +9,8 @@ defmodule ClaudeWrapperTest do
     Retry,
     Session,
     SessionServer,
-    StreamEvent
+    StreamEvent,
+    ToolPattern
   }
 
   describe "Config" do
@@ -208,6 +209,31 @@ defmodule ClaudeWrapperTest do
       assert Enum.count(args, &(&1 == "--disallowed-tools")) == 1
       di = Enum.find_index(args, &(&1 == "--disallowed-tools"))
       assert Enum.slice(args, di, 3) == ["--disallowed-tools", "WebFetch", "Edit"]
+    end
+  end
+
+  describe "allowed_tool/disallowed_tool accept ToolPattern (#96)" do
+    test "a ToolPattern renders to its string form in --allowed-tools" do
+      args =
+        Query.new("p")
+        |> Query.allowed_tool(ToolPattern.tool("Read"))
+        |> Query.allowed_tool(ToolPattern.tool_with_args("Bash", "git log:*"))
+        |> Query.build_args()
+
+      ai = Enum.find_index(args, &(&1 == "--allowed-tools"))
+      assert Enum.slice(args, ai, 3) == ["--allowed-tools", "Read", "Bash(git log:*)"]
+    end
+
+    test "plain strings still work and can be mixed with ToolPatterns" do
+      query =
+        Query.new("p")
+        |> Query.allowed_tool("Read")
+        |> Query.allowed_tool(ToolPattern.all("Write"))
+        |> Query.disallowed_tool(ToolPattern.mcp("srv", "*"))
+        |> Query.disallowed_tool("WebFetch")
+
+      assert query.allowed_tools == ["Read", "Write(*)"]
+      assert query.disallowed_tools == ["mcp__srv__*", "WebFetch"]
     end
   end
 


### PR DESCRIPTION
New module `ClaudeWrapper.ToolPattern`, ported from the Rust `claude-wrapper` `tool_pattern` module.

### API
- `tool/1`, `tool_with_args/2` (`Bash(git log:*)`), `all/1` (`Name(*)`), `mcp/2` (`mcp__server__tool`)
- `parse/1` -> `{:ok, t}` | `{:error, :empty | :missing_name | {:unbalanced_parens, s} | {:illegal_char, s}}`
- `to_string/1` + `String.Chars`

Loose constructors are un-validated (like Rust's `From<&str>`); `parse/1` validates.

### Query integration (non-breaking)
`Query.allowed_tool/2` and `disallowed_tool/2` now accept a `ToolPattern` **or** a plain string (delegates to the string clause via `to_string/1`; `allowed_tools`/`disallowed_tools` stay `[String.t()]`). Existing string usage unchanged.

ToolPattern tests + doctests + Query-integration tests; full suite 357 passing; credo/dialyzer clean.

Closes #96