### PR TITLE
feat: typed partial-message accessor on StreamEvent

### DIFF
--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -54,7 +54,7 @@ defmodule ClaudeWrapper.DuplexIEx do
     `:extra_args`) are forwarded as well
   """
 
-  alias ClaudeWrapper.{Config, DuplexSession, Result}
+  alias ClaudeWrapper.{Config, DuplexSession, Result, StreamEvent}
 
   @session_key :claude_wrapper_duplex_iex_session
   @printer_key :claude_wrapper_duplex_iex_printer
@@ -253,12 +253,9 @@ defmodule ClaudeWrapper.DuplexIEx do
   end
 
   @doc false
-  def handle_event({:stream_event, %{"event" => %{"delta" => %{"text" => text}}}})
-      when is_binary(text) do
-    IO.write(text)
+  def handle_event({:stream_event, msg}) when is_map(msg) do
+    print_partial_text(StreamEvent.partial_message(%StreamEvent{type: msg["type"], data: msg}))
   end
-
-  def handle_event({:stream_event, _other}), do: :ok
 
   def handle_event({:assistant, _msg}), do: :ok
 
@@ -293,6 +290,16 @@ defmodule ClaudeWrapper.DuplexIEx do
   def handle_event(_other), do: :ok
 
   # --- Private --------------------------------------------------------
+
+  # Write incremental assistant text as it streams in. Only text deltas
+  # are surfaced (the prior raw-map version keyed on delta["text"], which
+  # thinking/tool-input deltas don't carry); other partial-message shapes
+  # are ignored here.
+  defp print_partial_text({:block_delta, _index, {:text, text}}) when is_binary(text) do
+    IO.write(text)
+  end
+
+  defp print_partial_text(_other), do: :ok
 
   defp print_meta(%Result{} = result) do
     cost_str = format_cost(result.cost_usd)

--- a/lib/claude_wrapper/stream_event.ex
+++ b/lib/claude_wrapper/stream_event.ex
@@ -19,8 +19,46 @@ defmodule ClaudeWrapper.StreamEvent do
   @type t :: %__MODULE__{
           type: String.t() | nil,
           data: map(),
-          raw: String.t()
+          raw: String.t() | nil
         }
+
+  @typedoc """
+  The kind of content block reported by a `:block_start` partial message.
+
+  Mirrors the `content_block.type` field from the Anthropic streaming API.
+  Block kinds not modelled here surface as `{:other, raw_type}` -- callers
+  can still recover the type name from the carried string.
+  """
+  @type block_type ::
+          :text
+          | :thinking
+          | {:tool_use, id :: String.t(), name :: String.t()}
+          | {:other, String.t()}
+
+  @typedoc """
+  The incremental payload carried by a `:block_delta` partial message.
+
+  Mirrors the `delta.type` field from the Anthropic streaming API. Less
+  common delta kinds (signature, citations, ...) collapse to `:other`;
+  callers that need them can fall back to the struct's `:data` field.
+  """
+  @type block_delta ::
+          {:text, String.t()}
+          | {:thinking, String.t()}
+          | {:input_json, String.t()}
+          | :other
+
+  @typedoc """
+  A decoded partial-message event from a streaming `claude` call.
+
+  Returned by `partial_message/1`. The three variants correspond to the
+  Anthropic streaming content-block lifecycle: a block starts, gets one
+  or more deltas, then stops.
+  """
+  @type partial_message ::
+          {:block_start, index :: non_neg_integer(), block_type()}
+          | {:block_delta, index :: non_neg_integer(), block_delta()}
+          | {:block_stop, index :: non_neg_integer()}
 
   defstruct [:type, :raw, data: %{}]
 
@@ -71,4 +109,80 @@ defmodule ClaudeWrapper.StreamEvent do
   """
   @spec cost_usd(t()) :: float() | nil
   def cost_usd(%__MODULE__{data: data}), do: data["cost_usd"]
