### PR TITLE
feat: DuplexSession health helpers + Conversation bookkeeping

### DIFF
--- a/lib/claude_wrapper/conversation.ex
+++ b/lib/claude_wrapper/conversation.ex
@@ -1,0 +1,193 @@
+defmodule ClaudeWrapper.Conversation do
+  @moduledoc """
+  Host-side bookkeeping wrapper over a `ClaudeWrapper.DuplexSession`.
+
+  `Conversation` keeps a rolling history of `ClaudeWrapper.Result`
+  structs, cumulative cost, and a turn count on top of an underlying
+  long-lived `DuplexSession`. The duplex session remains the transport;
+  this wrapper only adds the accounting that `DuplexSession.send/3` does
+  not provide on its own.
+
+  It is the duplex-flavoured peer of `ClaudeWrapper.Session`, which is
+  the equivalent bookkeeping shape over transient per-call subprocess
+  turns. `Conversation` follows the same functional-struct style: a
+  `%Conversation{}` value threads through `send/2,3`, which returns the
+  updated struct alongside the turn's `Result`.
+
+  Mirrors the Rust crate's `conversation::Conversation`.
+
+  ## When to use
+
+  Reach for `Conversation` when you already want a `DuplexSession`
+  (long-running host, mid-turn interrupts, broadcast subscribers) and
+  also want to answer:
+
+    * How much have I spent on this conversation so far? (`total_cost/1`)
+    * What is the full history of turns? (`history/1`)
+    * How many turns have completed? (`turn_count/1`)
+
+  If you do not need bookkeeping, drive the `DuplexSession` directly. If
+  you want accounting over short-lived per-turn subprocess calls, use
+  `ClaudeWrapper.Session` instead.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+      {:ok, session} = ClaudeWrapper.DuplexSession.start_link(config: config)
+
+      conv = ClaudeWrapper.Conversation.new(session)
+
+      {:ok, conv, _result} = ClaudeWrapper.Conversation.send(conv, "hello")
+      {:ok, conv, _result} = ClaudeWrapper.Conversation.send(conv, "and again")
+
+      ClaudeWrapper.Conversation.turn_count(conv)
+      #=> 2
+
+      ClaudeWrapper.Conversation.total_cost(conv)
+      #=> 0.0123
+
+      ClaudeWrapper.Conversation.close(conv)
+
+  ## Beyond bookkeeping
+
+  `send/2,3` is the only entry point that records history. For
+  `DuplexSession.subscribe/1`, `DuplexSession.interrupt/2`, and
+  `DuplexSession.respond_to_permission/3`, reach the inner handle via
+  `session/1`. Those calls bypass the wrapper's accounting on purpose:
+  an interrupt still produces a `Result` that the in-flight `send/2,3`
+  records cleanly when the truncated turn lands.
+  """
+
+  alias ClaudeWrapper.{DuplexSession, Result}
+
+  @typedoc """
+  The underlying session reference: the pid or registered name of a
+  running `ClaudeWrapper.DuplexSession`.
+  """
+  @type session :: GenServer.server()
+
+  @type t :: %__MODULE__{
+          session: session(),
+          history: [Result.t()]
+        }
+
+  @enforce_keys [:session]
+  defstruct session: nil, history: []
+
+  @doc """
+  Wrap a running `DuplexSession` in a fresh conversation.
+
+  The conversation starts with an empty history; the underlying session
+  is not touched until the first `send/2,3`. `session` is the pid (or
+  registered name) returned by `DuplexSession.start_link/1`.
+  """
+  @spec new(session()) :: t()
+  def new(session) do
+    %__MODULE__{session: session, history: []}
+  end
+
+  @doc """
+  Send a user prompt over the underlying `DuplexSession` and record the
+  resulting `ClaudeWrapper.Result`.
+
+  Returns `{:ok, conversation, result}` with the history-updated
+  conversation on success, matching `ClaudeWrapper.Session.send/3`'s
+  return convention. Errors from `DuplexSession.send/3` (e.g.
+  `{:error, :turn_in_flight}`, `{:error, :port_closed}`) propagate
+  unchanged and do not update the history.
+
+  The `timeout` defaults to the same 120 seconds as
+  `DuplexSession.send/3`, since the entire turn (cold start + model
+  latency + tool calls) must complete within it.
+  """
+  @spec send(t(), String.t(), timeout()) ::
+          {:ok, t(), Result.t()} | {:error, term()}
+  def send(%__MODULE__{} = conversation, prompt, timeout \\ 120_000)
+      when is_binary(prompt) do
+    case DuplexSession.send(conversation.session, prompt, timeout) do
+      {:ok, %Result{} = result} ->
+        updated = %{conversation | history: conversation.history ++ [result]}
+        {:ok, updated, result}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @doc """
+  The per-turn `Result` history, in arrival order.
+  """
+  @spec history(t()) :: [Result.t()]
+  def history(%__MODULE__{history: history}), do: history
+
+  @doc """
+  The most recent turn's `Result`, or `nil` if no turn has completed.
+  """
+  @spec last_result(t()) :: Result.t() | nil
+  def last_result(%__MODULE__{history: []}), do: nil
+  def last_result(%__MODULE__{history: history}), do: List.last(history)
+
+  @doc """
+  Cumulative cost in USD across every recorded turn.
+
+  Turns whose `Result` carries no `cost_usd` contribute `0.0`.
+  """
+  @spec total_cost(t()) :: float()
+  def total_cost(%__MODULE__{history: history}) do
+    Enum.reduce(history, 0.0, fn %Result{} = result, acc ->
+      acc + (result.cost_usd || 0.0)
+    end)
+  end
+
+  @doc """
+  Number of turns recorded through `send/2,3`.
+  """
+  @spec turn_count(t()) :: non_neg_integer()
+  def turn_count(%__MODULE__{history: history}), do: length(history)
+
+  @doc """
+  The session id assigned by the CLI, or `nil` until the first turn (or
+  `system/init`) has been observed.
+
+  Prefers the most recent turn's `Result.session_id`; falls back to
+  querying the underlying `DuplexSession` when no turn has recorded one
+  yet (for example, `system/init` arrived but no turn has completed).
+  """
+  @spec session_id(t()) :: String.t() | nil
+  def session_id(%__MODULE__{history: history, session: session}) do
+    case last_recorded_session_id(history) do
+      nil -> DuplexSession.session_id(session)
+      sid -> sid
+    end
+  end
+
+  @doc """
+  Borrow the underlying `DuplexSession` reference.
+
+  Use this for `DuplexSession.subscribe/1`, `DuplexSession.interrupt/2`,
+  and `DuplexSession.respond_to_permission/3`, which bypass this
+  wrapper's bookkeeping on purpose.
+  """
+  @spec session(t()) :: session()
+  def session(%__MODULE__{session: session}), do: session
+
+  @doc """
+  Stop the underlying `DuplexSession`.
+
+  Delegates to `DuplexSession.close/1` (graceful stop). Returns `:ok`.
+  The `%Conversation{}` struct is left as-is; its accumulated history
+  remains readable after the session is gone.
+  """
+  @spec close(t()) :: :ok
+  def close(%__MODULE__{session: session}), do: DuplexSession.close(session)
+
+  # --- Internals ------------------------------------------------------
+
+  defp last_recorded_session_id([]), do: nil
+
+  defp last_recorded_session_id(history) do
+    history
+    |> List.last()
+    |> Map.get(:session_id)
+  end
+end

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -87,6 +87,37 @@ defmodule ClaudeWrapper.DuplexSession do
 
   Subscribers are monitored; if a subscriber crashes or exits, it is
   automatically removed.
