### PR TITLE
feat: Auth login options (email, mode, force_sso)

### DIFF
--- a/lib/claude_wrapper/commands/auth.ex
+++ b/lib/claude_wrapper/commands/auth.ex
@@ -69,18 +69,68 @@ defmodule ClaudeWrapper.Commands.Auth do
     end
   end
 
+  @typedoc """
+  Which billing path the CLI should authenticate against.
+
+  Maps to `--claudeai` (Claude subscription) or `--console` (Anthropic
+  Console / API usage billing) on `claude auth login`. The CLI defaults
+  to `:claudeai` when neither flag is passed; setting `:console` is the
+  only way Console-billed teams reach their account.
+  """
+  @type login_mode :: :claudeai | :console
+
   @doc """
   Login via browser. This is interactive -- the CLI will open a browser.
+
+  ## Options
+
+    * `:email` -- pre-populate the email address on the login page
+      (`--email <email>`).
+    * `:mode` -- pin the billing path. `:claudeai` (the CLI default,
+      maps to `--claudeai`) or `:console` (maps to `--console`,
+      required for teams on Anthropic Console billing).
+    * `:force_sso` -- when `true`, force the SSO login flow (`--sso`).
+
+  ## Examples
+
+      # Default subscription login
+      {:ok, _} = ClaudeWrapper.Commands.Auth.login(config)
+
+      # Console-billed login, pre-filling the email
+      {:ok, _} =
+        ClaudeWrapper.Commands.Auth.login(config,
+          mode: :console,
+          email: "ops@example.com"
+        )
   """
-  @spec login(Config.t()) :: {:ok, String.t()} | {:error, term()}
-  def login(%Config{} = config) do
-    args = Config.base_args(config) ++ ["auth", "login"]
+  @spec login(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def login(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ login_args(opts)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, {:exit, code, output}}
     end
   end
+
+  @doc false
+  @spec login_args(keyword()) :: [String.t()]
+  def login_args(opts) do
+    ["auth", "login"] ++
+      mode_flag(opts[:mode]) ++
+      value_flag(opts[:email], "--email") ++
+      bool_flag(opts[:force_sso], "--sso")
+  end
+
+  defp mode_flag(:claudeai), do: ["--claudeai"]
+  defp mode_flag(:console), do: ["--console"]
+  defp mode_flag(_), do: []
+
+  defp bool_flag(true, flag), do: [flag]
+  defp bool_flag(_falsy, _flag), do: []
+
+  defp value_flag(nil, _flag), do: []
+  defp value_flag(value, flag), do: [flag, to_string(value)]
 
   @doc """
   Logout.

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -1022,6 +1022,79 @@ defmodule ClaudeWrapperTest do
     end
   end
 
+  describe "Commands.Auth" do
+    alias ClaudeWrapper.Commands.Auth
+
+    test "module is loaded and has expected functions" do
+      Code.ensure_loaded!(Auth)
+      funcs = Auth.__info__(:functions)
+
+      assert {:status, 1} in funcs
+      assert {:login, 1} in funcs
+      assert {:login, 2} in funcs
+      assert {:logout, 1} in funcs
+      assert {:setup_token, 2} in funcs
+
+      # @doc false builder is public for arg-composition testing.
+      assert {:login_args, 1} in funcs
+    end
+
+    test "login_args defaults to just the subcommand" do
+      assert Auth.login_args([]) == ["auth", "login"]
+    end
+
+    test "login_args emits --email with the value" do
+      assert Auth.login_args(email: "user@example.com") ==
+               ["auth", "login", "--email", "user@example.com"]
+    end
+
+    test "login_args emits --claudeai for mode :claudeai" do
+      assert Auth.login_args(mode: :claudeai) == ["auth", "login", "--claudeai"]
+    end
+
+    test "login_args emits --console for mode :console" do
+      assert Auth.login_args(mode: :console) == ["auth", "login", "--console"]
+    end
+
+    test "login_args emits --sso when force_sso is true" do
+      assert Auth.login_args(force_sso: true) == ["auth", "login", "--sso"]
+    end
+
+    test "login_args omits --sso when force_sso is falsy" do
+      refute "--sso" in Auth.login_args(force_sso: false)
+      refute "--sso" in Auth.login_args([])
+    end
+
+    test "login_args composes mode, email, and force_sso in order" do
+      args =
+        Auth.login_args(
+          mode: :console,
+          email: "ops@example.com",
+          force_sso: true
+        )
+
+      assert args == [
+               "auth",
+               "login",
+               "--console",
+               "--email",
+               "ops@example.com",
+               "--sso"
+             ]
+    end
+
+    test "login_args puts mode before email (claudeai + email)" do
+      assert Auth.login_args(mode: :claudeai, email: "me@example.com") ==
+               ["auth", "login", "--claudeai", "--email", "me@example.com"]
+    end
+
+    test "login_args omits unset flags" do
+      refute "--email" in Auth.login_args(mode: :console)
+      refute "--claudeai" in Auth.login_args(email: "x@y.z")
+      refute "--console" in Auth.login_args(email: "x@y.z")
+    end
+  end
+
   describe "Commands.Agents" do
     alias ClaudeWrapper.Commands.Agents
 


### PR DESCRIPTION
Brings `ClaudeWrapper.Commands.Auth` login to parity with the Rust crate.

- `login/2` (`login/1` still works) with:
  - `:email` -> `--email <value>`
  - `:mode` -> `:claudeai` (`--claudeai`) | `:console` (`--console`)
  - `:force_sso` -> `--sso`

All three flags verified present in `claude auth login --help` (2.1.173). Composition is unit-tested via a `@doc false` `login_args/1` builder. Rust's deprecated `sso(provider)` legacy bridge intentionally not ported.

Full suite 413 passing; credo/dialyzer clean.

Closes #101