+
+  @doc """
+  Decode a partial-message event into a typed, tagged view.
+
+  Returns the tagged tuple when the event is one of the content-block
+  lifecycle events surfaced with `--include-partial-messages` -- start,
+  delta, or stop. Returns `nil` for any other event (system, assistant,
+  result, message-level stream events, etc.).
+
+  The CLI wraps each raw streaming event as
+  `%{"type" => "stream_event", "event" => %{...}}`; this accessor unwraps
+  that envelope. A raw (unwrapped) content-block event is also accepted.
+  Unknown block types and unknown delta types fall through to
+  `{:other, type}` / `:other` rather than returning `nil`, so future
+  content-block kinds remain accessible (just untyped).
+
+  ## Examples
+
+      iex> {:ok, event} =
+      ...>   ClaudeWrapper.StreamEvent.parse(
+      ...>     ~s({"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}})
+      ...>   )
+      iex> ClaudeWrapper.StreamEvent.partial_message(event)
+      {:block_delta, 0, {:text, "Hi"}}
+
+      iex> {:ok, event} = ClaudeWrapper.StreamEvent.parse(~s({"type":"result","result":"done"}))
+      iex> ClaudeWrapper.StreamEvent.partial_message(event)
+      nil
+  """
+  @spec partial_message(t()) :: partial_message() | nil
+  def partial_message(%__MODULE__{type: "stream_event", data: %{"event" => event}})
+      when is_map(event) do
+    decode_partial(event)
+  end
+
+  def partial_message(%__MODULE__{data: data}), do: decode_partial(data)
+
+  defp decode_partial(%{"type" => "content_block_start", "index" => index} = event)
+       when is_integer(index) and index >= 0 do
+    {:block_start, index, parse_block_type(Map.get(event, "content_block"))}
+  end
+
+  defp decode_partial(%{"type" => "content_block_delta", "index" => index} = event)
+       when is_integer(index) and index >= 0 do
+    {:block_delta, index, parse_block_delta(Map.get(event, "delta"))}
+  end
+
+  defp decode_partial(%{"type" => "content_block_stop", "index" => index})
+       when is_integer(index) and index >= 0 do
+    {:block_stop, index}
+  end
+
+  defp decode_partial(_other), do: nil
+
+  defp parse_block_type(%{"type" => "text"}), do: :text
+  defp parse_block_type(%{"type" => "thinking"}), do: :thinking
+
+  defp parse_block_type(%{"type" => "tool_use"} = block) do
+    {:tool_use, to_string(Map.get(block, "id", "")), to_string(Map.get(block, "name", ""))}
+  end
+
+  defp parse_block_type(%{"type" => type}), do: {:other, type}
+  defp parse_block_type(_), do: {:other, ""}
+
+  defp parse_block_delta(%{"type" => "text_delta", "text" => text}) when is_binary(text),
+    do: {:text, text}
+
+  defp parse_block_delta(%{"type" => "thinking_delta", "thinking" => text})
+       when is_binary(text),
+       do: {:thinking, text}
+
+  defp parse_block_delta(%{"type" => "input_json_delta", "partial_json" => json})
+       when is_binary(json),
+       do: {:input_json, json}
+
+  defp parse_block_delta(_), do: :other
 end

--- a/test/claude_wrapper/duplex_iex_test.exs
+++ b/test/claude_wrapper/duplex_iex_test.exs
@@ -132,22 +132,32 @@ defmodule ClaudeWrapper.DuplexIExTest do
   end
 
   describe "handle_event/1 (stream printing)" do
