### PR TITLE
feat!: canonical ClaudeWrapper.Error exception

### DIFF
--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -92,7 +92,7 @@ defmodule ClaudeWrapper do
   3. System PATH lookup
   """
 
-  alias ClaudeWrapper.{Commands, Config, Query, Result}
+  alias ClaudeWrapper.{Commands, Config, Error, Query, Result}
 
   @doc """
   Run an arbitrary CLI command that isn't wrapped by a dedicated module.
@@ -112,10 +112,10 @@ defmodule ClaudeWrapper do
 
     case System.cmd(config.binary, all_args, cmd_opts) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   rescue
-    e in ErlangError -> {:error, {:system_cmd, e}}
+    e in ErlangError -> {:error, Error.io(e)}
   end
 
   @doc """

--- a/lib/claude_wrapper/agents.ex
+++ b/lib/claude_wrapper/agents.ex
@@ -125,6 +125,7 @@ defmodule ClaudeWrapper.Agents do
   """
 
   alias ClaudeWrapper.Agents.{Definition, Summary}
+  alias ClaudeWrapper.Error
 
   @enforce_keys [:root]
   defstruct [:root]
@@ -149,12 +150,13 @@ defmodule ClaudeWrapper.Agents do
   @doc """
   Resolve the default agents root, `~/.claude/agents`.
 
-  Returns `{:error, :no_home}` when the user home cannot be determined.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :no_home}}` when the user
+  home cannot be determined.
   """
-  @spec home() :: {:ok, t()} | {:error, :no_home}
+  @spec home() :: {:ok, t()} | {:error, Error.t()}
   def home do
     case System.user_home() do
-      nil -> {:error, :no_home}
+      nil -> {:error, Error.new(:no_home)}
       home -> {:ok, %__MODULE__{root: Path.join([home, ".claude", "agents"])}}
     end
   end
@@ -177,7 +179,7 @@ defmodule ClaudeWrapper.Agents do
   install with no user agents). Files that fail to parse are skipped
   rather than failing the whole listing.
   """
-  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, term()}
+  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, Error.t()}
   def list(%__MODULE__{} = a) do
     case File.ls(a.root) do
       {:ok, names} ->
@@ -194,7 +196,7 @@ defmodule ClaudeWrapper.Agents do
         {:ok, []}
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, Error.io(reason)}
     end
   end
 
@@ -202,16 +204,17 @@ defmodule ClaudeWrapper.Agents do
   Read one agent by file stem (the basename of `<stem>.md` under the
   root) into a full `Definition`.
 
-  Returns `{:error, :not_found}` when no such file exists.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :not_found}}` when no such
+  file exists.
   """
-  @spec get(t(), String.t()) :: {:ok, Definition.t()} | {:error, :not_found | term()}
+  @spec get(t(), String.t()) :: {:ok, Definition.t()} | {:error, Error.t()}
   def get(%__MODULE__{} = a, file_stem) when is_binary(file_stem) do
     path = agent_path(a, file_stem)
 
     case File.read(path) do
       {:ok, raw} -> {:ok, parse_agent(raw, file_stem, path)}
-      {:error, :enoent} -> {:error, :not_found}
-      {:error, reason} -> {:error, reason}
+      {:error, :enoent} -> {:error, Error.new(:not_found, reason: file_stem)}
+      {:error, reason} -> {:error, Error.io(reason)}
     end
   end
 
@@ -222,19 +225,21 @@ defmodule ClaudeWrapper.Agents do
   for the accepted attributes. To fail when the agent already exists
   instead of overwriting, use `write_new/3`.
 
-  Returns `{:error, {:invalid_stem, stem}}` for empty, `.`, `..`, or
-  stems containing slashes or NUL bytes.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :invalid_stem}}` (with the
+  stem in `:reason`) for empty, `.`, `..`, or stems containing slashes
+  or NUL bytes.
   """
-  @spec write(t(), String.t(), attrs()) :: :ok | {:error, term()}
+  @spec write(t(), String.t(), attrs()) :: :ok | {:error, Error.t()}
   def write(%__MODULE__{} = a, file_stem, attrs) when is_binary(file_stem) do
     write_inner(a, file_stem, attrs, true)
   end
 
   @doc """
-  Like `write/3` but returns `{:error, :exists}` when the agent already
-  exists. Useful for create-only flows where overwriting would be a bug.
+  Like `write/3` but returns `{:error, %ClaudeWrapper.Error{kind:
+  :already_exists}}` when the agent already exists. Useful for
+  create-only flows where overwriting would be a bug.
   """
-  @spec write_new(t(), String.t(), attrs()) :: :ok | {:error, :exists | term()}
+  @spec write_new(t(), String.t(), attrs()) :: :ok | {:error, Error.t()}
   def write_new(%__MODULE__{} = a, file_stem, attrs) when is_binary(file_stem) do
     write_inner(a, file_stem, attrs, false)
   end
@@ -242,15 +247,16 @@ defmodule ClaudeWrapper.Agents do
   @doc """
   Remove the `<file_stem>.md` agent.
 
-  Returns `{:error, :not_found}` when no such file exists.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :not_found}}` when no such
+  file exists.
   """
-  @spec delete(t(), String.t()) :: :ok | {:error, :not_found | term()}
+  @spec delete(t(), String.t()) :: :ok | {:error, Error.t()}
   def delete(%__MODULE__{} = a, file_stem) when is_binary(file_stem) do
     with :ok <- validate_stem(file_stem) do
       case File.rm(agent_path(a, file_stem)) do
         :ok -> :ok
-        {:error, :enoent} -> {:error, :not_found}
-        {:error, reason} -> {:error, reason}
+        {:error, :enoent} -> {:error, Error.new(:not_found, reason: file_stem)}
+        {:error, reason} -> {:error, Error.io(reason)}
       end
     end
   end
@@ -262,16 +268,30 @@ defmodule ClaudeWrapper.Agents do
 
     with :ok <- validate_stem(file_stem),
          path = agent_path(a, file_stem),
-         :ok <- guard_overwrite(path, allow_overwrite),
-         :ok <- File.mkdir_p(a.root) do
-      File.write(path, render_markdown(file_stem, fields))
+         :ok <- guard_overwrite(path, file_stem, allow_overwrite),
+         :ok <- mkdir_p(a.root) do
+      write_file(path, render_markdown(file_stem, fields))
     end
   end
 
-  defp guard_overwrite(_path, true), do: :ok
+  defp guard_overwrite(_path, _stem, true), do: :ok
 
-  defp guard_overwrite(path, false) do
-    if File.exists?(path), do: {:error, :exists}, else: :ok
+  defp guard_overwrite(path, stem, false) do
+    if File.exists?(path), do: {:error, Error.new(:already_exists, reason: stem)}, else: :ok
+  end
+
+  defp mkdir_p(root) do
+    case File.mkdir_p(root) do
+      :ok -> :ok
+      {:error, reason} -> {:error, Error.io(reason)}
+    end
+  end
+
+  defp write_file(path, contents) do
+    case File.write(path, contents) do
+      :ok -> :ok
+      {:error, reason} -> {:error, Error.io(reason)}
+    end
   end
 
   defp normalize_attrs(attrs) do
@@ -434,11 +454,12 @@ defmodule ClaudeWrapper.Agents do
     Path.join(root, file_stem <> ".md")
   end
 
-  defp validate_stem(stem) when stem in ["", ".", ".."], do: {:error, {:invalid_stem, stem}}
+  defp validate_stem(stem) when stem in ["", ".", ".."],
+    do: {:error, Error.new(:invalid_stem, reason: stem)}
 
   defp validate_stem(stem) do
     if String.contains?(stem, ["/", "\\", "\0"]) do
-      {:error, {:invalid_stem, stem}}
+      {:error, Error.new(:invalid_stem, reason: stem)}
     else
       :ok
     end

--- a/lib/claude_wrapper/budget.ex
+++ b/lib/claude_wrapper/budget.ex
@@ -5,9 +5,9 @@ defmodule ClaudeWrapper.Budget do
   A budget process accumulates cost across turns and fires
   caller-supplied callbacks when configurable thresholds are first
   crossed. When a `:max_usd` ceiling is set, `check/1` returns
-  `{:error, {:budget_exceeded, total, max}}` once the running total is
-  at or above the ceiling, giving callers a hard stop before the next
-  CLI invocation.
+  `{:error, %ClaudeWrapper.Error{kind: :budget_exceeded}}` once the
+  running total is at or above the ceiling, giving callers a hard stop
+  before the next CLI invocation.
 
   This is the Elixir port of the Rust crate's `BudgetTracker` /
   `BudgetBuilder`. The Rust type is an `Arc<Mutex<...>>` handle shared
@@ -27,7 +27,8 @@ defmodule ClaudeWrapper.Budget do
       total is at or above this value, and never again until `reset/1`.
     * `:max_usd` -- `:on_exceeded` fires the first time the running
       total is at or above this value, and `check/1` returns
-      `{:error, {:budget_exceeded, total, max}}` from then on.
+      `{:error, %ClaudeWrapper.Error{kind: :budget_exceeded}}` from then
+      on.
 
   Both thresholds are "at or above" (`>=`), so a record that lands the
   total exactly on the threshold crosses it. Non-positive and
@@ -49,7 +50,7 @@ defmodule ClaudeWrapper.Budget do
 
       case ClaudeWrapper.Budget.check(budget) do
         :ok -> :keep_going
-        {:error, {:budget_exceeded, total, max}} -> {:halt, total, max}
+        {:error, %ClaudeWrapper.Error{kind: :budget_exceeded, reason: %{total_usd: total, max_usd: max}}} -> {:halt, total, max}
       end
 
       ClaudeWrapper.Budget.total(budget)
@@ -107,8 +108,8 @@ defmodule ClaudeWrapper.Budget do
 
     * `:max_usd` - Hard ceiling in USD. Once the running total reaches
       this value, `check/1` returns
-      `{:error, {:budget_exceeded, total, max}}`. `nil` (default)
-      means no ceiling.
+      `{:error, %ClaudeWrapper.Error{kind: :budget_exceeded}}`. `nil`
+      (default) means no ceiling.
     * `:warn_at_usd` - Warning threshold in USD. `:on_warning` fires
       the first time the running total reaches this value. `nil`
       (default) means no warning.
@@ -154,11 +155,12 @@ defmodule ClaudeWrapper.Budget do
   @doc """
   Check the budget against the configured ceiling.
 
-  Returns `{:error, {:budget_exceeded, total, max}}` when the running
-  total is at or above `:max_usd`, and `:ok` otherwise (including when
-  no ceiling is set).
+  Returns `{:error, %ClaudeWrapper.Error{kind: :budget_exceeded}}` (with
+  `:reason` `%{total_usd: total, max_usd: max}`) when the running total
+  is at or above `:max_usd`, and `:ok` otherwise (including when no
+  ceiling is set).
   """
-  @spec check(server()) :: :ok | {:error, {:budget_exceeded, float(), float()}}
+  @spec check(server()) :: :ok | {:error, ClaudeWrapper.Error.t()}
   def check(server) do
     GenServer.call(server, :check)
   end
@@ -296,7 +298,7 @@ defmodule ClaudeWrapper.Budget do
   defp check_state(%State{max_usd: nil}), do: :ok
 
   defp check_state(%State{max_usd: max, total: total}) when total >= max do
-    {:error, {:budget_exceeded, total, max}}
+    {:error, ClaudeWrapper.Error.new(:budget_exceeded, reason: %{total_usd: total, max_usd: max})}
   end
 
   defp check_state(_state), do: :ok

--- a/lib/claude_wrapper/cli_version.ex
+++ b/lib/claude_wrapper/cli_version.ex
@@ -75,16 +75,17 @@ defmodule ClaudeWrapper.CliVersion do
   whitespace-delimited token is considered, and it must be exactly three
   dot-separated non-negative integers.
 
-  Returns `{:error, {:invalid_version, original}}` for anything else,
-  carrying the original (untrimmed) string.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :invalid_version}}` for
+  anything else, with the original (untrimmed) string carried in
+  `:reason`.
 
       iex> ClaudeWrapper.CliVersion.parse("  2.1.71 (Claude Code)\\n")
       {:ok, %ClaudeWrapper.CliVersion{major: 2, minor: 1, patch: 71}}
 
       iex> ClaudeWrapper.CliVersion.parse("2.1")
-      {:error, {:invalid_version, "2.1"}}
+      {:error, %ClaudeWrapper.Error{kind: :invalid_version, reason: "2.1"}}
   """
