### PR TITLE
feat: add auto-mode, install, update, project-purge command wrappers

### DIFF
--- a/lib/claude_wrapper/commands/auto_mode.ex
+++ b/lib/claude_wrapper/commands/auto_mode.ex
@@ -1,0 +1,99 @@
+defmodule ClaudeWrapper.Commands.AutoMode do
+  @moduledoc """
+  Auto-mode classifier inspection commands.
+
+  Wraps `claude auto-mode config|defaults|critique`, which expose the
+  auto-mode classifier configuration the CLI uses to decide which actions
+  it can take without prompting.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # Print the effective config (your settings merged over defaults), as JSON
+      {:ok, json} = ClaudeWrapper.Commands.AutoMode.config(config)
+
+      # Print the default environment/allow/soft_deny/hard_deny rules, as JSON
+      {:ok, json} = ClaudeWrapper.Commands.AutoMode.defaults(config)
+
+      # Get AI feedback on your custom auto-mode rules (free-form text)
+      {:ok, feedback} = ClaudeWrapper.Commands.AutoMode.critique(config)
+
+      # Override the model used for the critique
+      {:ok, feedback} = ClaudeWrapper.Commands.AutoMode.critique(config, model: "opus")
+  """
+
+  alias ClaudeWrapper.Config
+
+  @doc """
+  Print the effective auto-mode config as JSON.
+
+  Emits your settings where set and defaults otherwise, merged. The string
+  is returned verbatim (trimmed); decode it with `Jason.decode/1` if you
+  need the structured form.
+  """
+  @spec config(Config.t()) :: {:ok, String.t()} | {:error, term()}
+  def config(%Config{} = config) do
+    args = Config.base_args(config) ++ config_args()
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec config_args() :: [String.t()]
+  def config_args, do: ["auto-mode", "config"]
+
+  @doc """
+  Print the default auto-mode environment, allow, soft_deny, and hard_deny
+  rules as JSON.
+
+  Useful as a reference when writing custom rules. The soft/hard deny split
+  distinguishes "warn but allow when explicitly overridden" from "always
+  block."
+  """
+  @spec defaults(Config.t()) :: {:ok, String.t()} | {:error, term()}
+  def defaults(%Config{} = config) do
+    args = Config.base_args(config) ++ defaults_args()
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec defaults_args() :: [String.t()]
+  def defaults_args, do: ["auto-mode", "defaults"]
+
+  @doc """
+  Get AI feedback on your custom auto-mode rules.
+
+  Output is free-form text.
+
+  ## Options
+
+    * `:model` - Override which model is used for the critique (`--model`).
+      Without one the CLI picks its default.
+  """
+  @spec critique(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def critique(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ critique_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec critique_args(keyword()) :: [String.t()]
+  def critique_args(opts) do
+    ["auto-mode", "critique"] ++ value_flag(opts[:model], "--model")
+  end
+
+  defp value_flag(nil, _flag), do: []
+  defp value_flag(value, flag), do: [flag, to_string(value)]
+end

--- a/lib/claude_wrapper/commands/install.ex
+++ b/lib/claude_wrapper/commands/install.ex
@@ -1,0 +1,57 @@
+defmodule ClaudeWrapper.Commands.Install do
+  @moduledoc """
+  Install a Claude Code native build.
+
+  Wraps `claude install [target] [--force]`.
+
+  > #### Mutating command {: .warning}
+  >
+  > `install/2` runs `claude install`, which downloads and installs a native
+  > build, mutating the local installation. Call it deliberately.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # Install the CLI's default build
+      {:ok, output} = ClaudeWrapper.Commands.Install.install(config)
+
+      # Install a specific target, forcing reinstall
+      {:ok, output} =
+        ClaudeWrapper.Commands.Install.install(config, target: "latest", force: true)
+  """
+
+  alias ClaudeWrapper.Config
+
+  @doc """
+  Install a Claude Code native build.
+
+  ## Options
+
+    * `:target` - Version to install: `"stable"`, `"latest"`, or a specific
+      version string (positional argument). Omit to use the CLI's default.
+    * `:force` - Force installation even if already installed (`--force`,
+      boolean).
+  """
+  @spec install(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def install(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ install_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec install_args(keyword()) :: [String.t()]
+  def install_args(opts) do
+    flags = bool_flag(opts[:force], "--force")
+    target = if opts[:target], do: [to_string(opts[:target])], else: []
+
+    ["install"] ++ flags ++ target
+  end
+
+  defp bool_flag(true, flag), do: [flag]
+  defp bool_flag(_falsy, _flag), do: []
+end

--- a/lib/claude_wrapper/commands/project.ex
+++ b/lib/claude_wrapper/commands/project.ex
@@ -1,0 +1,79 @@
+defmodule ClaudeWrapper.Commands.Project do
+  @moduledoc """
+  Project state management commands.
+
+  Wraps `claude project purge`, which deletes all Claude Code state for a
+  project: transcripts, tasks, file history, and the project's config entry.
+
+  > #### Destructive command {: .warning}
+  >
+  > `purge/2` permanently deletes project state. Pair it with `dry_run: true`
+  > to preview, and `yes: true` to run headless -- the CLI hangs on its
+  > confirmation prompt when stdin/stdout is not a TTY, which every wrapper
+  > consumer is by definition.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # Preview what would be deleted for a specific project, no confirmation
+      {:ok, preview} =
+        ClaudeWrapper.Commands.Project.purge(config, path: "/some/project", dry_run: true)
+
+      # Purge a specific project headless
+      {:ok, _} = ClaudeWrapper.Commands.Project.purge(config, path: "/some/project", yes: true)
+
+      # Purge every known project headless
+      {:ok, _} = ClaudeWrapper.Commands.Project.purge(config, all: true, yes: true)
+  """
+
+  alias ClaudeWrapper.Config
+
+  @doc """
+  Delete all Claude Code state for a project.
+
+  Removes transcripts, tasks, file history, and the project's config entry.
+  Without `:path` or `:all`, the CLI defaults to the current directory.
+
+  ## Options
+
+    * `:path` - Purge state for the project at this path (positional argument).
+      Mutually exclusive with `:all` at the CLI level.
+    * `:all` - Purge state for every known project (`--all`, boolean). Mutually
+      exclusive with `:path` at the CLI level.
+    * `:dry_run` - List what would be deleted without deleting anything
+      (`--dry-run`, boolean).
+    * `:interactive` - Prompt for each item before deleting (`--interactive`,
+      boolean). Only useful in TTY contexts; headless callers should leave this
+      off and pair `:dry_run` with `:yes`.
+    * `:yes` - Skip the confirmation prompt (`--yes`, boolean). Required when
+      stdin or stdout is not a TTY, which every wrapper consumer is by
+      definition.
+  """
+  @spec purge(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def purge(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ purge_args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec purge_args(keyword()) :: [String.t()]
+  def purge_args(opts) do
+    flags =
+      bool_flag(opts[:all], "--all") ++
+        bool_flag(opts[:dry_run], "--dry-run") ++
+        bool_flag(opts[:interactive], "--interactive") ++
+        bool_flag(opts[:yes], "--yes")
+
+    path = if opts[:path], do: [opts[:path]], else: []
+
+    ["project", "purge"] ++ flags ++ path
+  end
+
+  defp bool_flag(true, flag), do: [flag]
+  defp bool_flag(_falsy, _flag), do: []
+end

--- a/lib/claude_wrapper/commands/update.ex
+++ b/lib/claude_wrapper/commands/update.ex
@@ -1,0 +1,38 @@
+defmodule ClaudeWrapper.Commands.Update do
+  @moduledoc """
+  Check for CLI updates and install if available.
+
+  Wraps `claude update` (CLI alias `upgrade`). Takes no options.
+
+  > #### Mutating command {: .warning}
+  >
+  > `update/1` runs `claude update`, which installs a newer build when one is
+  > available, mutating the local installation. Call it deliberately.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+      {:ok, output} = ClaudeWrapper.Commands.Update.update(config)
+  """
+
+  alias ClaudeWrapper.Config
+
+  @doc """
+  Check for updates and install if available.
+
+  Returns the CLI's output on success.
+  """
+  @spec update(Config.t()) :: {:ok, String.t()} | {:error, term()}
+  def update(%Config{} = config) do
+    args = Config.base_args(config) ++ update_args()
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {:exit, code, output}}
+    end
+  end
+
+  @doc false
+  @spec update_args() :: [String.t()]
+  def update_args, do: ["update"]
+end

--- a/test/claude_wrapper/commands/auto_mode_test.exs
+++ b/test/claude_wrapper/commands/auto_mode_test.exs
@@ -1,0 +1,48 @@
+defmodule ClaudeWrapper.Commands.AutoModeTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Commands.AutoMode
+
+  describe "module surface" do
+    test "is loaded and exposes the expected functions" do
+      Code.ensure_loaded!(AutoMode)
+      funcs = AutoMode.__info__(:functions)
+
+      assert {:config, 1} in funcs
+      assert {:defaults, 1} in funcs
+      assert {:critique, 2} in funcs
+
+      # @doc false builders are public for arg-composition testing.
+      assert {:config_args, 0} in funcs
+      assert {:defaults_args, 0} in funcs
+      assert {:critique_args, 1} in funcs
+    end
+  end
+
+  describe "config_args/0" do
+    test "emits the bare subcommand" do
+      assert AutoMode.config_args() == ["auto-mode", "config"]
+    end
+  end
+
+  describe "defaults_args/0" do
+    test "emits the bare subcommand" do
+      assert AutoMode.defaults_args() == ["auto-mode", "defaults"]
+    end
+  end
+
+  describe "critique_args/1" do
+    test "defaults to the bare subcommand with no model" do
+      assert AutoMode.critique_args([]) == ["auto-mode", "critique"]
+    end
+
+    test "emits --model when set" do
+      assert AutoMode.critique_args(model: "opus") ==
+               ["auto-mode", "critique", "--model", "opus"]
+    end
+
+    test "omits --model when nil" do
+      refute "--model" in AutoMode.critique_args(model: nil)
+    end
+  end
+end

--- a/test/claude_wrapper/commands/install_test.exs
+++ b/test/claude_wrapper/commands/install_test.exs
@@ -1,0 +1,42 @@
+defmodule ClaudeWrapper.Commands.InstallTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Commands.Install
+
+  # These tests exercise only arg composition via the @doc false builder.
+  # They never invoke the real `claude install`, which mutates the system.
+
+  describe "module surface" do
+    test "is loaded and exposes the expected functions" do
+      Code.ensure_loaded!(Install)
+      funcs = Install.__info__(:functions)
+
+      assert {:install, 1} in funcs
+      assert {:install, 2} in funcs
+      assert {:install_args, 1} in funcs
+    end
+  end
+
+  describe "install_args/1" do
+    test "defaults to the bare subcommand" do
+      assert Install.install_args([]) == ["install"]
+    end
+
+    test "passes target as a positional" do
+      assert Install.install_args(target: "stable") == ["install", "stable"]
+    end
+
+    test "emits --force before the target positional" do
+      assert Install.install_args(target: "latest", force: true) ==
+               ["install", "--force", "latest"]
+    end
+
+    test "emits --force alone when no target is given" do
+      assert Install.install_args(force: true) == ["install", "--force"]
+    end
+
+    test "omits --force when falsy" do
+      assert Install.install_args(force: false) == ["install"]
+    end
+  end
+end

--- a/test/claude_wrapper/commands/project_test.exs
+++ b/test/claude_wrapper/commands/project_test.exs
@@ -1,0 +1,74 @@
+defmodule ClaudeWrapper.Commands.ProjectTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Commands.Project
+
+  # These tests exercise only arg composition via the @doc false builder.
+  # They never invoke the real `claude project purge`, which deletes state.
+
+  describe "module surface" do
+    test "is loaded and exposes the expected functions" do
+      Code.ensure_loaded!(Project)
+      funcs = Project.__info__(:functions)
+
+      assert {:purge, 1} in funcs
+      assert {:purge, 2} in funcs
+      assert {:purge_args, 1} in funcs
+    end
+  end
+
+  describe "purge_args/1" do
+    test "defaults to the bare subcommand" do
+      assert Project.purge_args([]) == ["project", "purge"]
+    end
+
+    test "passes path as a positional" do
+      assert Project.purge_args(path: "/tmp/old-project") ==
+               ["project", "purge", "/tmp/old-project"]
+    end
+
+    test "emits --all and --yes" do
+      assert Project.purge_args(all: true, yes: true) ==
+               ["project", "purge", "--all", "--yes"]
+    end
+
+    test "dry_run with yes is a safe preview" do
+      assert Project.purge_args(dry_run: true, yes: true) ==
+               ["project", "purge", "--dry-run", "--yes"]
+    end
+
+    test "emits --interactive" do
+      assert Project.purge_args(interactive: true) ==
+               ["project", "purge", "--interactive"]
+    end
+
+    test "composes all flags with the path positional last" do
+      assert Project.purge_args(
+               path: "/proj",
+               all: true,
+               dry_run: true,
+               interactive: true,
+               yes: true
+             ) ==
+               [
+                 "project",
+                 "purge",
+                 "--all",
+                 "--dry-run",
+                 "--interactive",
+                 "--yes",
+                 "/proj"
+               ]
+    end
+
+    test "the path positional always lands last so it is unambiguous" do
+      args = Project.purge_args(yes: true, path: "./me")
+      assert List.last(args) == "./me"
+    end
+
+    test "omits flags that are falsy" do
+      refute "--all" in Project.purge_args(all: false)
+      refute "--dry-run" in Project.purge_args(yes: true)
+    end
+  end
+end

--- a/test/claude_wrapper/commands/update_test.exs
+++ b/test/claude_wrapper/commands/update_test.exs
@@ -1,0 +1,24 @@
+defmodule ClaudeWrapper.Commands.UpdateTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Commands.Update
+
+  # These tests exercise only arg composition via the @doc false builder.
+  # They never invoke the real `claude update`, which mutates the system.
+
+  describe "module surface" do
+    test "is loaded and exposes the expected functions" do
+      Code.ensure_loaded!(Update)
+      funcs = Update.__info__(:functions)
+
+      assert {:update, 1} in funcs
+      assert {:update_args, 0} in funcs
+    end
+  end
+
+  describe "update_args/0" do
+    test "emits the bare subcommand with no options" do
+      assert Update.update_args() == ["update"]
+    end
+  end
+end


### PR DESCRIPTION
Adds the remaining CLI command wrappers from the Rust crate, each verified against the installed CLI (2.1.173).

- `Commands.AutoMode` -> `config/1`, `defaults/1`, `critique/2` (`--model`)
- `Commands.Install` -> `install/2` (`:target` positional, `:force` -> `--force`)
- `Commands.Update` -> `update/1` (`claude update`)
- `Commands.Project` -> `purge/2` (`:all`, `:dry_run`, `:interactive`, `:yes`, `:path`)

Each op exposes a `@doc false` arg builder for unit-tested composition. Tests cover arg composition + function existence only -- the mutating commands (`install`/`update`/`project purge`) are never executed. No CLI-vs-Rust coverage gaps.

Full suite 436 passing; credo/dialyzer clean.

Closes #102