-    test "prints text deltas to stdout" do
-      output =
-        capture_io(fn ->
-          DuplexIEx.handle_event(
-            {:stream_event, %{"event" => %{"delta" => %{"text" => "hello"}}}}
-          )
-        end)
+    # The CLI wraps each streaming event as
+    # %{"type" => "stream_event", "event" => %{...}}; build the realistic
+    # content_block_delta envelope the printer now decodes via
+    # StreamEvent.partial_message/1.
+    defp text_delta(text, index \\ 0) do
+      {:stream_event,
+       %{
+         "type" => "stream_event",
+         "event" => %{
+           "type" => "content_block_delta",
+           "index" => index,
+           "delta" => %{"type" => "text_delta", "text" => text}
+         }
+       }}
+    end
 
+    test "prints text deltas to stdout" do
+      output = capture_io(fn -> DuplexIEx.handle_event(text_delta("hello")) end)
       assert output == "hello"
     end
 
     test "concatenates multiple deltas without newlines" do
       output =
         capture_io(fn ->
-          DuplexIEx.handle_event({:stream_event, %{"event" => %{"delta" => %{"text" => "hel"}}}})
-          DuplexIEx.handle_event({:stream_event, %{"event" => %{"delta" => %{"text" => "lo"}}}})
+          DuplexIEx.handle_event(text_delta("hel"))
+          DuplexIEx.handle_event(text_delta("lo"))
         end)
 
       assert output == "hello"
@@ -157,7 +167,15 @@ defmodule ClaudeWrapper.DuplexIExTest do
       output =
         capture_io(fn ->
           DuplexIEx.handle_event(
-            {:stream_event, %{"event" => %{"delta" => %{"partial_json" => "{\"x\":"}}}}
+            {:stream_event,
+             %{
+               "type" => "stream_event",
+               "event" => %{
+                 "type" => "content_block_delta",
+                 "index" => 0,
+                 "delta" => %{"type" => "input_json_delta", "partial_json" => "{\"x\":"}
+               }
+             }}
           )
         end)
 
@@ -234,7 +252,14 @@ defmodule ClaudeWrapper.DuplexIExTest do
           state = :sys.get_state(pid)
 
           Port.command(state.port, [
-            Jason.encode!(%{type: "stream_event", event: %{delta: %{text: "hi"}}}),
+            Jason.encode!(%{
+              type: "stream_event",
+              event: %{
+                type: "content_block_delta",
+                index: 0,
+                delta: %{type: "text_delta", text: "hi"}
+              }
+            }),
             ?\n
           ])
 

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -395,6 +395,117 @@ defmodule ClaudeWrapperTest do
       event = %StreamEvent{type: "result", data: %{"cost_usd" => 0.03}}
       assert StreamEvent.cost_usd(event) == 0.03
     end