-  @spec parse(String.t()) :: {:ok, t()} | {:error, {:invalid_version, String.t()}}
+  @spec parse(String.t()) :: {:ok, t()} | {:error, ClaudeWrapper.Error.t()}
   def parse(output) when is_binary(output) do
     token =
       output
@@ -102,7 +103,7 @@ defmodule ClaudeWrapper.CliVersion do
   defp parse_token(token, original) do
     case String.split(token, ".") do
       [major, minor, patch] -> build_from_parts(major, minor, patch, original)
-      _ -> {:error, {:invalid_version, original}}
+      _ -> {:error, ClaudeWrapper.Error.new(:invalid_version, reason: original)}
     end
   end
 
@@ -112,7 +113,7 @@ defmodule ClaudeWrapper.CliVersion do
          {:ok, patch} <- parse_component(patch) do
       {:ok, new(major, minor, patch)}
     else
-      :error -> {:error, {:invalid_version, original}}
+      :error -> {:error, ClaudeWrapper.Error.new(:invalid_version, reason: original)}
     end
   end
 
@@ -199,20 +200,22 @@ defmodule ClaudeWrapper.CliVersion do
   Enforce a minimum version as a tagged-tuple result.
 
   Returns `:ok` when `found` satisfies `minimum`, otherwise
-  `{:error, {:version_mismatch, found, minimum}}`.
+  `{:error, %ClaudeWrapper.Error{kind: :version_mismatch}}` whose
+  `:reason` is `%{found: found, minimum: minimum}`.
 
       iex> v = ClaudeWrapper.CliVersion.new(2, 1, 71)
       iex> ClaudeWrapper.CliVersion.check_version(v, ClaudeWrapper.CliVersion.new(2, 1, 0))
       :ok
       iex> ClaudeWrapper.CliVersion.check_version(v, ClaudeWrapper.CliVersion.new(2, 2, 0))
-      {:error, {:version_mismatch, %ClaudeWrapper.CliVersion{major: 2, minor: 1, patch: 71}, %ClaudeWrapper.CliVersion{major: 2, minor: 2, patch: 0}}}
+      {:error, %ClaudeWrapper.Error{kind: :version_mismatch, reason: %{found: %ClaudeWrapper.CliVersion{major: 2, minor: 1, patch: 71}, minimum: %ClaudeWrapper.CliVersion{major: 2, minor: 2, patch: 0}}}}
   """
-  @spec check_version(t(), t()) :: :ok | {:error, {:version_mismatch, t(), t()}}
+  @spec check_version(t(), t()) :: :ok | {:error, ClaudeWrapper.Error.t()}
   def check_version(%__MODULE__{} = found, %__MODULE__{} = minimum) do
     if satisfies_minimum?(found, minimum) do
       :ok
     else
-      {:error, {:version_mismatch, found, minimum}}
+      {:error,
+       ClaudeWrapper.Error.new(:version_mismatch, reason: %{found: found, minimum: minimum})}
     end
   end
 

--- a/lib/claude_wrapper/command.ex
+++ b/lib/claude_wrapper/command.ex
@@ -7,6 +7,8 @@ defmodule ClaudeWrapper.Command do
   `ClaudeCommand` trait.
   """
 
+  alias ClaudeWrapper.Error
+
   @type args :: [String.t()]
 
   @callback args() :: args()
@@ -40,7 +42,7 @@ defmodule ClaudeWrapper.Command do
       {stdout, code} -> mod.parse_output(stdout, code)
     end
   rescue
-    e in ErlangError -> {:error, {:system_cmd, e}}
+    e in ErlangError -> {:error, Error.io(e)}
   end
 
   defp execute_cmd(mod, binary, args, opts, timeout) do
@@ -48,7 +50,7 @@ defmodule ClaudeWrapper.Command do
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
       {:ok, {stdout, code}} -> mod.parse_output(stdout, code)
-      nil -> {:error, {:timeout, timeout}}
+      nil -> {:error, Error.timeout(timeout)}
     end
   end
 

