### PR TITLE
feat: Plugin command parity (tag, details, prune)

### DIFF
--- a/lib/claude_wrapper/commands/plugin.ex
+++ b/lib/claude_wrapper/commands/plugin.ex
@@ -2,7 +2,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
   @moduledoc """
   Plugin management commands.
 
-  Wraps `claude plugin install|uninstall|list|enable|disable|update|validate`.
+  Wraps `claude plugin install|uninstall|list|enable|disable|update|validate|tag|details|prune`.
 
   ## Usage
 
@@ -23,6 +23,15 @@ defmodule ClaudeWrapper.Commands.Plugin do
       # Enable / disable
       {:ok, _} = ClaudeWrapper.Commands.Plugin.enable(config, "my-plugin")
       {:ok, _} = ClaudeWrapper.Commands.Plugin.disable(config, "my-plugin")
+
+      # Inspect a plugin's component inventory and token cost
+      {:ok, info} = ClaudeWrapper.Commands.Plugin.details(config, "my-plugin")
+
+      # Tag a plugin release (current dir), pushing the tag
+      {:ok, _} = ClaudeWrapper.Commands.Plugin.tag(config, message: "release %s", push: true)
+
+      # Remove auto-installed dependencies no longer needed (non-TTY needs :yes)
+      {:ok, _} = ClaudeWrapper.Commands.Plugin.prune(config, yes: true)
   """
 
   alias ClaudeWrapper.Config
@@ -79,18 +88,32 @@ defmodule ClaudeWrapper.Commands.Plugin do
   ## Options
 
     * `:scope` - Scope to uninstall from (`:user`, `:project`, or `:local`). Default: `:user`.
-    * `:keep_data` - Preserve the plugin's persistent data directory (boolean).
+    * `:keep_data` - Preserve the plugin's persistent data directory (`--keep-data`, boolean).
+    * `:prune` - Also remove auto-installed dependencies that are no longer needed
+      (`--prune`, boolean). Requires `:yes` in non-interactive contexts.
+    * `:yes` - Skip the `--prune` confirmation prompt (`--yes`, boolean). Required when
+      stdin or stdout is not a TTY, which every wrapper consumer is by definition.
   """
   @spec uninstall(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def uninstall(%Config{} = config, plugin, opts \\ []) do
-    args = Config.base_args(config) ++ ["plugin", "uninstall", plugin]
-    args = args ++ scope_args(opts[:scope])
-    args = if opts[:keep_data], do: args ++ ["--keep-data"], else: args
+    args = Config.base_args(config) ++ uninstall_args(plugin, opts)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, {:exit, code, output}}
     end
+  end
+
+  @doc false
+  @spec uninstall_args(String.t(), keyword()) :: [String.t()]
+  def uninstall_args(plugin, opts) do
+    flags =
+      scope_args(opts[:scope]) ++
+        bool_flag(opts[:keep_data], "--keep-data") ++
+        bool_flag(opts[:prune], "--prune") ++
+        bool_flag(opts[:yes], "--yes")
+
+    ["plugin", "uninstall", plugin | flags]
   end
 
   @doc """
@@ -162,6 +185,102 @@ defmodule ClaudeWrapper.Commands.Plugin do
       {output, code} -> {:error, {:exit, code, output}}
     end
   end