+
+    # partial_message/1 -- ported from the Rust crate's streaming tests
+    # (src/streaming.rs). Each sample is the CLI's stream_event envelope
+    # wrapping a raw Anthropic content-block lifecycle event.
+    defp parse_partial(inner) do
+      line =
+        Jason.encode!(%{
+          "type" => "stream_event",
+          "event" => inner,
+          "session_id" => "sess-1",
+          "parent_tool_use_id" => nil
+        })
+
+      assert {:ok, event} = StreamEvent.parse(line)
+      StreamEvent.partial_message(event)
+    end
+
+    test "partial_message decodes a text block lifecycle" do
+      assert parse_partial(%{
+               "type" => "content_block_start",
+               "index" => 0,
+               "content_block" => %{"type" => "text", "text" => ""}
+             }) == {:block_start, 0, :text}
+
+      assert parse_partial(%{
+               "type" => "content_block_delta",
+               "index" => 0,
+               "delta" => %{"type" => "text_delta", "text" => "Hello"}
+             }) == {:block_delta, 0, {:text, "Hello"}}
+
+      assert parse_partial(%{"type" => "content_block_stop", "index" => 0}) ==
+               {:block_stop, 0}
+    end
+
+    test "partial_message decodes a thinking block lifecycle" do
+      assert parse_partial(%{
+               "type" => "content_block_start",
+               "index" => 1,
+               "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+             }) == {:block_start, 1, :thinking}
+
+      assert parse_partial(%{
+               "type" => "content_block_delta",
+               "index" => 1,
+               "delta" => %{"type" => "thinking_delta", "thinking" => "weighing options"}
+             }) == {:block_delta, 1, {:thinking, "weighing options"}}
+    end
+
+    test "partial_message carries tool_use id and name, and streams input json" do
+      assert parse_partial(%{
+               "type" => "content_block_start",
+               "index" => 2,
+               "content_block" => %{
+                 "type" => "tool_use",
+                 "id" => "toolu_abc",
+                 "name" => "Bash",
+                 "input" => %{}
+               }
+             }) == {:block_start, 2, {:tool_use, "toolu_abc", "Bash"}}
+
+      assert parse_partial(%{
+               "type" => "content_block_delta",
+               "index" => 2,
+               "delta" => %{"type" => "input_json_delta", "partial_json" => "{\"cmd\":"}
+             }) == {:block_delta, 2, {:input_json, "{\"cmd\":"}}
+    end
+
+    test "partial_message falls through to :other for unknown kinds" do
+      assert parse_partial(%{
+               "type" => "content_block_start",
+               "index" => 3,
+               "content_block" => %{"type" => "redacted_thinking", "data" => "..."}
+             }) == {:block_start, 3, {:other, "redacted_thinking"}}
+
+      assert parse_partial(%{
+               "type" => "content_block_delta",
+               "index" => 3,
+               "delta" => %{"type" => "signature_delta", "signature" => "sig"}
+             }) == {:block_delta, 3, :other}
+    end
+
+    test "partial_message returns nil for non-partial events" do
+      assert {:ok, result} =
+               StreamEvent.parse(
+                 ~s({"type":"result","result":"done","session_id":"sess-1","total_cost_usd":0.01})
+               )
+
+      assert StreamEvent.partial_message(result) == nil
+
+      assert {:ok, assistant} =
+               StreamEvent.parse(
+                 ~s({"type":"assistant","message":{"role":"assistant","content":[]},"session_id":"sess-1"})
+               )
+
+      assert StreamEvent.partial_message(assistant) == nil
+
+      # A message-level stream event (not a content-block event) is also nil.
+      assert parse_partial(%{
+               "type" => "message_start",
+               "message" => %{"id" => "msg_1", "role" => "assistant", "content" => []}
+             }) == nil
+    end
+
+    test "partial_message accepts a raw, unwrapped content-block event" do
+      assert {:ok, event} =
+               StreamEvent.parse(
+                 ~s({"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}})
+               )
+
+      assert StreamEvent.partial_message(event) == {:block_delta, 0, {:text, "hi"}}
+    end
   end
 
   describe "Session" do


### PR DESCRIPTION
Adds `ClaudeWrapper.StreamEvent.partial_message/1`, ported from the Rust `claude-wrapper` streaming module, and uses it in the `DuplexIEx` token printer.

### API
`partial_message/1` -> `partial_message()` | `nil`:
- `{:block_start, index, block_type}` where `block_type :: :text | :thinking | {:tool_use, id, name} | {:other, s}`
- `{:block_delta, index, delta}` where `delta :: {:text, s} | {:thinking, s} | {:input_json, s} | :other`
- `{:block_stop, index}`

Unwraps the `%{"type" => "stream_event", "event" => ...}` envelope (content_block_start/delta/stop); `nil` for non-partial events.

DuplexIEx now matches `{:block_delta, _, {:text, t}}` instead of raw `data["event"]["delta"]["text"]`; visible behavior on real CLI output is unchanged (its tests updated to the real content_block_delta envelope). Also widened `StreamEvent.t()` `:raw` to `String.t() | nil` (it's built without `raw` in places) so dialyzer is accurate.

Streaming tests + doctests; full suite 369 passing; credo/dialyzer clean.

Closes #98