--- a/lib/claude_wrapper/commands/agents.ex
+++ b/lib/claude_wrapper/commands/agents.ex
@@ -3,7 +3,7 @@ defmodule ClaudeWrapper.Commands.Agents do
   `claude agents` command -- lists configured agents.
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @type agent :: %{
           name: String.t(),
@@ -30,7 +30,7 @@ defmodule ClaudeWrapper.Commands.Agents do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, parse_agents(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -43,7 +43,7 @@ defmodule ClaudeWrapper.Commands.Agents do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/auth.ex
+++ b/lib/claude_wrapper/commands/auth.ex
@@ -3,7 +3,7 @@ defmodule ClaudeWrapper.Commands.Auth do
   Authentication commands -- login, logout, status, token setup.
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @type auth_status :: %{
           logged_in: boolean(),
@@ -65,7 +65,7 @@ defmodule ClaudeWrapper.Commands.Auth do
         end
 
       {output, code} ->
-        {:error, {:exit, code, output}}
+        {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -109,7 +109,7 @@ defmodule ClaudeWrapper.Commands.Auth do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -141,7 +141,7 @@ defmodule ClaudeWrapper.Commands.Auth do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -162,11 +162,11 @@ defmodule ClaudeWrapper.Commands.Auth do
 
     receive do
       {^port, {:exit_status, 0}} -> {:ok, "token configured"}
-      {^port, {:exit_status, code}} -> {:error, {:exit, code, ""}}
+      {^port, {:exit_status, code}} -> {:error, Error.command_failed(code, "")}
     after
       30_000 ->
         send(port, {self(), :close})
-        {:error, :timeout}
+        {:error, Error.timeout(30_000)}
     end
   end
 end

--- a/lib/claude_wrapper/commands/auto_mode.ex
+++ b/lib/claude_wrapper/commands/auto_mode.ex
@@ -23,7 +23,7 @@ defmodule ClaudeWrapper.Commands.AutoMode do
       {:ok, feedback} = ClaudeWrapper.Commands.AutoMode.critique(config, model: "opus")
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @doc """
   Print the effective auto-mode config as JSON.
@@ -38,7 +38,7 @@ defmodule ClaudeWrapper.Commands.AutoMode do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -60,7 +60,7 @@ defmodule ClaudeWrapper.Commands.AutoMode do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -84,7 +84,7 @@ defmodule ClaudeWrapper.Commands.AutoMode do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/doctor.ex
+++ b/lib/claude_wrapper/commands/doctor.ex
@@ -3,7 +3,7 @@ defmodule ClaudeWrapper.Commands.Doctor do
   `claude doctor` command -- checks CLI health.
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @doc """
   Run `claude doctor` and return the output.
@@ -14,7 +14,7 @@ defmodule ClaudeWrapper.Commands.Doctor do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 end

--- a/lib/claude_wrapper/commands/install.ex
+++ b/lib/claude_wrapper/commands/install.ex
@@ -21,7 +21,7 @@ defmodule ClaudeWrapper.Commands.Install do
         ClaudeWrapper.Commands.Install.install(config, target: "latest", force: true)
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @doc """
   Install a Claude Code native build.
@@ -39,7 +39,7 @@ defmodule ClaudeWrapper.Commands.Install do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/marketplace.ex
+++ b/lib/claude_wrapper/commands/marketplace.ex
@@ -26,7 +26,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
       {:ok, _} = ClaudeWrapper.Commands.Marketplace.update(config)
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @type scope :: :user | :project | :local
 
@@ -41,11 +41,11 @@ defmodule ClaudeWrapper.Commands.Marketplace do
       {output, 0} ->
         case Jason.decode(output) do
           {:ok, data} -> {:ok, data}
-          {:error, reason} -> {:error, {:json_decode, reason}}
+          {:error, reason} -> {:error, Error.json(reason)}
         end
 
       {output, code} ->
-        {:error, {:exit, code, output}}
+        {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -70,7 +70,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -83,7 +83,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -99,7 +99,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/mcp.ex
+++ b/lib/claude_wrapper/commands/mcp.ex
@@ -41,7 +41,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
       {:ok, _} = ClaudeWrapper.Commands.Mcp.serve(config, verbose: true)
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @type scope :: :local | :user | :project
   @type transport :: :stdio | :sse | :http
@@ -63,11 +63,11 @@ defmodule ClaudeWrapper.Commands.Mcp do
       {output, 0} ->
         case Jason.decode(output) do
           {:ok, data} -> {:ok, data}
-          {:error, reason} -> {:error, {:json_decode, reason}}
+          {:error, reason} -> {:error, Error.json(reason)}
         end
 
       {output, code} ->
-        {:error, {:exit, code, output}}
+        {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -88,11 +88,11 @@ defmodule ClaudeWrapper.Commands.Mcp do
       {output, 0} ->
         case Jason.decode(output) do
           {:ok, data} -> {:ok, data}
-          {:error, reason} -> {:error, {:json_decode, reason}}
+          {:error, reason} -> {:error, Error.json(reason)}
         end
 
       {output, code} ->
-        {:error, {:exit, code, output}}
+        {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -129,7 +129,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -172,7 +172,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -205,7 +205,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -232,7 +232,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -254,7 +254,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -277,7 +277,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/plugin.ex
+++ b/lib/claude_wrapper/commands/plugin.ex
@@ -34,7 +34,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
       {:ok, _} = ClaudeWrapper.Commands.Plugin.prune(config, yes: true)
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @type scope :: :user | :project | :local
 
@@ -54,11 +54,11 @@ defmodule ClaudeWrapper.Commands.Plugin do
       {output, 0} ->
         case Jason.decode(output) do
           {:ok, data} -> {:ok, data}
-          {:error, reason} -> {:error, {:json_decode, reason}}
+          {:error, reason} -> {:error, Error.json(reason)}
         end
 
       {output, code} ->
-        {:error, {:exit, code, output}}
+        {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -78,7 +78,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -100,7 +100,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -130,7 +130,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -151,7 +151,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -169,7 +169,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -182,7 +182,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -209,7 +209,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -239,7 +239,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
@@ -261,7 +261,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/project.ex
+++ b/lib/claude_wrapper/commands/project.ex
@@ -27,7 +27,7 @@ defmodule ClaudeWrapper.Commands.Project do
       {:ok, _} = ClaudeWrapper.Commands.Project.purge(config, all: true, yes: true)
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @doc """
   Delete all Claude Code state for a project.
@@ -56,7 +56,7 @@ defmodule ClaudeWrapper.Commands.Project do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/update.ex
+++ b/lib/claude_wrapper/commands/update.ex
@@ -15,7 +15,7 @@ defmodule ClaudeWrapper.Commands.Update do
       {:ok, output} = ClaudeWrapper.Commands.Update.update(config)
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @doc """
   Check for updates and install if available.
@@ -28,7 +28,7 @@ defmodule ClaudeWrapper.Commands.Update do
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, {:exit, code, output}}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/lib/claude_wrapper/commands/version.ex
+++ b/lib/claude_wrapper/commands/version.ex
@@ -3,7 +3,7 @@ defmodule ClaudeWrapper.Commands.Version do
   `claude --version` command.
   """
 
-  alias ClaudeWrapper.Config
+  alias ClaudeWrapper.{Config, Error}
 
   @type version_info :: %{
           version: String.t(),
@@ -21,7 +21,7 @@ defmodule ClaudeWrapper.Commands.Version do
         {:ok, %{version: raw, raw: raw}}
 
       {output, code} ->
-        {:error, {:exit, code, output}}
+        {:error, Error.command_failed(code, output)}
     end
   end
 end

--- a/lib/claude_wrapper/conversation.ex
+++ b/lib/claude_wrapper/conversation.ex
@@ -93,7 +93,8 @@ defmodule ClaudeWrapper.Conversation do
   Returns `{:ok, conversation, result}` with the history-updated
   conversation on success, matching `ClaudeWrapper.Session.send/3`'s
   return convention. Errors from `DuplexSession.send/3` (e.g.
-  `{:error, :turn_in_flight}`, `{:error, :port_closed}`) propagate
+  `{:error, %ClaudeWrapper.Error{kind: :turn_in_flight}}`,
+  `{:error, %ClaudeWrapper.Error{kind: :duplex_closed}}`) propagate
   unchanged and do not update the history.
 
   The `timeout` defaults to the same 120 seconds as

--- a/lib/claude_wrapper/dangerous_client.ex
+++ b/lib/claude_wrapper/dangerous_client.ex
@@ -24,10 +24,10 @@ defmodule ClaudeWrapper.DangerousClient do
           query = ClaudeWrapper.Query.new("clean up the build artifacts")
           {:ok, result} = ClaudeWrapper.DangerousClient.query_bypass(client, query)
 
-        {:error, {:dangerous_not_allowed, env_var}} ->
+        {:error, %ClaudeWrapper.Error{kind: :dangerous_not_allowed} = error} ->
           # The caller forgot to set the env var; refuse loudly rather
           # than silently running with (or without) bypass.
-          {:error, {:dangerous_not_allowed, env_var}}
+          {:error, error}
       end
 
   ## Why this shape
@@ -54,7 +54,7 @@ defmodule ClaudeWrapper.DangerousClient do
   is synchronous and there are no feature gates.
   """
 
-  alias ClaudeWrapper.{Config, Query, Result}
+  alias ClaudeWrapper.{Config, Error, Query, Result}
 
   @typedoc """
   A guarded client. Holds the shared `t:ClaudeWrapper.Config.t/0` that
@@ -85,8 +85,8 @@ defmodule ClaudeWrapper.DangerousClient do
   Build a guarded client, refusing unless the opt-in env var is set.
 
   Succeeds only when `System.get_env("#{@allow_env}") == "1"`. Otherwise
-  returns `{:error, {:dangerous_not_allowed, env_var}}`, where `env_var`
-  is the name of the env var to set.
+  returns `{:error, %ClaudeWrapper.Error{kind: :dangerous_not_allowed}}`,
+  whose `:reason` is the name of the env var to set.
 
   The check is made on each call rather than memoized, so a process that
   sets the env var after start (or a test that flips it) is honored.
@@ -95,15 +95,15 @@ defmodule ClaudeWrapper.DangerousClient do
 
       {:ok, client} = ClaudeWrapper.DangerousClient.new(ClaudeWrapper.Config.new())
 
-      {:error, {:dangerous_not_allowed, "CLAUDE_WRAPPER_ALLOW_DANGEROUS"}} =
+      {:error, %ClaudeWrapper.Error{kind: :dangerous_not_allowed, reason: "CLAUDE_WRAPPER_ALLOW_DANGEROUS"}} =
         ClaudeWrapper.DangerousClient.new(ClaudeWrapper.Config.new())
   """
-  @spec new(Config.t()) :: {:ok, t()} | {:error, {:dangerous_not_allowed, String.t()}}
+  @spec new(Config.t()) :: {:ok, t()} | {:error, Error.t()}
   def new(%Config{} = config) do
     if allowed?() do
       {:ok, %__MODULE__{config: config}}
     else
-      {:error, {:dangerous_not_allowed, @allow_env}}
+      {:error, Error.new(:dangerous_not_allowed, reason: @allow_env)}
     end
   end
 

--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -54,7 +54,7 @@ defmodule ClaudeWrapper.DuplexIEx do
     `:extra_args`) are forwarded as well
   """
 
-  alias ClaudeWrapper.{Config, DuplexSession, Result, StreamEvent}
+  alias ClaudeWrapper.{Config, DuplexSession, Error, Result, StreamEvent}
 
   @session_key :claude_wrapper_duplex_iex_session
   @printer_key :claude_wrapper_duplex_iex_printer
@@ -118,7 +118,7 @@ defmodule ClaudeWrapper.DuplexIEx do
     case Process.get(@session_key) do
       nil ->
         IO.puts("\e[31mNo active session. Start one with start/1.\e[0m")
-        {:error, :no_session}
+        {:error, Error.new(:no_session)}
 
       pid ->
         timeout = Keyword.get(opts, :timeout, 120_000)
@@ -144,7 +144,7 @@ defmodule ClaudeWrapper.DuplexIEx do
     case Process.get(@session_key) do
       nil ->
         IO.puts("\e[31mNo active session.\e[0m")
-        {:error, :no_session}
+        {:error, Error.new(:no_session)}
 
       pid ->
         DuplexSession.interrupt(pid, timeout)

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -123,7 +123,7 @@ defmodule ClaudeWrapper.DuplexSession do
   use GenServer
   require Logger
 
-  alias ClaudeWrapper.{Config, Result}
+  alias ClaudeWrapper.{Config, Error, Result}
 
   @type tool_input :: map()
 
@@ -224,8 +224,9 @@ defmodule ClaudeWrapper.DuplexSession do
   @doc """
   Send a user prompt. Blocks until the turn's `result` event arrives.
 
-  Returns `{:ok, %Result{}}` on success, `{:error, :turn_in_flight}` if
-  another turn is already running, or `{:error, reason}` on failure.
+  Returns `{:ok, %Result{}}` on success, `{:error,
+  %ClaudeWrapper.Error{kind: :turn_in_flight}}` if another turn is
+  already running, or `{:error, %ClaudeWrapper.Error{}}` on failure.
 
   The default `timeout` is 120 seconds because the entire turn duration
   must complete within it (cold start + model latency + tool calls).
@@ -268,7 +269,8 @@ defmodule ClaudeWrapper.DuplexSession do
   given `request_id`. Calling this with a `request_id` the session has
   no record of is a no-op (returns `:ok`). The `decision` accepts the
   same shape as a synchronous handler return value, except `:defer`,
-  which is rejected with `{:error, :cannot_defer_again}`.
+  which is rejected with `{:error, %ClaudeWrapper.Error{kind:
+  :cannot_defer_again}}`.
 
   > #### `:allow` and `updatedInput` {: .info}
   >
@@ -282,9 +284,9 @@ defmodule ClaudeWrapper.DuplexSession do
   > plain `:allow`.
   """
   @spec respond_to_permission(GenServer.server(), String.t(), permission_decision()) ::
-          :ok | {:error, :cannot_defer_again}
+          :ok | {:error, Error.t()}
   def respond_to_permission(_server, _request_id, :defer),
-    do: {:error, :cannot_defer_again}
+    do: {:error, Error.new(:cannot_defer_again)}
 
   def respond_to_permission(server, request_id, decision)
       when is_binary(request_id) do
@@ -477,11 +479,11 @@ defmodule ClaudeWrapper.DuplexSession do
   end
 
   def handle_call({:send, _prompt}, _from, %{pending_turn: nil, port: nil} = state) do
-    {:reply, {:error, :port_closed}, state}
+    {:reply, {:error, Error.new(:duplex_closed)}, state}
   end
 
   def handle_call({:send, _prompt}, _from, state) do
-    {:reply, {:error, :turn_in_flight}, state}
+    {:reply, {:error, Error.new(:turn_in_flight)}, state}
   end
 
   def handle_call(:session_id, _from, state), do: {:reply, state.session_id, state}
@@ -514,7 +516,7 @@ defmodule ClaudeWrapper.DuplexSession do
   end
 
   def handle_call(:interrupt, _from, %{port: nil} = state) do
-    {:reply, {:error, :port_closed}, state}
+    {:reply, {:error, Error.new(:duplex_closed)}, state}
   end
 
   def handle_call(:interrupt, from, state) do
@@ -667,8 +669,8 @@ defmodule ClaudeWrapper.DuplexSession do
         reply =
           case resp do
             %{"subtype" => "success"} -> :ok
-            %{"subtype" => "error", "error" => err} -> {:error, err}
-            other -> {:error, other}
+            %{"subtype" => "error", "error" => err} -> {:error, control_failed(err)}
+            other -> {:error, control_failed(other)}
           end
 
         GenServer.reply(from, reply)
@@ -759,7 +761,7 @@ defmodule ClaudeWrapper.DuplexSession do
   defp fail_pending_turn(%{pending_turn: nil} = state, _reason), do: state
 
   defp fail_pending_turn(%{pending_turn: {from, _}} = state, reason) do
-    GenServer.reply(from, {:error, reason})
+    GenServer.reply(from, {:error, fail_reason_to_error(reason)})
     %{state | pending_turn: nil}
   end
 
@@ -768,12 +770,26 @@ defmodule ClaudeWrapper.DuplexSession do
        do: state
 
   defp fail_pending_control(%{pending_control: pending} = state, reason) do
+    error = fail_reason_to_error(reason)
+
     Enum.each(pending, fn {_id, from} ->
-      GenServer.reply(from, {:error, reason})
+      GenServer.reply(from, {:error, error})
     end)
 
     %{state | pending_control: %{}}
   end
+
+  # Map the internal fail-pending reasons to the canonical Error. A clean
+  # `:terminated` (terminate/2) stays bare; a `{:port_exit, x}` from a
+  # subprocess exit is carried in :reason so callers can recover the code.
+  defp fail_reason_to_error(:terminated), do: Error.new(:terminated)
+
+  defp fail_reason_to_error({:port_exit, _} = reason),
+    do: Error.new(:terminated, reason: reason)
+
+  # Wrap an interrupt/permission control_request failure reported by the
+  # CLI via a `subtype: "error"` control_response.
+  defp control_failed(reason), do: Error.new(:duplex_control_failed, reason: reason)
 
   defp port_env_opts(%Config{env: []}), do: []
   defp port_env_opts(%Config{env: env}), do: [{:env, env}]

--- a/lib/claude_wrapper/error.ex
+++ b/lib/claude_wrapper/error.ex
@@ -1,0 +1,223 @@
+defmodule ClaudeWrapper.Error do
+  @moduledoc """
+  Canonical error type for ClaudeWrapper.
+
+  Every operational failure in this library is returned as
+  `{:error, %ClaudeWrapper.Error{}}` and can also be raised (it is a
+  proper exception). Branch on the `:kind` atom for the failure
+  category; the `:reason` field plus the dedicated `:exit_code` /
+  `:stdout` / `:stderr` fields carry the details.
+
+      case ClaudeWrapper.query("hi") do
+        {:ok, result} -> result
+        {:error, %ClaudeWrapper.Error{kind: :max_turns_exceeded}} -> :hit_limit
+        {:error, %ClaudeWrapper.Error{kind: :command_failed, exit_code: code}} -> code
+      end
+
+  The variant set mirrors the Rust `claude-wrapper` `Error` enum.
+
+  ## Kinds
+
+    * `:binary_not_found` -- the `claude` binary could not be launched
+    * `:command_failed` -- the CLI exited non-zero (`:exit_code`,
+      `:stdout`, `:stderr`)
+    * `:io` -- an OS/IO error launching or talking to the CLI
+      (`:reason`)
+    * `:timeout` -- the call exceeded its timeout (`:reason` is the
+      timeout in ms)
+    * `:json` -- the CLI output could not be decoded as JSON
+      (`:reason`, optional `:stdout`)
+    * `:max_turns_exceeded` -- the CLI stopped at its `--max-turns`
+      limit
+    * `:version_mismatch` -- the CLI is older than a required minimum
+      (`:reason` is `%{found:, minimum:}`)
+    * `:invalid_version` -- a version string could not be parsed
+      (`:reason` is the original string)
+    * `:budget_exceeded` -- a client-side budget ceiling was hit
+      (`:reason` is `%{total_usd:, max_usd:}`)
+    * `:dangerous_not_allowed` -- a bypass query was attempted without
+      the opt-in env var (`:reason` is the env var name)
+    * `:duplex_closed` -- the duplex session port was already closed
+    * `:turn_in_flight` -- a turn is already running on the session
+    * `:duplex_control_failed` -- an interrupt/permission control
+      message failed (`:reason`)
+    * `:terminated` -- the session terminated while a turn was pending
+    * `:cannot_defer_again` -- a permission decision was deferred twice
+    * `:no_session` -- a REPL helper was used with no active session
+    * `:not_found` -- a requested resource does not exist (`:reason`
+      identifies it)
+    * `:already_exists` -- a create-new target already exists
+      (`:reason`)
+    * `:invalid_stem` -- an invalid file stem / identifier (`:reason`)
+    * `:no_home` -- the user home directory could not be determined
+    * `:invalid_settings_json` -- a settings file is not valid JSON
+      (`:reason` is `%{path:, error:}`)
+    * `:settings_read_error` -- a settings file could not be read
+      (`:reason` is `%{path:, error:}`)
+    * `:not_a_git_repo` -- a path is not inside a git repo (`:reason`
+      is the path)
+    * `:git_failed` -- a `git` invocation failed (`:reason`)
+    * `:git_unavailable` -- the `git` binary is not available
+      (`:reason`)
+    * `:invalid_tool_pattern` -- a tool pattern failed validation
+      (`:reason` is the specific problem)
+    * `:auth` -- an authentication failure, classified into `:reason`
+      (see `t:ClaudeWrapper.Auth.auth_error_kind/0`)
+  """
+
+  @type kind ::
+          :binary_not_found
+          | :command_failed
+          | :io
+          | :timeout
+          | :json
+          | :max_turns_exceeded
+          | :version_mismatch
+          | :invalid_version
+          | :budget_exceeded
+          | :dangerous_not_allowed
+          | :duplex_closed
+          | :turn_in_flight
+          | :duplex_control_failed
+          | :terminated
+          | :cannot_defer_again
+          | :no_session
+          | :not_found
+          | :already_exists
+          | :invalid_stem
+          | :no_home
+          | :invalid_settings_json
+          | :settings_read_error
+          | :not_a_git_repo
+          | :git_failed
+          | :git_unavailable
+          | :invalid_tool_pattern
+          | :auth
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          message: String.t() | nil,
+          reason: term(),
+          exit_code: integer() | nil,
+          stdout: String.t() | nil,
+          stderr: String.t() | nil
+        }
+
+  defexception [:kind, :message, :reason, :exit_code, :stdout, :stderr]
+
+  @impl true
+  def exception(opts) when is_list(opts) do
+    %__MODULE__{
+      kind: Keyword.fetch!(opts, :kind),
+      message: opts[:message],
+      reason: opts[:reason],
+      exit_code: opts[:exit_code],
+      stdout: opts[:stdout],
+      stderr: opts[:stderr]
+    }
+  end
+
+  @impl true
+  def message(%__MODULE__{message: msg}) when is_binary(msg), do: msg
+  def message(%__MODULE__{} = error), do: default_message(error)
+
+  @doc """
+  Build an error of `kind`, with optional `:message`, `:reason`,
+  `:exit_code`, `:stdout`, `:stderr`.
+  """
+  @spec new(kind(), keyword()) :: t()
+  def new(kind, opts \\ []) when is_atom(kind), do: exception([{:kind, kind} | opts])
+
+  @doc "A `:command_failed` error from a non-zero CLI exit."
+  @spec command_failed(integer(), String.t(), String.t() | nil) :: t()
+  def command_failed(exit_code, stdout, stderr \\ nil) do
+    %__MODULE__{kind: :command_failed, exit_code: exit_code, stdout: stdout, stderr: stderr}
+  end
+
+  @doc "A `:timeout` error (`ms` is the elapsed timeout)."
+  @spec timeout(non_neg_integer()) :: t()
+  def timeout(ms), do: %__MODULE__{kind: :timeout, reason: ms}
+
+  @doc "A `:json` decode error, optionally carrying the raw `stdout`."
+  @spec json(term(), String.t() | nil) :: t()
+  def json(reason, stdout \\ nil), do: %__MODULE__{kind: :json, reason: reason, stdout: stdout}
+
+  @doc "An `:io` error wrapping an underlying reason."
+  @spec io(term()) :: t()
+  def io(reason), do: %__MODULE__{kind: :io, reason: reason}
+
+  # --- default messages ---------------------------------------------
+
+  defp default_message(%{kind: :binary_not_found, reason: bin}),
+    do: "claude binary not found: #{inspect(bin)}"
+
+  defp default_message(%{kind: :command_failed, exit_code: code}),
+    do: "claude exited with status #{code}"
+
+  defp default_message(%{kind: :io, reason: reason}),
+    do: "i/o error running claude: #{inspect(reason)}"
+
+  defp default_message(%{kind: :timeout, reason: ms}),
+    do: "claude timed out after #{ms}ms"
+
+  defp default_message(%{kind: :json}),
+    do: "could not decode claude JSON output"
+
+  defp default_message(%{kind: :max_turns_exceeded}),
+    do: "claude reached its maximum number of turns"
+
+  defp default_message(%{kind: :version_mismatch, reason: %{found: found, minimum: min}}),
+    do: "claude #{found} is older than the required minimum #{min}"
+
+  defp default_message(%{kind: :invalid_version, reason: original}),
+    do: "invalid version string: #{inspect(original)}"
+
+  defp default_message(%{kind: :budget_exceeded, reason: %{total_usd: total, max_usd: max}}),
+    do: "budget exceeded: $#{total} spent of $#{max} ceiling"
+
+  defp default_message(%{kind: :dangerous_not_allowed, reason: env}),
+    do: "dangerous operations require #{env}=1"
+
+  defp default_message(%{kind: :duplex_closed}), do: "the duplex session is closed"
+  defp default_message(%{kind: :turn_in_flight}), do: "a turn is already in flight"
+
+  defp default_message(%{kind: :duplex_control_failed, reason: reason}),
+    do: "duplex control message failed: #{inspect(reason)}"
+
+  defp default_message(%{kind: :terminated}), do: "the session terminated with a turn pending"
+
+  defp default_message(%{kind: :cannot_defer_again}),
+    do: "a deferred permission cannot defer again"
+
+  defp default_message(%{kind: :no_session}), do: "no active session"
+
+  defp default_message(%{kind: :not_found, reason: reason}) when not is_nil(reason),
+    do: "not found: #{inspect(reason)}"
+
+  defp default_message(%{kind: :not_found}), do: "not found"
+  defp default_message(%{kind: :already_exists, reason: r}), do: "already exists: #{inspect(r)}"
+  defp default_message(%{kind: :invalid_stem, reason: r}), do: "invalid identifier: #{inspect(r)}"
+  defp default_message(%{kind: :no_home}), do: "could not determine the user home directory"
+
+  defp default_message(%{kind: :invalid_settings_json, reason: %{path: path}}),
+    do: "settings file is not valid JSON: #{path}"
+
+  defp default_message(%{kind: :settings_read_error, reason: %{path: path}}),
+    do: "could not read settings file: #{path}"
+
+  defp default_message(%{kind: :not_a_git_repo, reason: path}),
+    do: "not a git repository: #{path}"
+
+  defp default_message(%{kind: :git_failed, reason: reason}),
+    do: "git failed: #{inspect(reason)}"
+
+  defp default_message(%{kind: :git_unavailable}), do: "the git binary is not available"
+
+  defp default_message(%{kind: :invalid_tool_pattern, reason: reason}),
+    do: "invalid tool pattern: #{inspect(reason)}"
+
+  defp default_message(%{kind: :auth, reason: reason}),
+    do: "authentication error: #{inspect(reason)}"
+
+  defp default_message(%{kind: kind}), do: "claude_wrapper error: #{kind}"
+end

--- a/lib/claude_wrapper/history.ex
+++ b/lib/claude_wrapper/history.ex
@@ -114,6 +114,7 @@ defmodule ClaudeWrapper.History do
       end
   """
 
+  alias ClaudeWrapper.Error
   alias ClaudeWrapper.History.{ProjectSummary, SessionLog, SessionSummary}
 
   @enforce_keys [:root]
@@ -174,12 +175,13 @@ defmodule ClaudeWrapper.History do
   @doc """
   Resolve the default history root, `~/.claude/projects`.
 
-  Returns `{:error, :no_home}` when the user home cannot be determined.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :no_home}}` when the user
+  home cannot be determined.
   """
-  @spec home() :: {:ok, t()} | {:error, :no_home}
+  @spec home() :: {:ok, t()} | {:error, Error.t()}
   def home do
     case System.user_home() do
-      nil -> {:error, :no_home}
+      nil -> {:error, Error.new(:no_home)}
       home -> {:ok, %__MODULE__{root: Path.join([home, ".claude", "projects"])}}
     end
   end
@@ -201,7 +203,7 @@ defmodule ClaudeWrapper.History do
   Returns `{:ok, []}` when the root directory does not exist. See
   `t:list_opt/0` for options.
   """
-  @spec list_projects(t(), [list_opt()]) :: {:ok, [ProjectSummary.t()]} | {:error, term()}
+  @spec list_projects(t(), [list_opt()]) :: {:ok, [ProjectSummary.t()]} | {:error, Error.t()}
   def list_projects(%__MODULE__{} = h, opts \\ []) do
     case File.ls(h.root) do
       {:ok, names} ->
@@ -220,7 +222,7 @@ defmodule ClaudeWrapper.History do
         {:ok, []}
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, Error.io(reason)}
     end
   end
 
@@ -230,7 +232,7 @@ defmodule ClaudeWrapper.History do
 
   When no `:slug` is given, every project directory is unioned.
   """
-  @spec list_sessions(t(), [list_opt()]) :: {:ok, [SessionSummary.t()]} | {:error, term()}
+  @spec list_sessions(t(), [list_opt()]) :: {:ok, [SessionSummary.t()]} | {:error, Error.t()}
   def list_sessions(%__MODULE__{} = h, opts \\ []) do
     with {:ok, dirs} <- session_dirs(h, Keyword.get(opts, :slug)) do
       sessions =
@@ -249,7 +251,7 @@ defmodule ClaudeWrapper.History do
   `project_slug/1`. Convenience over `list_sessions(h, slug: ...)`.
   """
   @spec sessions_for_path(t(), String.t(), [list_opt()]) ::
-          {:ok, [SessionSummary.t()]} | {:error, term()}
+          {:ok, [SessionSummary.t()]} | {:error, Error.t()}
   def sessions_for_path(%__MODULE__{} = h, cwd, opts \\ []) when is_binary(cwd) do
     list_sessions(h, Keyword.put(opts, :slug, project_slug(cwd)))
   end
@@ -258,9 +260,10 @@ defmodule ClaudeWrapper.History do
   Read one session's full entry log, searching every project directory
   for `<session_id>.jsonl`. Malformed lines are skipped.
 
-  Returns `{:error, :not_found}` when no session file matches.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :not_found}}` when no
+  session file matches.
   """
-  @spec read_session(t(), String.t()) :: {:ok, SessionLog.t()} | {:error, :not_found | term()}
+  @spec read_session(t(), String.t()) :: {:ok, SessionLog.t()} | {:error, Error.t()}
   def read_session(%__MODULE__{} = h, session_id) when is_binary(session_id) do
     case find_session(h, session_id) do
       {:ok, {path, slug}} -> {:ok, parse_session(path, session_id, slug)}
@@ -272,13 +275,18 @@ defmodule ClaudeWrapper.History do
   Locate the on-disk path and project slug for a session id, searching
   every project directory.
 
-  Returns `{:ok, {path, slug}}` or `{:error, :not_found}`.
+  Returns `{:ok, {path, slug}}` or `{:error, %ClaudeWrapper.Error{kind:
+  :not_found}}`.
   """
   @spec find_session(t(), String.t()) ::
-          {:ok, {String.t(), String.t()}} | {:error, :not_found | term()}
+          {:ok, {String.t(), String.t()}} | {:error, Error.t()}
   def find_session(%__MODULE__{} = h, session_id) when is_binary(session_id) do
     with {:ok, projects} <- list_projects(h) do
-      Enum.find_value(projects, {:error, :not_found}, &session_in_project(h, &1, session_id))
+      Enum.find_value(
+        projects,
+        {:error, Error.new(:not_found, reason: session_id)},
+        &session_in_project(h, &1, session_id)
+      )
     end
   end
 

--- a/lib/claude_wrapper/jobs.ex
+++ b/lib/claude_wrapper/jobs.ex
@@ -140,6 +140,7 @@ defmodule ClaudeWrapper.Jobs do
       end
   """
 
+  alias ClaudeWrapper.Error
   alias ClaudeWrapper.Jobs.{Event, Job, Summary}
 
   @enforce_keys [:root]
@@ -150,12 +151,13 @@ defmodule ClaudeWrapper.Jobs do
   @doc """
   Resolve the default jobs root, `~/.claude/jobs`.
 
-  Returns `{:error, :no_home}` when the user home cannot be determined.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :no_home}}` when the user
+  home cannot be determined.
   """
-  @spec home() :: {:ok, t()} | {:error, :no_home}
+  @spec home() :: {:ok, t()} | {:error, Error.t()}
   def home do
     case System.user_home() do
-      nil -> {:error, :no_home}
+      nil -> {:error, Error.new(:no_home)}
       home -> {:ok, %__MODULE__{root: Path.join([home, ".claude", "jobs"])}}
     end
   end
@@ -179,7 +181,7 @@ defmodule ClaudeWrapper.Jobs do
   entries that are not directories, that carry no `state.json`, or
   whose `state.json` fails to parse.
   """
-  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, term()}
+  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, Error.t()}
   def list(%__MODULE__{} = jobs) do
     case File.ls(jobs.root) do
       {:ok, names} ->
@@ -195,7 +197,7 @@ defmodule ClaudeWrapper.Jobs do
         {:ok, []}
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, Error.io(reason)}
     end
   end
 
@@ -204,18 +206,18 @@ defmodule ClaudeWrapper.Jobs do
   name) into a full `ClaudeWrapper.Jobs.Job`, including the parsed
   `timeline.jsonl` and the raw `state.json` map.
 
-  Returns `{:error, :not_found}` when no such directory exists or its
-  `state.json` is missing.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :not_found}}` when no such
+  directory exists or its `state.json` is missing.
   """
-  @spec get(t(), String.t()) :: {:ok, Job.t()} | {:error, :not_found | term()}
+  @spec get(t(), String.t()) :: {:ok, Job.t()} | {:error, Error.t()}
   def get(%__MODULE__{} = jobs, short_id) when is_binary(short_id) do
     dir = Path.join(jobs.root, short_id)
     state_path = Path.join(dir, "state.json")
 
     case File.read(state_path) do
       {:ok, raw} -> read_job(state_path, raw, dir, short_id)
-      {:error, :enoent} -> {:error, :not_found}
-      {:error, reason} -> {:error, reason}
+      {:error, :enoent} -> {:error, Error.new(:not_found, reason: short_id)}
+      {:error, reason} -> {:error, Error.io(reason)}
     end
   end
 
@@ -232,7 +234,7 @@ defmodule ClaudeWrapper.Jobs do
          }}
 
       :error ->
-        {:error, :not_found}
+        {:error, Error.new(:not_found, reason: short_id)}
     end
   end
 

--- a/lib/claude_wrapper/mcp_config.ex
+++ b/lib/claude_wrapper/mcp_config.ex
@@ -126,12 +126,30 @@ defmodule ClaudeWrapper.McpConfig do
 
   @doc """
   Read and parse an existing `.mcp.json` file.