+
+  @doc """
+  Create a `{name}--v{version}` git tag for a plugin release.
+
+  Validates that the plugin's `plugin.json` and any enclosing marketplace entry
+  agree on the version before tagging. Without `:path`, the CLI uses the current
+  directory.
+
+  ## Options
+
+    * `:path` - Path to the plugin directory (positional argument).
+    * `:dry_run` - Print what would be tagged without creating it (`--dry-run`, boolean).
+    * `:force` - Skip the dirty-working-tree and tag-already-exists checks
+      (`--force`, boolean).
+    * `:message` - Tag annotation message; use `%s` for the version (`--message`).
+    * `:push` - Push the tag to the remote after creating it (`--push`, boolean).
+    * `:remote` - Remote to push to with `:push` (`--remote`). Default: `origin`.
+  """
+  @spec tag(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def tag(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ tag_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec tag_args(keyword()) :: [String.t()]
+  def tag_args(opts) do
+    flags =
+      bool_flag(opts[:dry_run], "--dry-run") ++
+        bool_flag(opts[:force], "--force") ++
+        value_flag(opts[:message], "--message") ++
+        bool_flag(opts[:push], "--push") ++
+        value_flag(opts[:remote], "--remote")
+
+    path = if opts[:path], do: [opts[:path]], else: []
+
+    ["plugin", "tag"] ++ flags ++ path
+  end
+
+  @doc """
+  Show a plugin's component inventory and projected token cost.
+
+  Wraps `claude plugin details <name>`.
+  """
+  @spec details(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def details(%Config{} = config, plugin) do
+    args = Config.base_args(config) ++ ["plugin", "details", plugin]
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc """
+  Remove auto-installed dependencies that are no longer needed.
+
+  Wraps `claude plugin prune` (alias `autoremove`).
+
+  ## Options
+
+    * `:dry_run` - List what would be removed without removing it (`--dry-run`, boolean).
+    * `:scope` - Prune at scope (`:user`, `:project`, or `:local`). Default: `:user`.
+    * `:yes` - Skip the confirmation prompt (`--yes`, boolean). Required when stdin or
+      stdout is not a TTY, which every wrapper consumer is by definition.
+  """
+  @spec prune(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def prune(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ prune_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec prune_args(keyword()) :: [String.t()]
+  def prune_args(opts) do
+    flags =
+      bool_flag(opts[:dry_run], "--dry-run") ++
+        scope_args(opts[:scope]) ++
+        bool_flag(opts[:yes], "--yes")
+
+    ["plugin", "prune"] ++ flags
+  end
+
+  defp bool_flag(true, flag), do: [flag]
+  defp bool_flag(_falsy, _flag), do: []
+
+  defp value_flag(nil, _flag), do: []
+  defp value_flag(value, flag), do: [flag, value]
 
   defp scope_args(nil), do: []
   defp scope_args(:user), do: ["--scope", "user"]

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -725,6 +725,89 @@ defmodule ClaudeWrapperTest do
       assert {:disable, 3} in Plugin.__info__(:functions)
       assert {:update, 3} in Plugin.__info__(:functions)
       assert {:validate, 2} in Plugin.__info__(:functions)
+      assert {:tag, 2} in Plugin.__info__(:functions)
+      assert {:details, 2} in Plugin.__info__(:functions)
+      assert {:prune, 2} in Plugin.__info__(:functions)
+    end
+
+    test "tag_args defaults to just the subcommand" do
+      assert Plugin.tag_args([]) == ["plugin", "tag"]
+    end
+
+    test "tag_args composes all flags with path last" do
+      args =
+        Plugin.tag_args(
+          path: "./my-plugin",
+          dry_run: true,
+          force: true,
+          message: "release %s",
+          push: true,
+          remote: "upstream"
+        )
+
+      assert args == [
+               "plugin",
+               "tag",
+               "--dry-run",
+               "--force",
+               "--message",
+               "release %s",
+               "--push",
+               "--remote",
+               "upstream",
+               "./my-plugin"
+             ]
+    end
+
+    test "tag_args emits only the flags that are set" do
+      assert Plugin.tag_args(message: "v%s") == ["plugin", "tag", "--message", "v%s"]
+      assert Plugin.tag_args(push: true) == ["plugin", "tag", "--push"]
+      assert Plugin.tag_args(path: "./p") == ["plugin", "tag", "./p"]
+      refute "--force" in Plugin.tag_args(dry_run: true)
+    end
+
+    test "prune_args defaults to just the subcommand" do
+      assert Plugin.prune_args([]) == ["plugin", "prune"]
+    end
+
+    test "prune_args composes dry_run, scope, and yes" do
+      assert Plugin.prune_args(dry_run: true, scope: :user, yes: true) ==
+               ["plugin", "prune", "--dry-run", "--scope", "user", "--yes"]
+    end
+
+    test "prune_args emits scope value and omits unset flags" do
+      assert Plugin.prune_args(scope: :project) == ["plugin", "prune", "--scope", "project"]
+      assert Plugin.prune_args(yes: true) == ["plugin", "prune", "--yes"]
+      refute "--dry-run" in Plugin.prune_args(yes: true)
+    end
+
+    test "uninstall_args defaults to plugin name with no flags" do
+      assert Plugin.uninstall_args("old-plugin", []) == ["plugin", "uninstall", "old-plugin"]
+    end
+
+    test "uninstall_args composes scope, keep_data, prune, and yes" do
+      assert Plugin.uninstall_args("old-plugin",
+               scope: :user,
+               keep_data: true,
+               prune: true,
+               yes: true
+             ) ==
+               [
+                 "plugin",
+                 "uninstall",
+                 "old-plugin",
+                 "--scope",
+                 "user",
+                 "--keep-data",
+                 "--prune",
+                 "--yes"
+               ]
+    end
+
+    test "uninstall_args emits --prune and --yes independently" do
+      assert Plugin.uninstall_args("p", prune: true) == ["plugin", "uninstall", "p", "--prune"]
+      assert Plugin.uninstall_args("p", yes: true) == ["plugin", "uninstall", "p", "--yes"]
+      refute "--keep-data" in Plugin.uninstall_args("p", prune: true)
     end
   end
 


### PR DESCRIPTION
Brings `ClaudeWrapper.Commands.Plugin` to parity with the Rust crate.

- `tag/2` -> `plugin tag` (`--dry-run`, `--force`, `--message`, `--push`, `--remote`, trailing `[path]`)
- `details/2` -> `plugin details <name>`
- `prune/2` -> `plugin prune` (`--dry-run`, `--scope`, `--yes`)
- `uninstall/3` gains `:prune` (`--prune`) and `:yes` (`--yes`)

Flags verified against `claude plugin --help` (2.1.173) and cross-checked with the Rust reference (no discrepancies). New ops factor args into `@doc false` builders (`tag_args/1`, `prune_args/1`, `uninstall_args/2`) so flag composition is unit-tested (default + all-opts + partial cases).

Full suite 378 passing; credo/dialyzer clean.

Closes #99