### PR TITLE
feat: Mcp command parity (add-from-desktop, serve, richer add)

### DIFF
--- a/lib/claude_wrapper/commands/mcp.ex
+++ b/lib/claude_wrapper/commands/mcp.ex
@@ -2,15 +2,56 @@ defmodule ClaudeWrapper.Commands.Mcp do
   @moduledoc """
   MCP (Model Context Protocol) server management commands.
 
-  Wraps `claude mcp add|remove|list|get|serve|reset-project-choices`.
+  Wraps `claude mcp add|add-json|add-from-claude-desktop|remove|list|get|serve|reset-project-choices`.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # List / inspect configured servers (JSON-decoded)
+      {:ok, servers} = ClaudeWrapper.Commands.Mcp.list(config)
+      {:ok, server} = ClaudeWrapper.Commands.Mcp.get(config, "sentry")
+
+      # Add an HTTP server with an auth header
+      {:ok, _} =
+        ClaudeWrapper.Commands.Mcp.add(config, "sentry", "https://mcp.sentry.dev/mcp",
+          [],
+          transport: :http,
+          header: ["Authorization: Bearer abc123"],
+          scope: :user
+        )
+
+      # Add a stdio server with env vars and subprocess args
+      {:ok, _} =
+        ClaudeWrapper.Commands.Mcp.add(config, "my-server", "npx", [],
+          env: %{"API_KEY" => "xxx"},
+          server_args: ["my-mcp-server"]
+        )
+
+      # Add from a JSON blob, prompting for the OAuth client secret
+      {:ok, _} =
+        ClaudeWrapper.Commands.Mcp.add_json(config, "srv", ~s({"command":"npx"}),
+          client_secret: true
+        )
+
+      # Import from Claude Desktop (Mac and WSL only)
+      {:ok, _} = ClaudeWrapper.Commands.Mcp.add_from_desktop(config, nil, scope: :user)
+
+      # Run Claude Code itself as an MCP server
+      {:ok, _} = ClaudeWrapper.Commands.Mcp.serve(config, verbose: true)
   """
 
   alias ClaudeWrapper.Config
 
   @type scope :: :local | :user | :project
+  @type transport :: :stdio | :sse | :http
 
   @doc """
   List configured MCP servers.
+
+  ## Options
+
+    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`).
   """
   @spec list(Config.t(), keyword()) :: {:ok, list(map())} | {:error, term()}
   def list(%Config{} = config, opts \\ []) do
@@ -32,6 +73,10 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
   @doc """
   Get details for a specific MCP server.
+
+  ## Options
+
+    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`).
   """
   @spec get(Config.t(), String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def get(%Config{} = config, name, opts \\ []) do
@@ -52,33 +97,78 @@ defmodule ClaudeWrapper.Commands.Mcp do
   end
 
   @doc """
-  Add a stdio MCP server.
+  Add an MCP server.
+
+  `command_or_url` is the stdio command (e.g. `"npx"`) or the server URL for
+  HTTP/SSE transports. Trailing `command_args` are passed through as positional
+  arguments; prefer `:server_args` (which uses the CLI's `--` separator) for
+  flags that would otherwise be parsed by `claude` itself.
+
+  ## Options
+
+    * `:transport` - Transport type (`:stdio`, `:sse`, or `:http`). Emits
+      `--transport`. The CLI defaults to stdio when omitted.
+    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`). Emits
+      `--scope`.
+    * `:env` - Environment variables as a map or keyword list. Each pair emits
+      `-e KEY=value`.
+    * `:header` - WebSocket/HTTP headers for HTTP/SSE transports. Accepts a list
+      of `"Key: Value"` strings or a map (each pair rendered `"Key: Value"`).
+      Each header emits its own `--header` flag.
+    * `:server_args` - Extra arguments for the server command, emitted after a
+      `--` separator so `claude` does not interpret them.
+    * `:callback_port` - Fixed port for the OAuth callback (`--callback-port`).
+    * `:client_id` - OAuth client ID for HTTP/SSE servers (`--client-id`).
+    * `:client_secret` - Prompt for the OAuth client secret (`--client-secret`,
+      boolean; or set the `MCP_CLIENT_SECRET` env var).
   """
   @spec add(Config.t(), String.t(), String.t(), [String.t()], keyword()) ::
           {:ok, String.t()} | {:error, term()}
-  def add(%Config{} = config, name, command, command_args \\ [], opts \\ []) do
-    args = Config.base_args(config) ++ ["mcp", "add", name, command] ++ command_args
-    args = args ++ scope_args(opts[:scope])
-
-    args =
-      if opts[:env],
-        do: args ++ Enum.flat_map(opts[:env], fn {k, v} -> ["-e", "#{k}=#{v}"] end),
-        else: args
+  def add(%Config{} = config, name, command_or_url, command_args \\ [], opts \\ []) do
+    args = Config.base_args(config) ++ add_args(name, command_or_url, command_args, opts)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, {:exit, code, output}}
     end