+
+  Returns `{:error, %ClaudeWrapper.Error{kind: :io}}` when the file
+  cannot be read and `{:error, %ClaudeWrapper.Error{kind: :json}}` when
+  its contents are not valid JSON.
   """
-  @spec read(String.t()) :: {:ok, t()} | {:error, term()}
+  @spec read(String.t()) :: {:ok, t()} | {:error, ClaudeWrapper.Error.t()}
   def read(path) do
-    with {:ok, content} <- File.read(path),
-         {:ok, data} <- Jason.decode(content) do
+    with {:ok, content} <- read_file(path),
+         {:ok, data} <- decode_json(content) do
       {:ok, from_map(data)}
+    end
+  end
+
+  defp read_file(path) do
+    case File.read(path) do
+      {:ok, content} -> {:ok, content}
+      {:error, reason} -> {:error, ClaudeWrapper.Error.io(reason)}
+    end
+  end
+
+  defp decode_json(content) do
+    case Jason.decode(content) do
+      {:ok, data} -> {:ok, data}
+      {:error, reason} -> {:error, ClaudeWrapper.Error.json(reason)}
     end
   end
 

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -23,7 +23,7 @@ defmodule ClaudeWrapper.Query do
       |> Stream.run()
   """
 
-  alias ClaudeWrapper.{Command, Config, Result, StreamEvent, Telemetry}
+  alias ClaudeWrapper.{Auth, Command, Config, Error, Result, StreamEvent, Telemetry}
 
   @type permission_mode ::
           :default | :accept_edits | :bypass_permissions | :dont_ask | :plan | :auto