+
+  > #### Subscriber delivery has no capacity bound {: .info}
+  >
+  > The Rust crate backs `subscribe` with a bounded
+  > `tokio::sync::broadcast` channel (default capacity 256) and slow
+  > consumers observe a `Lagged` error. The Elixir session instead
+  > delivers each event with `Process.send/3` straight into every
+  > subscriber's process mailbox, which is unbounded, so there is no
+  > `subscriber_capacity` knob and no lag/drop semantics: a slow
+  > subscriber simply accumulates messages in its own mailbox. Apply
+  > back-pressure at the subscriber (drain promptly, or unsubscribe)
+  > if that is a concern.
+
+  ## Health and liveness
+
+  `alive?/1`, `exit_status/1`, and `wait_for_exit/2` give service-shaped
+  hosts non-consuming visibility into whether a session is still usable,
+  mirroring the Rust crate's `is_alive` / `exit_status` / `wait_for_exit`
+  (`SessionExitStatus`). See `t:exit_status/0`.
+
+  `wait_for_exit/2` is the authoritative source of the terminal status:
+  it blocks until the session exits and returns `:completed` for a clean
+  shutdown or `{:failed, {:port_exit, code}}` when the underlying
+  `claude` subprocess exits with a non-zero status (or the port closes
+  abnormally). The status is delivered live from `terminate/2`, so there
+  is no persisted state and nothing to read post-mortem.
+
+  `exit_status/1` is only a *live snapshot*: it reports `:running` while
+  the session process is alive and `:completed` once the process is
+  gone. It cannot distinguish a clean exit from a failed one after the
+  fact -- use `wait_for_exit/2` if you need the failure reason.
   """
 
   use GenServer
@@ -130,6 +161,20 @@ defmodule ClaudeWrapper.DuplexSession do
           | {:name, GenServer.name()}
           | GenServer.option()
 
+  @typedoc """
+  Terminal liveness status of a session, mirroring the Rust crate's
+  `SessionExitStatus`:
+
+    * `:running` -- the session process is alive and usable.
+    * `:completed` -- the session shut down cleanly (graceful
+      `stop/3`/`close/1`, or the `claude` subprocess exited with status
+      `0`).
+    * `{:failed, reason}` -- the `claude` subprocess exited abnormally
+      (non-zero status, or the port closed with an error reason). The
+      `reason` is the recorded `{:port_exit, code | term}` tuple.
+  """
+  @type exit_status :: :running | :completed | {:failed, term()}
+
   @type state :: %__MODULE__{
           port: port() | nil,
           config: Config.t(),
@@ -138,7 +183,9 @@ defmodule ClaudeWrapper.DuplexSession do
           pending_turn: {GenServer.from(), [map()]} | nil,
           pending_control: %{String.t() => GenServer.from()},
           subscribers: %{pid() => reference()},
-          on_permission: permission_handler()
+          on_permission: permission_handler(),
+          exit_status: exit_status(),
+          exit_waiters: %{reference() => pid()}
         }
 
   defstruct [
@@ -149,7 +196,9 @@ defmodule ClaudeWrapper.DuplexSession do
     buffer: <<>>,
     pending_turn: nil,
     pending_control: %{},
-    subscribers: %{}
+    subscribers: %{},
+    exit_status: :running,
+    exit_waiters: %{}
   ]
 
   # --- Public API ------------------------------------------------------
@@ -280,6 +329,117 @@ defmodule ClaudeWrapper.DuplexSession do
     GenServer.call(server, :interrupt, timeout)
   end
 
+  @doc """
+  Cheap, non-consuming liveness check. Mirrors the Rust `is_alive`.
+
+  Returns `true` while the session process is alive, `false` once it has
+  exited (cleanly or with an error). Resolves registered names and pids;
+  any non-pid name that does not resolve is treated as not alive.
+  """
+  @spec alive?(GenServer.server()) :: boolean()
+  def alive?(server) do
+    case resolve_pid(server) do
+      pid when is_pid(pid) -> Process.alive?(pid)
+      nil -> false
+    end
+  end
+
+  @doc """
+  Live snapshot of the session's `t:exit_status/0`. Mirrors the Rust
+  `exit_status` / `SessionExitStatus`, but is best-effort only.
+
+  Returns `:running` while the session process is alive and `:completed`
+  once it is gone. Unlike `wait_for_exit/2`, this cannot distinguish a
+  clean exit from a failed one after the fact: the session keeps no
+  persisted terminal status, so a dead process always reads back as
+  `:completed`. If you need the failure reason (e.g.
+  `{:failed, {:port_exit, code}}`), use `wait_for_exit/2`, which is the
+  authoritative source.
+  """
+  @spec exit_status(GenServer.server()) :: exit_status()
+  def exit_status(server) do
+    case resolve_pid(server) do
+      pid when is_pid(pid) ->
+        if Process.alive?(pid) do
+          call_exit_status(pid)
+        else
+          :completed
+        end
+
+      nil ->
+        :completed
+    end
+  end
+
+  @doc """
+  Block until the session exits, then return its terminal
+  `t:exit_status/0`. Mirrors the Rust `wait_for_exit`.
+
+  This is the authoritative source of the terminal status. It returns
+  `:completed` for a clean shutdown and `{:failed, {:port_exit, code}}`
+  when the underlying `claude` subprocess exited with a non-zero status
+  (or the port closed abnormally). Returns immediately (`:completed`) if
+  the session has already exited.
+
+  Implemented with a `Process.monitor/1` plus a one-shot waiter
+  registration on the session: `terminate/2` sends each registered
+  waiter the precise terminal status, and the monitor `:DOWN` is the
+  fallback if the session dies before (or during) registration. Multiple
+  concurrent callers are fine and the call does not consume the session.
+
+  `timeout` (default 5 seconds) bounds the wait; on timeout this returns
+  `:running` to signal "still alive past the deadline" (the analog of
+  the Rust call simply not having resolved yet).
+  """
+  @spec wait_for_exit(GenServer.server(), timeout()) :: exit_status()
+  def wait_for_exit(server, timeout \\ 5_000) do
+    case resolve_pid(server) do
+      nil -> :completed
+      pid when is_pid(pid) -> await_exit(pid, timeout)
+    end
+  end
+
+  # Register as an exit waiter and block for the terminal status. The
+  # monitor guards the window where the session dies before/while we
+  # register: if the GenServer.call races a shutdown (:noproc/:normal
+  # exit), we fall through to the :DOWN branch rather than raising.
+  defp await_exit(pid, timeout) do
+    mref = Process.monitor(pid)
+    ref = make_ref()
+    register_exit_waiter(pid, ref)
+
+    receive do
+      {:duplex_exit, ^ref, status} ->
+        Process.demonitor(mref, [:flush])
+        status
+
+      {:DOWN, ^mref, :process, ^pid, reason} ->
+        down_reason_to_status(reason)
+    after
+      timeout ->
+        Process.demonitor(mref, [:flush])
+        :running
+    end
+  end
+
+  # GenServer.call that tolerates the process dying mid-call. A normal
+  # shutdown (:normal/:noproc) means the :DOWN message is already (or
+  # about to be) in our mailbox, so swallow the exit and let await_exit's
+  # receive pick it up. Any other exit is genuinely unexpected; re-raise.
+  defp register_exit_waiter(pid, ref) do
+    GenServer.call(pid, {:await_exit, ref})
+  catch
+    :exit, {reason, _} when reason in [:normal, :noproc, :shutdown] -> :ok
+    :exit, {{:shutdown, _}, _} -> :ok
+  end
+
+  defp call_exit_status(pid) do
+    GenServer.call(pid, :exit_status)
+  catch
+    :exit, {reason, _} when reason in [:normal, :noproc, :shutdown] -> :completed
+    :exit, {{:shutdown, _}, _} -> :completed
+  end
+
   # --- GenServer callbacks --------------------------------------------
 
   @impl true
@@ -325,6 +485,12 @@ defmodule ClaudeWrapper.DuplexSession do
   end
 
   def handle_call(:session_id, _from, state), do: {:reply, state.session_id, state}
+
+  def handle_call(:exit_status, _from, state), do: {:reply, state.exit_status, state}
+
+  def handle_call({:await_exit, ref}, {pid, _tag}, state) do
+    {:reply, :ok, %{state | exit_waiters: Map.put(state.exit_waiters, ref, pid)}}
+  end
 
   def handle_call({:subscribe, pid}, _from, state) do
     state =
@@ -373,12 +539,14 @@ defmodule ClaudeWrapper.DuplexSession do
 
   def handle_info({port, {:exit_status, code}}, %{port: port} = state) do
     state = fail_pending(state, {:port_exit, code})
-    {:stop, :normal, %{state | port: nil}}
+    status = derive_exit_status({:port_exit, code})
+    {:stop, :normal, %{state | port: nil, exit_status: status}}
   end
 
   def handle_info({:EXIT, port, reason}, %{port: port} = state) do
     state = fail_pending(state, {:port_exit, reason})
-    {:stop, :normal, %{state | port: nil}}
+    status = derive_exit_status({:port_exit, reason})
+    {:stop, :normal, %{state | port: nil, exit_status: status}}
   end
 
   def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
@@ -391,9 +559,10 @@ defmodule ClaudeWrapper.DuplexSession do
   def handle_info(_other, state), do: {:noreply, state}
 
   @impl true
-  def terminate(_reason, %{port: port} = state) do
+  def terminate(reason, %{port: port} = state) do
     if is_port(port) and Port.info(port) != nil, do: Port.close(port)
     fail_pending(state, :terminated)
+    notify_exit_waiters(state, final_exit_status(state, reason))
     :ok
   end
 
@@ -657,4 +826,56 @@ defmodule ClaudeWrapper.DuplexSession do
   defp generate_request_id do
     :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
   end
+
+  # --- Health helpers (internals) -------------------------------------
+
+  # Resolve a GenServer.server() reference to a concrete pid. Pids pass
+  # through; registered names (atoms / {:via, ...} / {name, node}) are
+  # looked up via GenServer.whereis/1, which returns nil if unregistered.
+  defp resolve_pid(pid) when is_pid(pid), do: pid
+  defp resolve_pid(server), do: GenServer.whereis(server)
+
+  # Map a port-exit observation to a terminal status. A status code of 0
+  # (or a reason of :normal) is a clean completion; anything else is a
+  # failure carrying the original {:port_exit, ...} tuple.
+  defp derive_exit_status({:port_exit, 0}), do: :completed
+  defp derive_exit_status({:port_exit, :normal}), do: :completed
+  defp derive_exit_status({:port_exit, _} = reason), do: {:failed, reason}
+
+  # The terminal status to hand to exit waiters from terminate/2. A port
+  # exit already recorded a status in state; honor it. Otherwise the
+  # GenServer is being stopped externally (stop/3, close/1, supervisor)
+  # -- :normal and :shutdown are clean completions, any other reason is a
+  # failure.
+  defp final_exit_status(%{exit_status: status}, _reason) when status != :running, do: status
+  defp final_exit_status(_state, :normal), do: :completed
+  defp final_exit_status(_state, :shutdown), do: :completed
+  defp final_exit_status(_state, {:shutdown, _}), do: :completed
+  defp final_exit_status(_state, reason), do: {:failed, reason}
+
+  # Notify every registered exit waiter with the terminal status. Called
+  # once from terminate/2. This is the authoritative delivery path; the
+  # monitor :DOWN that each waiter also holds is only the fallback for
+  # the death-before-registration race.
+  defp notify_exit_waiters(%{exit_waiters: waiters}, _status)
+       when map_size(waiters) == 0,
+       do: :ok
+
+  defp notify_exit_waiters(%{exit_waiters: waiters}, status) do
+    Enum.each(waiters, fn {ref, pid} ->
+      Process.send(pid, {:duplex_exit, ref, status}, [])
+    end)
+  end
+
+  # Fallback translation of a monitor :DOWN reason into a terminal status,
+  # used only when a waiter never received a {:duplex_exit, ...} message
+  # (the session died before/while it registered). We stop with :normal
+  # even when the child failed (to keep supervision semantics unchanged),
+  # so a clean-looking down reason is treated as :completed; only a
+  # genuinely abnormal exit (e.g. a hard kill) maps to {:failed, reason}.
+  defp down_reason_to_status(:noproc), do: :completed
+  defp down_reason_to_status(:normal), do: :completed
+  defp down_reason_to_status(:shutdown), do: :completed
+  defp down_reason_to_status({:shutdown, _}), do: :completed
+  defp down_reason_to_status(reason), do: {:failed, reason}
 end

--- a/test/claude_wrapper/conversation_test.exs
+++ b/test/claude_wrapper/conversation_test.exs
@@ -1,0 +1,271 @@
+defmodule ClaudeWrapper.ConversationTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.{Config, Conversation, DuplexSession, Result}
+
+  # Spawn a DuplexSession against `cat` (same pattern as
+  # DuplexSessionTest): cat echoes whatever the session writes to its
+  # stdin back out, but it never produces `result` events on its own.
+  # We drive turn completion by injecting a synthetic `result` line from
+  # the test process while a `Conversation.send/3` call blocks in a
+  # separate process.
+  defp start_with_fake_claude do
+    config = Config.new(binary: System.find_executable("cat"))
+    {:ok, pid} = DuplexSession.start_link(config: config, args_override: [])
+    pid
+  end
+
+  # Inject a raw NDJSON term into the running session's port. Yields via
+  # :sys.get_state/1 so the inbound :data message is processed first.
+  defp inject(session, term) do
+    state = :sys.get_state(session)
+    Port.command(state.port, [Jason.encode!(term), ?\n])
+    :sys.get_state(session)
+  end
+
+  # Run one full turn: kick off Conversation.send/3 in a child process,
+  # wait until the underlying session registers the pending turn, inject
+  # a `result` carrying the given fields, and return the {:ok, conv,
+  # result} tuple the send produced.
+  defp run_turn(conversation, prompt, result_fields) do
+    parent = self()
+    session = Conversation.session(conversation)
+
+    spawn_link(fn ->
+      reply = Conversation.send(conversation, prompt, 5_000)
+      Kernel.send(parent, {:turn_done, reply})
+    end)
+
+    # Wait for the session to mark a turn in flight, then complete it.
+    poll_for(fn ->
+      case :sys.get_state(session).pending_turn do
+        {_from, _events} -> {:ok, :pending}
+        _ -> :not_yet
+      end
+    end)
+
+    inject(session, Map.merge(%{type: "result"}, result_fields))
+
+    receive do
+      {:turn_done, reply} -> reply
+    after
+      5_000 -> flunk("turn did not complete")
+    end
+  end
+
+  describe "new/1" do
+    test "starts with an empty history and the given session" do
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+
+        assert conv.session == pid
+        assert Conversation.history(conv) == []
+        assert Conversation.turn_count(conv) == 0
+        assert Conversation.total_cost(conv) == 0.0
+        assert Conversation.last_result(conv) == nil
+        assert Conversation.session(conv) == pid
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+  end
+
+  describe "send/3" do
+    test "accumulates history, cost, and turn count across turns" do
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+
+        assert {:ok, conv, %Result{} = r1} =
+                 run_turn(conv, "hello", %{
+                   result: "hi there",
+                   session_id: "sess-1",
+                   total_cost_usd: 0.01
+                 })
+
+        assert r1.result == "hi there"
+        assert Conversation.turn_count(conv) == 1
+        assert_in_delta Conversation.total_cost(conv), 0.01, 1.0e-9
+        assert Conversation.last_result(conv) == r1
+
+        assert {:ok, conv, %Result{} = r2} =
+                 run_turn(conv, "again", %{
+                   result: "second",
+                   session_id: "sess-1",
+                   total_cost_usd: 0.02
+                 })
+
+        assert Conversation.turn_count(conv) == 2
+        assert_in_delta Conversation.total_cost(conv), 0.03, 1.0e-9
+        assert Conversation.history(conv) == [r1, r2]
+        assert Conversation.last_result(conv) == r2
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "treats a turn with no cost as 0.0" do
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+
+        assert {:ok, conv, _result} =
+                 run_turn(conv, "hello", %{result: "ok", session_id: "sess-1"})
+
+        assert Conversation.turn_count(conv) == 1
+        assert Conversation.total_cost(conv) == 0.0
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "propagates :turn_in_flight without recording a turn" do
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+        session = Conversation.session(conv)
+
+        # Occupy the session with an in-flight turn that we never finish.
+        parent = self()
+
+        spawn_link(fn ->
+          _ = Conversation.send(conv, "first", 5_000)
+          Kernel.send(parent, :first_done)
+        end)
+
+        poll_for(fn ->
+          case :sys.get_state(session).pending_turn do
+            {_from, _events} -> {:ok, :pending}
+            _ -> :not_yet
+          end
+        end)
+
+        # A second concurrent send must be rejected, leaving history empty.
+        assert {:error, :turn_in_flight} = Conversation.send(conv, "second", 1_000)
+        assert Conversation.turn_count(conv) == 0
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "propagates :port_closed without recording a turn" do
+      # A session whose port has been closed but whose GenServer is still
+      # alive replies {:error, :port_closed}. We reach that state by
+      # nil-ing the port via :sys.replace_state, which leaves the
+      # GenServer running so it can answer the call.
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+
+        # Close and drop the real port so the send-with-nil-port clause
+        # is exercised, but keep the GenServer process alive.
+        :sys.replace_state(pid, fn state ->
+          if is_port(state.port) and Port.info(state.port) != nil do
+            Port.close(state.port)
+          end
+
+          %{state | port: nil}
+        end)
+
+        assert {:error, :port_closed} = Conversation.send(conv, "hello", 1_000)
+        assert Conversation.turn_count(conv) == 0
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+  end
+
+  describe "session_id/1" do
+    test "is nil before any turn or init" do
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+        assert Conversation.session_id(conv) == nil
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "falls back to the live session id from system/init" do
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+        inject(pid, %{type: "system", subtype: "init", session_id: "init-abc"})
+
+        # The init line round-trips through `cat` async; poll until the
+        # underlying session has recorded it.
+        poll_for(fn ->
+          case Conversation.session_id(conv) do
+            "init-abc" -> {:ok, :seen}
+            _ -> :not_yet
+          end
+        end)
+
+        assert Conversation.session_id(conv) == "init-abc"
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "prefers the most recent recorded turn's session id" do
+      pid = start_with_fake_claude()
+
+      try do
+        conv = Conversation.new(pid)
+
+        assert {:ok, conv, _r} =
+                 run_turn(conv, "hello", %{result: "ok", session_id: "turn-xyz"})
+
+        assert Conversation.session_id(conv) == "turn-xyz"
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+  end
+
+  describe "close/1" do
+    test "stops the underlying session" do
+      pid = start_with_fake_claude()
+      ref = Process.monitor(pid)
+
+      conv = Conversation.new(pid)
+
+      assert :ok = Conversation.close(conv)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+      refute Process.alive?(pid)
+
+      # History survives the underlying session being gone.
+      assert Conversation.history(conv) == []
+    end
+  end
+
+  # --- Helpers --------------------------------------------------------
+
+  defp poll_for(fun, deadline_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_poll_for(fun, deadline)
+  end
+
+  defp do_poll_for(fun, deadline) do
+    case fun.() do
+      {:ok, value} ->
+        value
+
+      _ ->
+        if System.monotonic_time(:millisecond) > deadline do
+          flunk("poll_for: condition not met before deadline")
+        else
+          Process.sleep(10)
+          do_poll_for(fun, deadline)
+        end
+    end
+  end
+end

--- a/test/claude_wrapper/duplex_session_test.exs
+++ b/test/claude_wrapper/duplex_session_test.exs
@@ -519,6 +519,151 @@ defmodule ClaudeWrapper.DuplexSessionTest do
     end
   end
 
+  describe "alive?/1" do
+    test "true for a live session, false after close" do
+      pid = start_with_fake_claude()
+
+      assert DuplexSession.alive?(pid) == true
+
+      :ok = DuplexSession.close(pid)
+      refute Process.alive?(pid)
+      assert DuplexSession.alive?(pid) == false
+    end
+
+    test "false for an unregistered name" do
+      assert DuplexSession.alive?(:no_such_duplex_session) == false
+    end
+  end
+
+  describe "exit_status/1" do
+    test "is :running while the session is live" do
+      pid = start_with_fake_claude()
+
+      try do
+        assert DuplexSession.exit_status(pid) == :running
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "reads :completed once the process is gone (clean close)" do
+      pid = start_with_fake_claude()
+      ref = Process.monitor(pid)
+
+      :ok = DuplexSession.close(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+
+      assert DuplexSession.exit_status(pid) == :completed
+    end
+
+    test "is a best-effort snapshot: a failed subprocess exit still reads :completed once dead" do
+      # exit_status/1 keeps no persisted terminal status, so a dead
+      # session always reads :completed regardless of how it died. The
+      # failure reason is only available via wait_for_exit/2 (covered
+      # below). This locks the documented snapshot semantics.
+      pid = start_with_fake_claude()
+      ref = Process.monitor(pid)
+      port = :sys.get_state(pid).port
+
+      Kernel.send(pid, {port, {:exit_status, 1}})
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+
+      assert DuplexSession.exit_status(pid) == :completed
+    end
+
+    test "is :completed for an unregistered name" do
+      assert DuplexSession.exit_status(:no_such_duplex_session) == :completed
+    end
+  end
+
+  describe "wait_for_exit/2" do
+    test "returns :completed promptly after the session is closed" do
+      pid = start_with_fake_claude()
+      :ok = DuplexSession.close(pid)
+
+      assert DuplexSession.wait_for_exit(pid, 1_000) == :completed
+    end
+
+    test "returns immediately if the session has already exited" do
+      pid = start_with_fake_claude()
+      ref = Process.monitor(pid)
+      :ok = DuplexSession.close(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+
+      # Process is already gone; the call must not block.
+      assert DuplexSession.wait_for_exit(pid, 1_000) == :completed
+    end
+
+    test "blocks until a live session exits, then returns :completed" do
+      pid = start_with_fake_claude()
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          Kernel.send(parent, :waiting)
+          DuplexSession.wait_for_exit(pid, 5_000)
+        end)
+
+      # Wait until the waiter has actually registered on the session, so
+      # the terminal status flows through the {:duplex_exit, ...} path.
+      assert_receive :waiting, 1_000
+      wait_until(fn -> map_size(:sys.get_state(pid).exit_waiters) == 1 end)
+
+      :ok = DuplexSession.close(pid)
+      assert Task.await(task, 5_000) == :completed
+    end
+
+    test "surfaces a failed subprocess exit to a blocked waiter" do
+      pid = start_with_fake_claude()
+      port = :sys.get_state(pid).port
+
+      task = Task.async(fn -> DuplexSession.wait_for_exit(pid, 5_000) end)
+
+      # Ensure the waiter is registered before driving the non-zero exit,
+      # so the {:failed, ...} status is delivered via {:duplex_exit, ...}.
+      wait_until(fn -> map_size(:sys.get_state(pid).exit_waiters) == 1 end)
+      Kernel.send(pid, {port, {:exit_status, 2}})
+
+      assert Task.await(task, 5_000) == {:failed, {:port_exit, 2}}
+    end
+
+    test "falls back to the monitor when the session is hard-killed" do
+      # A hard kill is untrappable: terminate/2 never runs, so no
+      # {:duplex_exit, ...} is sent even though the waiter registered.
+      # This exercises the :DOWN fallback, where a non-:normal exit
+      # reason (:killed) maps to {:failed, reason}.
+      pid = start_with_fake_claude_quiet()
+      parent = self()
+
+      spawn(fn ->
+        status = DuplexSession.wait_for_exit(pid, 5_000)
+        Kernel.send(parent, {:waited, status})
+      end)
+
+      # Register first so the test is deterministic; the kill still skips
+      # terminate/2, forcing the monitor path.
+      wait_until(fn -> map_size(:sys.get_state(pid).exit_waiters) == 1 end)
+      Process.exit(pid, :kill)
+
+      assert_receive {:waited, {:failed, :killed}}, 5_000
+    end
+
+    test "returns :running on timeout while the session is still alive" do
+      pid = start_with_fake_claude()
+
+      try do
+        assert DuplexSession.wait_for_exit(pid, 50) == :running
+        assert Process.alive?(pid)
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "returns :completed for an unregistered name" do
+      assert DuplexSession.wait_for_exit(:no_such_duplex_session, 100) == :completed
+    end
+  end
+
   defp poll_for(fun, deadline_ms \\ 1_000) do
     deadline = System.monotonic_time(:millisecond) + deadline_ms
     do_poll_for(fun, deadline)

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -297,4 +297,58 @@ defmodule ClaudeWrapper.IntegrationTest do
       assert output =~ "Session closed"
     end
   end
+
+  describe "DuplexSession health" do
+    test "alive?/exit_status/wait_for_exit across a clean shutdown", %{config: config} do
+      {:ok, pid} =
+        DuplexSession.start_link(
+          config: config,
+          extra_args: ["--permission-mode", "plan", "--no-session-persistence"]
+        )
+
+      # No turn is sent, so this spends no tokens -- it just verifies the
+      # health helpers against a real, live stream-json subprocess.
+      assert DuplexSession.alive?(pid)
+      assert DuplexSession.exit_status(pid) == :running
+
+      :ok = DuplexSession.stop(pid)
+
+      refute DuplexSession.alive?(pid)
+      assert DuplexSession.wait_for_exit(pid) == :completed
+      assert DuplexSession.exit_status(pid) == :completed
+    end
+  end
+
+  describe "Conversation" do
+    alias ClaudeWrapper.Conversation
+
+    test "accumulates history over a real turn", %{config: config} do
+      {:ok, pid} =
+        DuplexSession.start_link(
+          config: config,
+          extra_args: [
+            "--permission-mode",
+            "plan",
+            "--max-turns",
+            "1",
+            "--no-session-persistence"
+          ]
+        )
+
+      try do
+        conv = Conversation.new(pid)
+
+        assert {:ok, conv, %ClaudeWrapper.Result{} = result} =
+                 Conversation.send(conv, "Respond with exactly: hi", 120_000)
+
+        assert is_binary(result.result)
+        assert Conversation.turn_count(conv) == 1
+        assert Conversation.last_result(conv) == result
+        assert Conversation.history(conv) == [result]
+        assert Conversation.session_id(conv) != nil
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Completes the DuplexSession parity gap from the Rust crate.

### Health helpers on `DuplexSession`
- `alive?/1` -> `Process.alive?`
- `exit_status/1` -> live snapshot: `:running` while alive, `:completed` once gone
- `wait_for_exit/2` -> authoritative terminal status via an exit-waiters list + monitor fallback: `:completed`, or `{:failed, {:port_exit, code}}` for a non-zero subprocess exit, or `{:failed, reason}` for an abnormal GenServer exit (hard kill)
- `@type exit_status :: :running | :completed | {:failed, term()}` (mirrors Rust `SessionExitStatus`)

No `:persistent_term` (avoids a pid-keyed leak / pid-reuse staleness / global write cost). The session still stops `:normal`, so linked `start_link` callers are unaffected.

### `ClaudeWrapper.Conversation`
Functional wrapper over a `DuplexSession` (mirrors `Session`'s shape): `new/1`, `send/2,3`, `history/1`, `last_result/1`, `total_cost/1`, `turn_count/1`, `session_id/1`, `session/1`, `close/1`.

### subscriber_capacity
Not applicable -- Elixir subscribers use unbounded process mailboxes (documented in the moduledoc) vs Rust's bounded broadcast channel.

### Tests
Unit (cat-fake harness): health transitions incl. a hard-kill `{:failed, :killed}` fallback; Conversation accumulation + error propagation. **Live integration** (`@tag :integration`): health helpers across a real start/stop (no tokens) and a real Conversation turn -- both **verified green against claude 2.1.173**.

Full unit suite 458 passing; credo/dialyzer clean.

Closes #103