+  end
+
+  @doc false
+  @spec add_args(String.t(), String.t(), [String.t()], keyword()) :: [String.t()]
+  def add_args(name, command_or_url, command_args, opts) do
+    flags =
+      transport_args(opts[:transport]) ++
+        scope_args(opts[:scope]) ++
+        env_args(opts[:env]) ++
+        header_args(opts[:header]) ++
+        value_flag(opts[:callback_port], "--callback-port") ++
+        value_flag(opts[:client_id], "--client-id") ++
+        bool_flag(opts[:client_secret], "--client-secret")
+
+    server_args =
+      case opts[:server_args] do
+        nil -> []
+        [] -> []
+        list -> ["--" | Enum.map(list, &to_string/1)]
+      end
+
+    ["mcp", "add"] ++ flags ++ [name, command_or_url] ++ command_args ++ server_args
   end
 
   @doc """
   Add an MCP server from a JSON configuration.
+
+  ## Options
+
+    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`). Emits
+      `--scope`.
+    * `:client_secret` - Prompt for the OAuth client secret (`--client-secret`,
+      boolean; or set the `MCP_CLIENT_SECRET` env var).
   """
   @spec add_json(Config.t(), String.t(), String.t(), keyword()) ::
           {:ok, String.t()} | {:error, term()}
   def add_json(%Config{} = config, name, json, opts \\ []) do
-    args = Config.base_args(config) ++ ["mcp", "add-json", name, json]
-    args = args ++ scope_args(opts[:scope])
+    args = Config.base_args(config) ++ add_json_args(name, json, opts)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
@@ -86,8 +176,54 @@ defmodule ClaudeWrapper.Commands.Mcp do
     end
   end
 