@@ -463,7 +463,7 @@ defmodule ClaudeWrapper.Query do
 
   Automatically sets `--output-format json` for parsing.
   """
-  @spec execute(t(), Config.t()) :: {:ok, Result.t()} | {:error, term()}
+  @spec execute(t(), Config.t()) :: {:ok, Result.t()} | {:error, Error.t()}
   def execute(%__MODULE__{} = query, %Config{} = config) do
     query = %{query | output_format: :json}
 
@@ -482,15 +482,49 @@ defmodule ClaudeWrapper.Query do
       {:ok, stdout} ->
         parse_json_output(stdout)
 
-      {:error, {:exit, code, stdout}} ->
-        # CLI may exit non-zero but still produce valid JSON (e.g. max_turns reached)
-        case parse_json_output(stdout) do
-          {:ok, result} -> {:ok, result}
-          {:error, _} -> {:error, {:exit, code, stdout}}
-        end
+      {:error, %Error{kind: :command_failed, exit_code: code, stdout: stdout}} ->
+        handle_nonzero_exit(code, stdout)
 
       {:error, _} = error ->
         error
+    end
+  end
+
+  # A non-zero CLI exit that still emits valid JSON is not always a hard
+  # failure: max-turns is the one case the CLI reports this way and we
+  # surface it as a typed error; any other valid-JSON result keeps its
+  # `is_error` flag and returns `{:ok, %Result{}}`. When the output is not
+  # decodable JSON the exit is a genuine command failure -- classified as
+  # an auth error first when it looks auth-shaped, otherwise plain.
+  defp handle_nonzero_exit(code, stdout) do
+    case parse_json_output(stdout) do
+      {:ok, result} ->
+        if max_turns_result?(result) do
+          {:error, Error.new(:max_turns_exceeded, exit_code: code, stdout: stdout)}
+        else
+          {:ok, result}
+        end
+
+      {:error, _} ->
+        classify_command_failure(code, stdout)
+    end
+  end
+
+  defp max_turns_result?(%Result{extra: extra}) do
+    Map.get(extra, "subtype") == "error_max_turns"
+  end
+
+  # A non-zero exit with no parseable JSON: run the auth classifier over
+  # the output and, when it recognizes an auth-shaped failure, surface a
+  # typed `:auth` error carrying the classified kind in `:reason`.
+  # Otherwise fall back to a plain `:command_failed`.
+  defp classify_command_failure(code, stdout) do
+    case Auth.classify_failure(code, stdout, "") do
+      nil ->
+        {:error, Error.command_failed(code, stdout)}
+
+      kind ->
+        {:error, Error.new(:auth, reason: kind, exit_code: code, stdout: stdout)}
     end
   end
 
@@ -668,7 +702,7 @@ defmodule ClaudeWrapper.Query do
 
     case Jason.decode(json_line) do
       {:ok, data} -> {:ok, Result.from_json(data)}
-      {:error, reason} -> {:error, {:json_decode, reason, stdout}}
+      {:error, reason} -> {:error, Error.json(reason, stdout)}
     end
   end
 
@@ -686,10 +720,10 @@ defmodule ClaudeWrapper.Query do
   defp run_cmd(binary, args, opts, nil) do
     case System.cmd(binary, args, opts) do
       {stdout, 0} -> {:ok, stdout}
-      {stdout, code} -> {:error, {:exit, code, stdout}}
+      {stdout, code} -> {:error, Error.command_failed(code, stdout)}
     end
   rescue
-    e in ErlangError -> {:error, {:system_cmd, e}}
+    e in ErlangError -> {:error, Error.io(e)}
   end
 
   defp run_cmd(binary, args, opts, timeout) do
@@ -697,8 +731,8 @@ defmodule ClaudeWrapper.Query do
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
       {:ok, {stdout, 0}} -> {:ok, stdout}
-      {:ok, {stdout, code}} -> {:error, {:exit, code, stdout}}
-      nil -> {:error, {:timeout, timeout}}
+      {:ok, {stdout, code}} -> {:error, Error.command_failed(code, stdout)}
+      nil -> {:error, Error.timeout(timeout)}
     end
   end
 

--- a/lib/claude_wrapper/retry.ex
+++ b/lib/claude_wrapper/retry.ex
@@ -16,16 +16,15 @@ defmodule ClaudeWrapper.Retry do
 
       # With custom retry predicate
       {:ok, result} = ClaudeWrapper.Retry.execute(query, config,
-        max_retries: 5,
         retry_on: fn
-          {:error, {:exit, 1, _}} -> true
-          {:error, {:timeout, _}} -> true
+          {:error, %ClaudeWrapper.Error{kind: :command_failed, exit_code: 1}} -> true
+          {:error, %ClaudeWrapper.Error{kind: :timeout}} -> true
           _ -> false
         end
       )
   """
 
-  alias ClaudeWrapper.{Config, Query, Result}
+  alias ClaudeWrapper.{Config, Error, Query, Result}
 
   @type opts :: [
           max_retries: non_neg_integer(),
@@ -117,7 +116,11 @@ defmodule ClaudeWrapper.Retry do
     end
   end
 
-  defp default_retry_on({:error, {:timeout, _}}), do: true
-  defp default_retry_on({:error, {:exit, code, _}}) when code != 0, do: true
+  defp default_retry_on({:error, %Error{kind: :timeout}}), do: true
+
+  defp default_retry_on({:error, %Error{kind: :command_failed, exit_code: code}})
+       when code != 0,
+       do: true
+
   defp default_retry_on(_), do: false
 end

--- a/lib/claude_wrapper/settings.ex
+++ b/lib/claude_wrapper/settings.ex
@@ -33,6 +33,8 @@ defmodule ClaudeWrapper.Settings do
       end
   """
 
+  alias ClaudeWrapper.Error
+
   @enforce_keys [:user, :user_local, :project, :project_local, :paths]
   defstruct [:user, :user_local, :project, :project_local, :paths]
 
@@ -66,11 +68,12 @@ defmodule ClaudeWrapper.Settings do
       project layers (default: none, so the project layers stay `nil`)
 
   Missing files become `nil`; a malformed JSON file returns
-  `{:error, {:invalid_settings_json, path, reason}}`. Returns
-  `{:error, :no_home}` when `:user_root` is omitted and the home
-  directory cannot be determined.
+  `{:error, %ClaudeWrapper.Error{kind: :invalid_settings_json}}` (with
+  `:reason` `%{path:, error:}`). Returns `{:error,
+  %ClaudeWrapper.Error{kind: :no_home}}` when `:user_root` is omitted
+  and the home directory cannot be determined.
   """
-  @spec load(keyword()) :: {:ok, t()} | {:error, term()}
+  @spec load(keyword()) :: {:ok, t()} | {:error, Error.t()}
   def load(opts \\ []) do
     with {:ok, user_root} <- resolve_user_root(opts) do
       paths = build_paths(user_root, Keyword.get(opts, :project_root))
@@ -125,7 +128,7 @@ defmodule ClaudeWrapper.Settings do
     case Keyword.get(opts, :user_root) do
       nil ->
         case System.user_home() do
-          nil -> {:error, :no_home}
+          nil -> {:error, Error.new(:no_home)}
           home -> {:ok, Path.join(home, ".claude")}
         end
 
@@ -147,16 +150,24 @@ defmodule ClaudeWrapper.Settings do
 
   defp read_layer(path) do
     case File.read(path) do
-      {:ok, raw} -> decode_layer(path, raw)
-      {:error, :enoent} -> {:ok, nil}
-      {:error, reason} -> {:error, {:settings_read_error, path, reason}}
+      {:ok, raw} ->
+        decode_layer(path, raw)
+
+      {:error, :enoent} ->
+        {:ok, nil}
+
+      {:error, reason} ->
+        {:error, Error.new(:settings_read_error, reason: %{path: path, error: reason})}
     end
   end
 
   defp decode_layer(path, raw) do
     case Jason.decode(raw) do
-      {:ok, value} -> {:ok, value}
-      {:error, reason} -> {:error, {:invalid_settings_json, path, reason}}
+      {:ok, value} ->
+        {:ok, value}
+
+      {:error, reason} ->
+        {:error, Error.new(:invalid_settings_json, reason: %{path: path, error: reason})}
     end
   end
 end

--- a/lib/claude_wrapper/skills.ex
+++ b/lib/claude_wrapper/skills.ex
@@ -132,6 +132,7 @@ defmodule ClaudeWrapper.Skills do
       IO.puts(skill.body)
   """
 
+  alias ClaudeWrapper.Error
   alias ClaudeWrapper.Skills.{Skill, Summary}
 
   @skill_file "SKILL.md"
@@ -144,12 +145,13 @@ defmodule ClaudeWrapper.Skills do
   @doc """
   Resolve the default skills root, `~/.claude/skills`.
 
-  Returns `{:error, :no_home}` when the user home cannot be determined.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :no_home}}` when the user
+  home cannot be determined.
   """
-  @spec home() :: {:ok, t()} | {:error, :no_home}
+  @spec home() :: {:ok, t()} | {:error, Error.t()}
   def home do
     case System.user_home() do
-      nil -> {:error, :no_home}
+      nil -> {:error, Error.new(:no_home)}
       home -> {:ok, %__MODULE__{root: Path.join([home, ".claude", "skills"])}}
     end
   end
@@ -175,7 +177,7 @@ defmodule ClaudeWrapper.Skills do
   `SKILL.md` fails to read are skipped rather than failing the whole
   listing.
   """
-  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, term()}
+  @spec list(t()) :: {:ok, [Summary.t()]} | {:error, Error.t()}
   def list(%__MODULE__{} = s) do
     case File.ls(s.root) do
       {:ok, names} ->
@@ -191,7 +193,7 @@ defmodule ClaudeWrapper.Skills do
         {:ok, []}
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, Error.io(reason)}
     end
   end
 
@@ -199,18 +201,18 @@ defmodule ClaudeWrapper.Skills do
   Read one skill by directory stem (the basename of the `<dir_stem>/`
   directory under the root) into a full `Skill`.
 
-  Returns `{:error, :not_found}` when no such directory exists or it has
-  no `SKILL.md`.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :not_found}}` when no such
+  directory exists or it has no `SKILL.md`.
   """
-  @spec get(t(), String.t()) :: {:ok, Skill.t()} | {:error, :not_found | term()}
+  @spec get(t(), String.t()) :: {:ok, Skill.t()} | {:error, Error.t()}
   def get(%__MODULE__{} = s, dir_stem) when is_binary(dir_stem) do
     dir = Path.join(s.root, dir_stem)
     path = Path.join(dir, @skill_file)
 
     case File.read(path) do
       {:ok, raw} -> {:ok, parse_skill(raw, dir_stem, dir, path)}
-      {:error, :enoent} -> {:error, :not_found}
-      {:error, reason} -> {:error, reason}
+      {:error, :enoent} -> {:error, Error.new(:not_found, reason: dir_stem)}
+      {:error, reason} -> {:error, Error.io(reason)}
     end
   end
 

--- a/lib/claude_wrapper/stream_event.ex
+++ b/lib/claude_wrapper/stream_event.ex
@@ -65,7 +65,7 @@ defmodule ClaudeWrapper.StreamEvent do
   @doc """
   Parse a single NDJSON line into a stream event.
   """
-  @spec parse(String.t()) :: {:ok, t()} | {:error, term()}
+  @spec parse(String.t()) :: {:ok, t()} | {:error, ClaudeWrapper.Error.t()}
   def parse(line) when is_binary(line) do
     case Jason.decode(line) do
       {:ok, data} when is_map(data) ->
@@ -77,10 +77,10 @@ defmodule ClaudeWrapper.StreamEvent do
          }}
 
       {:ok, _other} ->
-        {:error, :not_an_object}
+        {:error, ClaudeWrapper.Error.json(:not_an_object)}
 
       {:error, reason} ->
-        {:error, {:json_decode, reason}}
+        {:error, ClaudeWrapper.Error.json(reason)}
     end
   end
 

--- a/lib/claude_wrapper/telemetry.ex
+++ b/lib/claude_wrapper/telemetry.ex
@@ -71,7 +71,7 @@ defmodule ClaudeWrapper.Telemetry do
       )
   """
 
-  alias ClaudeWrapper.{Query, Result, StreamEvent}
+  alias ClaudeWrapper.{Error, Query, Result, StreamEvent}
 
   @type metadata :: %{optional(atom()) => term()}
 
@@ -173,7 +173,7 @@ defmodule ClaudeWrapper.Telemetry do
     }
   end
 
-  defp exec_stop_metadata({:error, {:exit, code, _stdout}}) do
+  defp exec_stop_metadata({:error, %Error{exit_code: code}}) do
     %{cost_usd: nil, exit_code: code}
   end
 
@@ -189,7 +189,7 @@ defmodule ClaudeWrapper.Telemetry do
     }
   end
 
-  defp session_turn_stop_metadata({:error, {:exit, code, _stdout}}) do
+  defp session_turn_stop_metadata({:error, %Error{exit_code: code}}) do
     %{cost_usd: nil, exit_code: code}
   end
 

--- a/lib/claude_wrapper/tool_pattern.ex
+++ b/lib/claude_wrapper/tool_pattern.ex
@@ -42,7 +42,9 @@ defmodule ClaudeWrapper.ToolPattern do
   @type t :: %__MODULE__{value: String.t()}
 
   @typedoc """
-  Errors from `parse/1`.
+  The specific validation problem behind a `parse/1` failure, carried in
+  the `:reason` field of the returned `t:ClaudeWrapper.Error.t/0` (kind
+  `:invalid_tool_pattern`).
 
     * `:empty` -- input was empty or all whitespace.
     * `:missing_name` -- the tool-name part was empty (e.g. `(args)`
@@ -53,7 +55,7 @@ defmodule ClaudeWrapper.ToolPattern do
       or a control char (can break the shell). Carries the trimmed
       input.
   """
-  @type pattern_error ::
+  @type problem ::
           :empty
           | :missing_name
           | {:unbalanced_parens, String.t()}
@@ -121,18 +123,20 @@ defmodule ClaudeWrapper.ToolPattern do
   whitespace is trimmed before validation, so leading/trailing control
   characters do not trip `{:illegal_char, _}`.
 
-  Returns `{:ok, t}` or `{:error, t:pattern_error/0}`.
+  Returns `{:ok, t}` or `{:error, %ClaudeWrapper.Error{kind:
+  :invalid_tool_pattern}}` whose `:reason` is the specific
+  `t:problem/0`.
 
       iex> ClaudeWrapper.ToolPattern.parse("Bash(git log:*)")
       {:ok, %ClaudeWrapper.ToolPattern{value: "Bash(git log:*)"}}
 
       iex> ClaudeWrapper.ToolPattern.parse("")
-      {:error, :empty}
+      {:error, %ClaudeWrapper.Error{kind: :invalid_tool_pattern, reason: :empty}}
 
       iex> ClaudeWrapper.ToolPattern.parse("(args)")
-      {:error, :missing_name}
+      {:error, %ClaudeWrapper.Error{kind: :invalid_tool_pattern, reason: :missing_name}}
   """
-  @spec parse(String.t()) :: {:ok, t()} | {:error, pattern_error()}
+  @spec parse(String.t()) :: {:ok, t()} | {:error, ClaudeWrapper.Error.t()}
   def parse(input) when is_binary(input) do
     trimmed = String.trim(input)
 
@@ -140,6 +144,9 @@ defmodule ClaudeWrapper.ToolPattern do
          :ok <- check_legal_chars(trimmed),
          :ok <- check_parens(trimmed) do
       {:ok, %__MODULE__{value: trimmed}}
+    else
+      {:error, problem} ->
+        {:error, ClaudeWrapper.Error.new(:invalid_tool_pattern, reason: problem)}
     end
   end
 

--- a/lib/claude_wrapper/worktrees.ex
+++ b/lib/claude_wrapper/worktrees.ex
@@ -67,6 +67,7 @@ defmodule ClaudeWrapper.Worktrees do
       end
   """
 
+  alias ClaudeWrapper.Error
   alias ClaudeWrapper.Worktrees.Worktree
 
   @enforce_keys [:repo_path]
@@ -81,12 +82,13 @@ defmodule ClaudeWrapper.Worktrees do
   resolves the `.git` itself. Runs `git worktree list --porcelain` once
   to validate that `path` is in fact inside a git repository.
 
-  Returns `{:error, {:not_a_git_repo, path}}` when `path` is not inside a
-  repository, `{:error, {:git_failed, exit_status, stderr}}` for other
-  non-zero git exits, and `{:error, {:git_unavailable, reason}}` when the
-  `git` binary cannot be spawned.
+  Returns `{:error, %ClaudeWrapper.Error{kind: :not_a_git_repo}}` when
+  `path` is not inside a repository (the path is in `:reason`),
+  `{:error, %ClaudeWrapper.Error{kind: :git_failed}}` for other non-zero
+  git exits, and `{:error, %ClaudeWrapper.Error{kind: :git_unavailable}}`
+  when the `git` binary cannot be spawned.
   """
-  @spec for_repo(String.t()) :: {:ok, t()} | {:error, term()}
+  @spec for_repo(String.t()) :: {:ok, t()} | {:error, Error.t()}
   def for_repo(path) when is_binary(path) do
     root = %__MODULE__{repo_path: path}
 
@@ -108,7 +110,7 @@ defmodule ClaudeWrapper.Worktrees do
 
   Returns the same error shapes as `for_repo/1`.
   """
-  @spec list(t()) :: {:ok, [Worktree.t()]} | {:error, term()}
+  @spec list(t()) :: {:ok, [Worktree.t()]} | {:error, Error.t()}
   def list(%__MODULE__{} = root) do
     case run_porcelain(root) do
       {:ok, stdout} -> {:ok, parse_porcelain(stdout)}
@@ -133,14 +135,20 @@ defmodule ClaudeWrapper.Worktrees do
   defp safe_cmd(args) do
     {:ok, System.cmd("git", args, stderr_to_stdout: true)}
   rescue
-    e in ErlangError -> {:error, {:git_unavailable, e.original}}
+    e in ErlangError -> {:error, Error.new(:git_unavailable, reason: e.original)}
   end
 
   defp classify_failure(repo_path, status, output) do
     if String.contains?(output, "not a git repository") do
-      {:not_a_git_repo, repo_path}
+      Error.new(:not_a_git_repo, reason: repo_path)
     else
-      {:git_failed, status, String.trim(output)}
+      stderr = String.trim(output)
+
+      Error.new(:git_failed,
+        reason: %{status: status, stderr: stderr},
+        exit_code: status,
+        stderr: stderr
+      )
     end
   end
 

--- a/test/claude_wrapper/agents_test.exs
+++ b/test/claude_wrapper/agents_test.exs
@@ -125,9 +125,11 @@ defmodule ClaudeWrapper.AgentsTest do
       assert agent.extra == %{}
     end
 
-    test "unknown stem returns {:error, :not_found}", %{root: root} do
+    test "unknown stem returns a :not_found error", %{root: root} do
       fixture(root)
-      assert Agents.get(Agents.at(root), "nope") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "nope"}} =
+               Agents.get(Agents.at(root), "nope")
     end
 
     test "extra frontmatter keys round-trip as raw strings", %{root: root} do
@@ -275,15 +277,18 @@ defmodule ClaudeWrapper.AgentsTest do
       a = Agents.at(root)
 
       for bad <- ["", ".", "..", "a/b", "a\\b", "a\0b"] do
-        assert Agents.write(a, bad, body: "b") == {:error, {:invalid_stem, bad}}
+        assert {:error, %ClaudeWrapper.Error{kind: :invalid_stem, reason: ^bad}} =
+                 Agents.write(a, bad, body: "b")
       end
     end
   end
 
   describe "write_new/3" do
-    test "errors with {:error, :exists} when the agent already exists", %{root: root} do
+    test "errors with an :already_exists error when the agent already exists", %{root: root} do
       fixture(root)
-      assert Agents.write_new(Agents.at(root), "rust-qa", body: "body") == {:error, :exists}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :already_exists, reason: "rust-qa"}} =
+               Agents.write_new(Agents.at(root), "rust-qa", body: "body")
     end
 
     test "succeeds for a fresh stem", %{root: root} do
@@ -295,8 +300,8 @@ defmodule ClaudeWrapper.AgentsTest do
     end
 
     test "rejects path-traversal stems before touching the filesystem", %{root: root} do
-      assert Agents.write_new(Agents.at(root), "a/b", body: "b") ==
-               {:error, {:invalid_stem, "a/b"}}
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_stem, reason: "a/b"}} =
+               Agents.write_new(Agents.at(root), "a/b", body: "b")
     end
   end
 
@@ -307,19 +312,24 @@ defmodule ClaudeWrapper.AgentsTest do
 
       assert {:ok, _} = Agents.get(a, "rust-qa")
       assert :ok = Agents.delete(a, "rust-qa")
-      assert Agents.get(a, "rust-qa") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "rust-qa"}} =
+               Agents.get(a, "rust-qa")
     end
 
-    test "unknown stem returns {:error, :not_found}", %{root: root} do
+    test "unknown stem returns a :not_found error", %{root: root} do
       fixture(root)
-      assert Agents.delete(Agents.at(root), "nope") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "nope"}} =
+               Agents.delete(Agents.at(root), "nope")
     end
 
     test "rejects path-traversal stems", %{root: root} do
       a = Agents.at(root)
 
       for bad <- ["", ".", "..", "a/b", "a\\b"] do
-        assert Agents.delete(a, bad) == {:error, {:invalid_stem, bad}}
+        assert {:error, %ClaudeWrapper.Error{kind: :invalid_stem, reason: ^bad}} =
+                 Agents.delete(a, bad)
       end
     end
   end

--- a/test/claude_wrapper/budget_test.exs
+++ b/test/claude_wrapper/budget_test.exs
@@ -67,7 +67,13 @@ defmodule ClaudeWrapper.BudgetTest do
 
       # total 0.10 -> at the threshold (>=) crosses it
       Budget.record(b, 0.05)
-      assert {:error, {:budget_exceeded, total, max}} = Budget.check(b)
+
+      assert {:error,
+              %ClaudeWrapper.Error{
+                kind: :budget_exceeded,
+                reason: %{total_usd: total, max_usd: max}
+              }} = Budget.check(b)
+
       assert_in_delta total, 0.10, 1.0e-9
       assert_in_delta max, 0.10, 1.0e-9
     end
@@ -151,7 +157,7 @@ defmodule ClaudeWrapper.BudgetTest do
       Budget.record(b, 0.25)
       assert_receive :warned
       assert_receive :exceeded