+  @doc false
+  @spec add_json_args(String.t(), String.t(), keyword()) :: [String.t()]
+  def add_json_args(name, json, opts) do
+    flags =
+      scope_args(opts[:scope]) ++
+        bool_flag(opts[:client_secret], "--client-secret")
+
+    ["mcp", "add-json"] ++ flags ++ [name, json]
+  end
+
+  @doc """
+  Import MCP servers from Claude Desktop (Mac and WSL only).
+
+  The installed CLI (`claude mcp add-from-claude-desktop`) takes no name
+  argument; `name` is accepted for forward compatibility and appended as a
+  positional only when non-nil.
+
+  ## Options
+
+    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`). Emits
+      `--scope`.
+  """
+  @spec add_from_desktop(Config.t(), String.t() | nil, keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def add_from_desktop(%Config{} = config, name \\ nil, opts \\ []) do
+    args = Config.base_args(config) ++ add_from_desktop_args(name, opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec add_from_desktop_args(String.t() | nil, keyword()) :: [String.t()]
+  def add_from_desktop_args(name, opts) do
+    positional = if name, do: [name], else: []
+
+    ["mcp", "add-from-claude-desktop"] ++ scope_args(opts[:scope]) ++ positional
+  end
+
   @doc """
   Remove an MCP server.
+
+  ## Options
+
+    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`). When
+      omitted the CLI removes the server from whichever scope it exists in.
   """
   @spec remove(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def remove(%Config{} = config, name, opts \\ []) do
@@ -98,6 +234,38 @@ defmodule ClaudeWrapper.Commands.Mcp do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, {:exit, code, output}}
     end
+  end
+
+  @doc """
+  Start the Claude Code MCP server.
+
+  Wraps `claude mcp serve`, which exposes this Claude Code installation as an
+  MCP server over stdio.
+
+  ## Options
+
+    * `:debug` - Enable debug mode (`--debug`, boolean).
+    * `:verbose` - Override the verbose-mode setting from config (`--verbose`,
+      boolean).
+  """
+  @spec serve(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def serve(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ serve_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec serve_args(keyword()) :: [String.t()]
+  def serve_args(opts) do
+    flags =
+      bool_flag(opts[:debug], "--debug") ++
+        bool_flag(opts[:verbose], "--verbose")
+
+    ["mcp", "serve"] ++ flags
   end
 
   @doc """
@@ -112,6 +280,34 @@ defmodule ClaudeWrapper.Commands.Mcp do
       {output, code} -> {:error, {:exit, code, output}}
     end
   end
+
+  defp transport_args(nil), do: []
+  defp transport_args(:stdio), do: ["--transport", "stdio"]
+  defp transport_args(:sse), do: ["--transport", "sse"]
+  defp transport_args(:http), do: ["--transport", "http"]
+
+  defp env_args(nil), do: []
+
+  defp env_args(env) do
+    Enum.flat_map(env, fn {k, v} -> ["-e", "#{k}=#{v}"] end)
+  end
+
+  defp header_args(nil), do: []
+
+  defp header_args(headers) when is_map(headers) do
+    headers
+    |> Enum.flat_map(fn {k, v} -> ["--header", "#{k}: #{v}"] end)
+  end
+
+  defp header_args(headers) when is_list(headers) do
+    Enum.flat_map(headers, fn header -> ["--header", header] end)
+  end
+
+  defp bool_flag(true, flag), do: [flag]
+  defp bool_flag(_falsy, _flag), do: []
+
+  defp value_flag(nil, _flag), do: []
+  defp value_flag(value, flag), do: [flag, to_string(value)]
 
   defp scope_args(nil), do: []
   defp scope_args(:local), do: ["--scope", "local"]

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -811,6 +811,217 @@ defmodule ClaudeWrapperTest do
     end
   end
 
+  describe "Commands.Mcp" do
+    alias ClaudeWrapper.Commands.Mcp
+
+    test "module is loaded and has expected functions" do
+      Code.ensure_loaded!(Mcp)
+      funcs = Mcp.__info__(:functions)
+
+      assert {:list, 2} in funcs
+      assert {:get, 3} in funcs
+      assert {:add, 5} in funcs
+      assert {:add_json, 4} in funcs
+      assert {:add_from_desktop, 3} in funcs
+      assert {:remove, 3} in funcs
+      assert {:serve, 2} in funcs
+      assert {:reset_project_choices, 1} in funcs
+
+      # @doc false builders are public for arg-composition testing.
+      assert {:add_args, 4} in funcs
+      assert {:add_json_args, 3} in funcs
+      assert {:add_from_desktop_args, 2} in funcs
+      assert {:serve_args, 1} in funcs
+    end
+
+    test "add_args defaults to subcommand plus positionals" do
+      assert Mcp.add_args("srv", "npx", [], []) == ["mcp", "add", "srv", "npx"]
+    end
+
+    test "add_args passes inline command_args through as positionals" do
+      assert Mcp.add_args("srv", "my-command", ["--some-flag", "arg1"], []) ==
+               ["mcp", "add", "srv", "my-command", "--some-flag", "arg1"]
+    end
+
+    test "add_args emits --transport before the positionals" do
+      assert Mcp.add_args("sentry", "https://mcp.sentry.dev/mcp", [], transport: :http) ==
+               ["mcp", "add", "--transport", "http", "sentry", "https://mcp.sentry.dev/mcp"]
+
+      assert Mcp.add_args("s", "u", [], transport: :sse) ==
+               ["mcp", "add", "--transport", "sse", "s", "u"]
+
+      assert Mcp.add_args("s", "u", [], transport: :stdio) ==
+               ["mcp", "add", "--transport", "stdio", "s", "u"]
+    end
+
+    test "add_args emits env as repeated -e KEY=value (map and keyword)" do
+      assert Mcp.add_args("s", "npx", [], env: %{"API_KEY" => "xxx"}) ==
+               ["mcp", "add", "-e", "API_KEY=xxx", "s", "npx"]
+
+      assert Mcp.add_args("s", "npx", [], env: [API_KEY: "xxx"]) ==
+               ["mcp", "add", "-e", "API_KEY=xxx", "s", "npx"]
+    end
+
+    test "add_args emits one --header per header (list)" do
+      args =
+        Mcp.add_args("c", "https://app.corridor.dev/api/mcp", [],
+          transport: :http,
+          header: ["Authorization: Bearer abc", "X-Custom: value"]
+        )
+
+      assert args == [
+               "mcp",
+               "add",
+               "--transport",
+               "http",
+               "--header",
+               "Authorization: Bearer abc",
+               "--header",
+               "X-Custom: value",
+               "c",
+               "https://app.corridor.dev/api/mcp"
+             ]
+
+      assert Enum.count(args, &(&1 == "--header")) == 2
+    end
+
+    test "add_args accepts headers as a map rendered Key: Value" do
+      assert Mcp.add_args("s", "u", [], header: %{"X-Api-Key" => "abc123"}) ==
+               ["mcp", "add", "--header", "X-Api-Key: abc123", "s", "u"]
+    end
+
+    test "add_args emits server_args after a -- separator" do
+      assert Mcp.add_args("my-server", "npx", [], server_args: ["my-mcp-server"]) ==
+               ["mcp", "add", "my-server", "npx", "--", "my-mcp-server"]
+
+      assert Mcp.add_args("s", "npx", [], server_args: ["a", "b"]) ==
+               ["mcp", "add", "s", "npx", "--", "a", "b"]
+    end
+
+    test "add_args omits the -- separator when server_args is empty" do
+      assert Mcp.add_args("s", "npx", [], server_args: []) == ["mcp", "add", "s", "npx"]
+    end
+
+    test "add_args emits --callback-port with a stringified value" do
+      assert Mcp.add_args("s", "https://example.com/mcp", [], callback_port: 8080) ==
+               ["mcp", "add", "--callback-port", "8080", "s", "https://example.com/mcp"]
+    end
+
+    test "add_args emits --client-id and --client-secret together" do
+      assert Mcp.add_args("s", "https://example.com/mcp", [],
+               client_id: "my-app-id",
+               client_secret: true
+             ) ==
+               [
+                 "mcp",
+                 "add",
+                 "--client-id",
+                 "my-app-id",
+                 "--client-secret",
+                 "s",
+                 "https://example.com/mcp"
+               ]
+    end
+
+    test "add_args omits --client-secret when falsy" do
+      refute "--client-secret" in Mcp.add_args("s", "u", [], client_id: "id")
+      refute "--client-secret" in Mcp.add_args("s", "u", [], client_secret: false)
+    end
+
+    test "add_args composes transport, scope, env, port, client_id, secret in order" do
+      args =
+        Mcp.add_args("srv", "https://example.com/mcp", [],
+          transport: :http,
+          scope: :user,
+          env: %{"TOKEN" => "t"},
+          callback_port: 9000,
+          client_id: "cid",
+          client_secret: true
+        )
+
+      assert args == [
+               "mcp",
+               "add",
+               "--transport",
+               "http",
+               "--scope",
+               "user",
+               "-e",
+               "TOKEN=t",
+               "--callback-port",
+               "9000",
+               "--client-id",
+               "cid",
+               "--client-secret",
+               "srv",
+               "https://example.com/mcp"
+             ]
+    end
+
+    test "add_args puts server_args after inline command_args, both after the URL" do
+      assert Mcp.add_args("s", "npx", ["inline"], server_args: ["trailing"]) ==
+               ["mcp", "add", "s", "npx", "inline", "--", "trailing"]
+    end
+
+    test "add_json_args defaults to subcommand plus positionals" do
+      assert Mcp.add_json_args("srv", ~s({"command":"npx"}), []) ==
+               ["mcp", "add-json", "srv", ~s({"command":"npx"})]
+    end
+
+    test "add_json_args emits --scope" do
+      assert Mcp.add_json_args("srv", "{}", scope: :user) ==
+               ["mcp", "add-json", "--scope", "user", "srv", "{}"]
+    end
+
+    test "add_json_args emits --client-secret" do
+      assert Mcp.add_json_args("srv", "{}", client_secret: true) ==
+               ["mcp", "add-json", "--client-secret", "srv", "{}"]
+    end
+
+    test "add_json_args omits --client-secret by default" do
+      refute "--client-secret" in Mcp.add_json_args("srv", "{}", [])
+    end
+
+    test "add_json_args composes scope and client_secret" do
+      assert Mcp.add_json_args("srv", "{}", scope: :project, client_secret: true) ==
+               ["mcp", "add-json", "--scope", "project", "--client-secret", "srv", "{}"]
+    end
+
+    test "add_from_desktop_args defaults to just the subcommand" do
+      assert Mcp.add_from_desktop_args(nil, []) == ["mcp", "add-from-claude-desktop"]
+    end
+
+    test "add_from_desktop_args emits --scope" do
+      assert Mcp.add_from_desktop_args(nil, scope: :user) ==
+               ["mcp", "add-from-claude-desktop", "--scope", "user"]
+    end
+
+    test "add_from_desktop_args appends a name positional when given" do
+      assert Mcp.add_from_desktop_args("srv", []) ==
+               ["mcp", "add-from-claude-desktop", "srv"]
+
+      assert Mcp.add_from_desktop_args("srv", scope: :project) ==
+               ["mcp", "add-from-claude-desktop", "--scope", "project", "srv"]
+    end
+
+    test "serve_args defaults to just the subcommand" do
+      assert Mcp.serve_args([]) == ["mcp", "serve"]
+    end
+
+    test "serve_args emits --debug and --verbose" do
+      assert Mcp.serve_args(debug: true) == ["mcp", "serve", "--debug"]
+      assert Mcp.serve_args(verbose: true) == ["mcp", "serve", "--verbose"]
+
+      assert Mcp.serve_args(debug: true, verbose: true) ==
+               ["mcp", "serve", "--debug", "--verbose"]
+    end
+
+    test "serve_args omits unset flags" do
+      refute "--debug" in Mcp.serve_args(verbose: true)
+      refute "--verbose" in Mcp.serve_args(debug: true)
+    end
+  end
+
   describe "Commands.Agents" do
     alias ClaudeWrapper.Commands.Agents
 


### PR DESCRIPTION
Brings `ClaudeWrapper.Commands.Mcp` to parity with the Rust crate.

- `add_from_desktop/3` -> `claude mcp add-from-claude-desktop` (`:scope`)
- `serve/2` -> `claude mcp serve` (`:debug`, `:verbose`)
- `add_json/4` gains `:client_secret` (`--client-secret`)
- `add/5` gains `:transport`, `:header` (repeated), `:server_args` (after `--`), `:callback_port`, `:client_id`, `:client_secret` (keeps `:scope`/`:env`); now also `add/3` and `add/4` via defaults; emits flags before positionals

Flags verified against `claude mcp ... --help` (2.1.173). Notable CLI facts: the subcommand is `add-from-claude-desktop` and takes no name positional; `--header` is the long form of `-H`. New/changed ops use `@doc false` arg builders (`add_args/4`, `add_json_args/3`, `add_from_desktop_args/2`, `serve_args/1`) so composition is unit-tested.

Full suite 403 passing; credo/dialyzer clean.

Closes #100