-      assert {:error, {:budget_exceeded, _, _}} = Budget.check(b)
+      assert {:error, %ClaudeWrapper.Error{kind: :budget_exceeded}} = Budget.check(b)
 
       assert :ok = Budget.reset(b)
       assert Budget.total(b) == 0.0
@@ -170,7 +176,7 @@ defmodule ClaudeWrapper.BudgetTest do
       {:ok, _pid} = Budget.start_link(name: name, max_usd: 0.10)
 
       assert :ok = Budget.record(name, 0.20)
-      assert {:error, {:budget_exceeded, _, _}} = Budget.check(name)
+      assert {:error, %ClaudeWrapper.Error{kind: :budget_exceeded}} = Budget.check(name)
     end
   end
 end

--- a/test/claude_wrapper/cli_version_test.exs
+++ b/test/claude_wrapper/cli_version_test.exs
@@ -32,27 +32,33 @@ defmodule ClaudeWrapper.CliVersionTest do
     end
 
     test "rejects non-version text, carrying the original string" do
-      assert {:error, {:invalid_version, "not-a-version"}} = CliVersion.parse("not-a-version")
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_version, reason: "not-a-version"}} =
+               CliVersion.parse("not-a-version")
     end
 
     test "rejects a two-part version" do
-      assert {:error, {:invalid_version, "2.1"}} = CliVersion.parse("2.1")
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_version, reason: "2.1"}} =
+               CliVersion.parse("2.1")
     end
 
     test "rejects a non-numeric component" do
-      assert {:error, {:invalid_version, "2.1.x"}} = CliVersion.parse("2.1.x")
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_version, reason: "2.1.x"}} =
+               CliVersion.parse("2.1.x")
     end
 
     test "rejects a four-part version" do
-      assert {:error, {:invalid_version, "1.2.3.4"}} = CliVersion.parse("1.2.3.4")
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_version, reason: "1.2.3.4"}} =
+               CliVersion.parse("1.2.3.4")
     end
 
     test "rejects an empty string" do
-      assert {:error, {:invalid_version, ""}} = CliVersion.parse("")
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_version, reason: ""}} =
+               CliVersion.parse("")
     end
 
     test "the error keeps the untrimmed original" do
-      assert {:error, {:invalid_version, "  bad\n"}} = CliVersion.parse("  bad\n")
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_version, reason: "  bad\n"}} =
+               CliVersion.parse("  bad\n")
     end
   end
 
@@ -161,8 +167,11 @@ defmodule ClaudeWrapper.CliVersionTest do
       found = CliVersion.new(2, 1, 71)
       minimum = CliVersion.new(2, 2, 0)
 
-      assert CliVersion.check_version(found, minimum) ==
-               {:error, {:version_mismatch, found, minimum}}
+      assert {:error,
+              %ClaudeWrapper.Error{
+                kind: :version_mismatch,
+                reason: %{found: ^found, minimum: ^minimum}
+              }} = CliVersion.check_version(found, minimum)
     end
   end
 end

--- a/test/claude_wrapper/conversation_test.exs
+++ b/test/claude_wrapper/conversation_test.exs
@@ -123,7 +123,7 @@ defmodule ClaudeWrapper.ConversationTest do
       end
     end
 
-    test "propagates :turn_in_flight without recording a turn" do
+    test "propagates a :turn_in_flight error without recording a turn" do
       pid = start_with_fake_claude()
 
       try do
@@ -146,16 +146,18 @@ defmodule ClaudeWrapper.ConversationTest do
         end)
 
         # A second concurrent send must be rejected, leaving history empty.
-        assert {:error, :turn_in_flight} = Conversation.send(conv, "second", 1_000)
+        assert {:error, %ClaudeWrapper.Error{kind: :turn_in_flight}} =
+                 Conversation.send(conv, "second", 1_000)
+
         assert Conversation.turn_count(conv) == 0
       after
         DuplexSession.stop(pid)
       end
     end
 
-    test "propagates :port_closed without recording a turn" do
+    test "propagates a :duplex_closed error without recording a turn" do
       # A session whose port has been closed but whose GenServer is still
-      # alive replies {:error, :port_closed}. We reach that state by
+      # alive replies {:error, %Error{kind: :duplex_closed}}. We reach that state by
       # nil-ing the port via :sys.replace_state, which leaves the
       # GenServer running so it can answer the call.
       pid = start_with_fake_claude()
@@ -173,7 +175,9 @@ defmodule ClaudeWrapper.ConversationTest do
           %{state | port: nil}
         end)
 
-        assert {:error, :port_closed} = Conversation.send(conv, "hello", 1_000)
+        assert {:error, %ClaudeWrapper.Error{kind: :duplex_closed}} =
+                 Conversation.send(conv, "hello", 1_000)
+
         assert Conversation.turn_count(conv) == 0
       after
         DuplexSession.stop(pid)

--- a/test/claude_wrapper/dangerous_client_test.exs
+++ b/test/claude_wrapper/dangerous_client_test.exs
@@ -32,16 +32,16 @@ defmodule ClaudeWrapper.DangerousClientTest do
     test "errors when the env var is unset" do
       System.delete_env(@allow_env)
 
-      assert DangerousClient.new(Config.new()) ==
-               {:error, {:dangerous_not_allowed, @allow_env}}
+      assert {:error, %ClaudeWrapper.Error{kind: :dangerous_not_allowed, reason: @allow_env}} =
+               DangerousClient.new(Config.new())
     end
 
     test "errors when the env var is set to something other than \"1\"" do
       for value <- ["0", "true", "yes", ""] do
         System.put_env(@allow_env, value)
 
-        assert DangerousClient.new(Config.new()) ==
-                 {:error, {:dangerous_not_allowed, @allow_env}},
+        assert {:error, %ClaudeWrapper.Error{kind: :dangerous_not_allowed, reason: @allow_env}} =
+                 DangerousClient.new(Config.new()),
                "expected the gate to stay closed for #{inspect(value)}"
       end
     end

--- a/test/claude_wrapper/duplex_iex_test.exs
+++ b/test/claude_wrapper/duplex_iex_test.exs
@@ -47,14 +47,20 @@ defmodule ClaudeWrapper.DuplexIExTest do
 
   describe "say/2" do
     test "prints error when no session is active" do
-      output = capture_io(fn -> assert {:error, :no_session} = DuplexIEx.say("hi") end)
+      output =
+        capture_io(fn ->
+          assert {:error, %ClaudeWrapper.Error{kind: :no_session}} = DuplexIEx.say("hi")
+        end)
+
       assert output =~ "No active session"
     end
   end
 
   describe "interrupt/1" do
-    test "returns :no_session when no session is active" do
-      capture_io(fn -> assert {:error, :no_session} = DuplexIEx.interrupt() end)
+    test "returns a :no_session error when no session is active" do
+      capture_io(fn ->
+        assert {:error, %ClaudeWrapper.Error{kind: :no_session}} = DuplexIEx.interrupt()
+      end)
     end
   end
 

--- a/test/claude_wrapper/duplex_session_test.exs
+++ b/test/claude_wrapper/duplex_session_test.exs
@@ -328,7 +328,7 @@ defmodule ClaudeWrapper.DuplexSessionTest do
         assert :ok = DuplexSession.respond_to_permission(pid, "deferred-1", :allow)
 
         # Calling respond_to_permission with :defer is rejected.
-        assert {:error, :cannot_defer_again} =
+        assert {:error, %ClaudeWrapper.Error{kind: :cannot_defer_again}} =
                  DuplexSession.respond_to_permission(pid, "deferred-1", :defer)
       after
         DuplexSession.stop(pid)
@@ -474,7 +474,10 @@ defmodule ClaudeWrapper.DuplexSessionTest do
           }
         })
 
-        assert_receive {:interrupt_returned, {:error, "boom"}}, 5_000
+        assert_receive {:interrupt_returned,
+                        {:error,
+                         %ClaudeWrapper.Error{kind: :duplex_control_failed, reason: "boom"}}},
+                       5_000
       after
         if Process.alive?(caller), do: Process.exit(caller, :kill)
         DuplexSession.stop(pid)

--- a/test/claude_wrapper/error_test.exs
+++ b/test/claude_wrapper/error_test.exs
@@ -1,0 +1,141 @@
+defmodule ClaudeWrapper.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Error
+
+  doctest ClaudeWrapper.Error
+
+  describe "new/2" do
+    test "builds an error with just a kind" do
+      error = Error.new(:no_session)
+
+      assert %Error{kind: :no_session} = error
+      assert error.message == nil
+      assert error.reason == nil
+      assert error.exit_code == nil
+      assert error.stdout == nil
+      assert error.stderr == nil
+    end
+
+    test "carries optional fields through" do
+      error =
+        Error.new(:auth,
+          reason: :invalid_credentials,
+          exit_code: 1,
+          stdout: "out",
+          stderr: "err",
+          message: "custom"
+        )
+
+      assert %Error{
+               kind: :auth,
+               reason: :invalid_credentials,
+               exit_code: 1,
+               stdout: "out",
+               stderr: "err",
+               message: "custom"
+             } = error
+    end
+
+    test "is an exception struct" do
+      assert Exception.exception?(Error.new(:timeout, reason: 1_000))
+    end
+  end
+
+  describe "command_failed/3" do
+    test "sets kind, exit_code and stdout" do
+      assert %Error{kind: :command_failed, exit_code: 2, stdout: "boom", stderr: nil} =
+               Error.command_failed(2, "boom")
+    end
+
+    test "captures stderr when given" do
+      assert %Error{kind: :command_failed, exit_code: 2, stdout: "out", stderr: "err"} =
+               Error.command_failed(2, "out", "err")
+    end
+  end
+
+  describe "timeout/1" do
+    test "carries the elapsed ms in :reason" do
+      assert %Error{kind: :timeout, reason: 30_000} = Error.timeout(30_000)
+    end
+  end
+
+  describe "json/2" do
+    test "wraps a decode reason" do
+      assert %Error{kind: :json, reason: :reason, stdout: nil} = Error.json(:reason)
+    end
+
+    test "optionally carries the raw stdout" do
+      assert %Error{kind: :json, reason: :reason, stdout: "{bad"} = Error.json(:reason, "{bad")
+    end
+  end
+
+  describe "io/1" do
+    test "wraps an underlying reason" do
+      assert %Error{kind: :io, reason: :enoent} = Error.io(:enoent)
+    end
+  end
+
+  describe "message/1" do
+    test "returns an explicit message verbatim" do
+      assert Error.message(Error.new(:command_failed, message: "explicit")) == "explicit"
+    end
+
+    test "derives a default for :command_failed from the exit code" do
+      assert Error.message(Error.command_failed(2, "boom")) == "claude exited with status 2"
+    end
+
+    test "derives a default for :timeout from the elapsed ms" do
+      assert Error.message(Error.timeout(5_000)) == "claude timed out after 5000ms"
+    end
+
+    test "derives a default for :max_turns_exceeded" do
+      assert Error.message(Error.new(:max_turns_exceeded)) =~ "maximum number of turns"
+    end
+
+    test "derives a default for :not_found with and without a reason" do
+      assert Error.message(Error.new(:not_found, reason: "auditor")) =~ "auditor"
+      assert Error.message(Error.new(:not_found)) == "not found"
+    end
+
+    test "derives a default for :version_mismatch from the reason map" do
+      found = %ClaudeWrapper.CliVersion{major: 2, minor: 1, patch: 71}
+      minimum = %ClaudeWrapper.CliVersion{major: 2, minor: 2, patch: 0}
+
+      message =
+        Error.message(Error.new(:version_mismatch, reason: %{found: found, minimum: minimum}))
+
+      assert message =~ "2.1.71"
+      assert message =~ "2.2.0"
+    end
+
+    test "derives a default for :budget_exceeded from the reason map" do
+      message =
+        Error.message(Error.new(:budget_exceeded, reason: %{total_usd: 5.0, max_usd: 4.0}))
+
+      assert message =~ "5.0"
+      assert message =~ "4.0"
+    end
+
+    test "falls back to a generic message for an unmapped kind" do
+      assert Error.message(Error.new(:duplex_closed)) =~ "duplex"
+    end
+  end
+
+  describe "raising" do
+    test "raise/2 accepts the exception with options" do
+      assert_raise Error, "claude timed out after 1000ms", fn ->
+        raise Error, kind: :timeout, reason: 1_000
+      end
+    end
+
+    test "the struct can be raised directly and surfaces its message" do
+      error = Error.command_failed(7, "nope")
+
+      raised =
+        assert_raise Error, fn -> raise error end
+
+      assert Exception.message(raised) == "claude exited with status 7"
+    end
+  end
+end

--- a/test/claude_wrapper/history_test.exs
+++ b/test/claude_wrapper/history_test.exs
@@ -214,8 +214,9 @@ defmodule ClaudeWrapper.HistoryTest do
       assert raw["operation"] == "enqueue"
     end
 
-    test "read_session unknown id returns {:error, :not_found}", %{root: root} do
-      assert History.read_session(History.at(root), "nope") == {:error, :not_found}
+    test "read_session unknown id returns a :not_found error", %{root: root} do
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "nope"}} =
+               History.read_session(History.at(root), "nope")
     end
 
     test "find_session locates a real session and rejects unknown ids", %{root: root} do
@@ -225,7 +226,9 @@ defmodule ClaudeWrapper.HistoryTest do
 
       assert {:ok, {path, "-projB"}} = History.find_session(h, "session-ccc")
       assert String.ends_with?(path, "session-ccc.jsonl")
-      assert History.find_session(h, "missing") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "missing"}} =
+               History.find_session(h, "missing")
     end
   end
 

--- a/test/claude_wrapper/jobs_test.exs
+++ b/test/claude_wrapper/jobs_test.exs
@@ -152,19 +152,25 @@ defmodule ClaudeWrapper.JobsTest do
       assert job.timeline == []
     end
 
-    test "unknown id returns {:error, :not_found}", %{root: root} do
+    test "unknown id returns a :not_found error", %{root: root} do
       fixture(root)
-      assert Jobs.get(Jobs.at(root), "nope") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "nope"}} =
+               Jobs.get(Jobs.at(root), "nope")
     end
 
-    test "dir present but state.json missing returns {:error, :not_found}", %{root: root} do
+    test "dir present but state.json missing returns a :not_found error", %{root: root} do
       File.mkdir_p!(Path.join(root, "cccccccc"))
-      assert Jobs.get(Jobs.at(root), "cccccccc") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "cccccccc"}} =
+               Jobs.get(Jobs.at(root), "cccccccc")
     end
 
-    test "malformed state.json returns {:error, :not_found}", %{root: root} do
+    test "malformed state.json returns a :not_found error", %{root: root} do
       write_job(root, "deadbeef", "not valid json {{")
-      assert Jobs.get(Jobs.at(root), "deadbeef") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "deadbeef"}} =
+               Jobs.get(Jobs.at(root), "deadbeef")
     end
 
     test "timeline skips blank and malformed lines without failing", %{root: root} do

--- a/test/claude_wrapper/settings_test.exs
+++ b/test/claude_wrapper/settings_test.exs
@@ -68,7 +68,7 @@ defmodule ClaudeWrapper.SettingsTest do
     test "malformed JSON returns an error", %{user_root: user_root} do
       File.write!(Path.join(user_root, "settings.json"), "{not json")
 
-      assert {:error, {:invalid_settings_json, path, _reason}} =
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_settings_json, reason: %{path: path}}} =
                Settings.load(user_root: user_root)
 
       assert path == Path.join(user_root, "settings.json")

--- a/test/claude_wrapper/skills_test.exs
+++ b/test/claude_wrapper/skills_test.exs
@@ -150,9 +150,11 @@ defmodule ClaudeWrapper.SkillsTest do
       assert skill.extra == %{}
     end
 
-    test "unknown stem returns {:error, :not_found}", %{root: root} do
+    test "unknown stem returns a :not_found error", %{root: root} do
       fixture(root)
-      assert Skills.get(Skills.at(root), "nope") == {:error, :not_found}
+
+      assert {:error, %ClaudeWrapper.Error{kind: :not_found, reason: "nope"}} =
+               Skills.get(Skills.at(root), "nope")
     end
 
     test "extra frontmatter keys round-trip as raw strings", %{root: root} do

--- a/test/claude_wrapper/telemetry_test.exs
+++ b/test/claude_wrapper/telemetry_test.exs
@@ -71,11 +71,11 @@ defmodule ClaudeWrapper.TelemetryTest do
       assert start_meta.session_id == "sess-prev"
     end
 
-    test "stop metadata on {:error, {:exit, code, stdout}} carries exit_code" do
+    test "stop metadata on a :command_failed error carries exit_code" do
       query = Query.new("hi")
+      error = ClaudeWrapper.Error.command_failed(2, "boom")
 
-      assert {:error, {:exit, 2, "boom"}} =
-               Telemetry.span_exec(query, fn -> {:error, {:exit, 2, "boom"}} end)
+      assert {:error, ^error} = Telemetry.span_exec(query, fn -> {:error, error} end)
 
       assert_receive {:telemetry, [:claude_wrapper, :exec, :stop], _, meta}
       assert meta.exit_code == 2
@@ -134,10 +134,11 @@ defmodule ClaudeWrapper.TelemetryTest do
     test "error tuple sets exit_code" do
       query = Query.new("x")
       session = %{session_id: nil}
+      error = ClaudeWrapper.Error.command_failed(1, "stderr")
 
-      assert {:error, {:exit, 1, "stderr"}} =
+      assert {:error, ^error} =
                Telemetry.span_session_turn(session, query, fn ->
-                 {:error, {:exit, 1, "stderr"}}
+                 {:error, error}
                end)
 
       assert_receive {:telemetry, [:claude_wrapper, :session, :turn, :stop], _, meta}

--- a/test/claude_wrapper/tool_pattern_test.exs
+++ b/test/claude_wrapper/tool_pattern_test.exs
@@ -60,30 +60,54 @@ defmodule ClaudeWrapper.ToolPatternTest do
 
   describe "parse/1 errors" do
     test "rejects empty input" do
-      assert ToolPattern.parse("") == {:error, :empty}
-      assert ToolPattern.parse("   ") == {:error, :empty}
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_tool_pattern, reason: :empty}} =
+               ToolPattern.parse("")
+
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_tool_pattern, reason: :empty}} =
+               ToolPattern.parse("   ")
     end
 
     test "rejects unbalanced parens" do
-      assert {:error, {:unbalanced_parens, "Bash(git log"}} = ToolPattern.parse("Bash(git log")
-      assert {:error, {:unbalanced_parens, "Bashgit log)"}} = ToolPattern.parse("Bashgit log)")
+      assert {:error,
+              %ClaudeWrapper.Error{
+                kind: :invalid_tool_pattern,
+                reason: {:unbalanced_parens, "Bash(git log"}
+              }} = ToolPattern.parse("Bash(git log")
 
-      assert {:error, {:unbalanced_parens, "Bash((nested))"}} =
-               ToolPattern.parse("Bash((nested))")
+      assert {:error,
+              %ClaudeWrapper.Error{
+                kind: :invalid_tool_pattern,
+                reason: {:unbalanced_parens, "Bashgit log)"}
+              }} = ToolPattern.parse("Bashgit log)")
+
+      assert {:error,
+              %ClaudeWrapper.Error{
+                kind: :invalid_tool_pattern,
+                reason: {:unbalanced_parens, "Bash((nested))"}
+              }} = ToolPattern.parse("Bash((nested))")
     end
 
     test "rejects a missing name before the args" do
-      assert ToolPattern.parse("(args)") == {:error, :missing_name}
+      assert {:error, %ClaudeWrapper.Error{kind: :invalid_tool_pattern, reason: :missing_name}} =
+               ToolPattern.parse("(args)")
     end
 
     test "rejects a comma" do
-      assert {:error, {:illegal_char, "Bash,Read"}} = ToolPattern.parse("Bash,Read")
+      assert {:error,
+              %ClaudeWrapper.Error{
+                kind: :invalid_tool_pattern,
+                reason: {:illegal_char, "Bash,Read"}
+              }} = ToolPattern.parse("Bash,Read")
     end
 
     test "rejects a mid-string control char" do
       # Leading/trailing whitespace is trimmed, so the control char must
       # be in the interior to trip the check.
-      assert {:error, {:illegal_char, "Ba\nsh"}} = ToolPattern.parse("Ba\nsh")
+      assert {:error,
+              %ClaudeWrapper.Error{
+                kind: :invalid_tool_pattern,
+                reason: {:illegal_char, "Ba\nsh"}
+              }} = ToolPattern.parse("Ba\nsh")
     end
   end
 

--- a/test/claude_wrapper/worktrees_test.exs
+++ b/test/claude_wrapper/worktrees_test.exs
@@ -51,11 +51,12 @@ defmodule ClaudeWrapper.WorktreesTest do
       assert Worktrees.path(root) == repo
     end
 
-    test "errors with {:not_a_git_repo, path} for a plain directory", %{base: base} do
+    test "errors with a :not_a_git_repo error for a plain directory", %{base: base} do
       plain = Path.join(base, "plain")
       File.mkdir_p!(plain)
 
-      assert {:error, {:not_a_git_repo, ^plain}} = Worktrees.for_repo(plain)
+      assert {:error, %ClaudeWrapper.Error{kind: :not_a_git_repo, reason: ^plain}} =
+               Worktrees.for_repo(plain)
     end
   end
 
@@ -191,12 +192,13 @@ defmodule ClaudeWrapper.WorktreesTest do
   end
 
   describe "list/1 -- error path" do
-    test "errors with {:not_a_git_repo, path} for a non-repo directory", %{base: base} do
+    test "errors with a :not_a_git_repo error for a non-repo directory", %{base: base} do
       plain = Path.join(base, "plain")
       File.mkdir_p!(plain)
       root = %Worktrees{repo_path: plain}
 
-      assert {:error, {:not_a_git_repo, ^plain}} = Worktrees.list(root)
+      assert {:error, %ClaudeWrapper.Error{kind: :not_a_git_repo, reason: ^plain}} =
+               Worktrees.list(root)
     end
   end
 end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -373,7 +373,7 @@ defmodule ClaudeWrapperTest do
     end
 
     test "parse invalid JSON" do
-      assert {:error, {:json_decode, _}} = StreamEvent.parse("not json")
+      assert {:error, %ClaudeWrapper.Error{kind: :json}} = StreamEvent.parse("not json")
     end
 
     test "result? checks type" do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -45,6 +45,25 @@ defmodule ClaudeWrapper.IntegrationTest do
     end
   end
 
+  describe "max-turns" do
+    test "surfaces a typed :max_turns_exceeded error", %{config: config} do
+      # Force a tool turn so a single --max-turns is exceeded: the model
+      # must actually run the command to know its output, which costs one
+      # turn, leaving none to report back.
+      result =
+        Query.new(
+          "Using the Bash tool, run `echo $((6 * 7))` and then tell me the exact number it printed."
+        )
+        |> Query.max_turns(1)
+        |> Query.dangerously_skip_permissions()
+        |> Query.no_session_persistence()
+        |> Query.execute(config)
+
+      assert {:error, %ClaudeWrapper.Error{kind: :max_turns_exceeded, exit_code: code}} = result
+      assert is_integer(code)
+    end
+  end
+
   describe "stream" do
     test "streams events from a prompt", %{config: config} do
       events =


### PR DESCRIPTION
Replaces the library's ad-hoc tagged-tuple errors with one canonical, raisable `ClaudeWrapper.Error` exception, returned as `{:error, %ClaudeWrapper.Error{kind: ...}}` everywhere. The `kind` set mirrors the Rust `claude-wrapper` `Error` enum.

### Behavior fix
Hitting `--max-turns` now returns `{:error, %Error{kind: :max_turns_exceeded}}` instead of `{:ok, %Result{is_error: true}}`. **Verified live** against `claude` 2.1.173 (the real CLI emits `subtype: "error_max_turns"`). Other non-zero-but-valid-JSON results keep returning `{:ok, %Result{is_error: true}}`.

### Auth wiring
Command-failure auth classification (deferred from #93) is now wired into the exec path: a non-zero exit whose output classifies as auth becomes `{:error, %Error{kind: :auth, reason: <auth_error_kind>}}`.

### Internal matchers updated
`retry.ex`'s default predicate and `telemetry.ex`'s metadata extraction now read `%Error{}` (behavior preserved).

### Scope
31 lib modules + 15 test files migrated; new `lib/claude_wrapper/error.ex` + `test/claude_wrapper/error_test.exs`. `ToolPattern.parse`/`CliVersion.parse` now return `%Error{kind: :invalid_tool_pattern | :invalid_version}` carrying the specific problem in `:reason`.

### BREAKING CHANGE
Every `{:error, reason}` now carries a `%ClaudeWrapper.Error{}` struct. Consumers match on `%ClaudeWrapper.Error{kind: ...}`. Batched into the 0.8.0 milestone.

Unit suite 477 passing; credo/dialyzer clean. Live: max-turns typed error verified against the real CLI.

Closes #92