### PR TITLE
fix: mcp/auth command output handling + live integration coverage

### DIFF
--- a/lib/claude_wrapper/commands/auth.ex
+++ b/lib/claude_wrapper/commands/auth.ex
@@ -23,7 +23,7 @@ defmodule ClaudeWrapper.Commands.Auth do
   """
   @spec status(Config.t()) :: {:ok, auth_status()} | {:error, term()}
   def status(%Config{} = config) do
-    args = Config.base_args(config) ++ ["auth", "status", "--output-format", "json"]
+    args = Config.base_args(config) ++ ["auth", "status", "--json"]
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} ->

--- a/lib/claude_wrapper/commands/mcp.ex
+++ b/lib/claude_wrapper/commands/mcp.ex
@@ -8,9 +8,9 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
       config = ClaudeWrapper.Config.new()
 
-      # List / inspect configured servers (JSON-decoded)
-      {:ok, servers} = ClaudeWrapper.Commands.Mcp.list(config)
-      {:ok, server} = ClaudeWrapper.Commands.Mcp.get(config, "sentry")
+      # List / inspect configured servers (raw text; the CLI has no JSON mode)
+      {:ok, servers_text} = ClaudeWrapper.Commands.Mcp.list(config)
+      {:ok, server_text} = ClaudeWrapper.Commands.Mcp.get(config, "sentry")
 
       # Add an HTTP server with an auth header
       {:ok, _} =
@@ -49,50 +49,40 @@ defmodule ClaudeWrapper.Commands.Mcp do
   @doc """
   List configured MCP servers.
 
+  `claude mcp list` emits human-readable text (it has no JSON mode), so
+  this returns the raw, trimmed output rather than structured data.
+
   ## Options
 
     * `:scope` - Configuration scope (`:local`, `:user`, or `:project`).
   """
-  @spec list(Config.t(), keyword()) :: {:ok, list(map())} | {:error, term()}
+  @spec list(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def list(%Config{} = config, opts \\ []) do
-    args = Config.base_args(config) ++ ["mcp", "list"]
-    args = args ++ scope_args(opts[:scope])
-    args = args ++ ["--output-format", "json"]
+    args = Config.base_args(config) ++ ["mcp", "list"] ++ scope_args(opts[:scope])
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
-      {output, 0} ->
-        case Jason.decode(output) do
-          {:ok, data} -> {:ok, data}
-          {:error, reason} -> {:error, Error.json(reason)}
-        end
-
-      {output, code} ->
-        {:error, Error.command_failed(code, output)}
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 
   @doc """
   Get details for a specific MCP server.
 
+  `claude mcp get` emits human-readable text (it has no JSON mode), so
+  this returns the raw, trimmed output rather than structured data.
+
   ## Options
 
     * `:scope` - Configuration scope (`:local`, `:user`, or `:project`).
   """
-  @spec get(Config.t(), String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  @spec get(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def get(%Config{} = config, name, opts \\ []) do
-    args = Config.base_args(config) ++ ["mcp", "get", name]
-    args = args ++ scope_args(opts[:scope])
-    args = args ++ ["--output-format", "json"]
+    args = Config.base_args(config) ++ ["mcp", "get", name] ++ scope_args(opts[:scope])
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
-      {output, 0} ->
-        case Jason.decode(output) do
-          {:ok, data} -> {:ok, data}
-          {:error, reason} -> {:error, Error.json(reason)}
-        end
-
-      {output, code} ->
-        {:error, Error.command_failed(code, output)}
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, Error.command_failed(code, output)}
     end
   end
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -277,7 +277,7 @@ defmodule ClaudeWrapper.IntegrationTest do
         # Give the first call a moment to register pending_turn.
         Process.sleep(50)
 
-        assert {:error, :turn_in_flight} =
+        assert {:error, %ClaudeWrapper.Error{kind: :turn_in_flight}} =
                  DuplexSession.send(pid, "second", 1_000)
 
         assert_receive {:first_done, {:ok, %ClaudeWrapper.Result{}}}, 120_000
@@ -368,6 +368,91 @@ defmodule ClaudeWrapper.IntegrationTest do
       after
         DuplexSession.stop(pid)
       end
+    end
+  end
+
+  describe "read modules (live ~/.claude)" do
+    test "History reads real project transcripts" do
+      {:ok, root} = ClaudeWrapper.History.home()
+      assert {:ok, projects} = ClaudeWrapper.History.list_projects(root)
+      assert is_list(projects)
+
+      for p <- Enum.take(projects, 1) do
+        assert %ClaudeWrapper.History.ProjectSummary{slug: slug} = p
+        assert is_binary(slug)
+        assert {:ok, sessions} = ClaudeWrapper.History.list_sessions(root, slug: slug, limit: 1)
+
+        for s <- Enum.take(sessions, 1) do
+          assert {:ok, %ClaudeWrapper.History.SessionLog{entries: entries}} =
+                   ClaudeWrapper.History.read_session(root, s.session_id)
+
+          assert is_list(entries)
+        end
+      end
+    end
+
+    test "Settings loads real layers" do
+      assert {:ok, %ClaudeWrapper.Settings{paths: paths}} =
+               ClaudeWrapper.Settings.load(project_root: File.cwd!())
+
+      assert is_binary(paths.user)
+    end
+
+    test "Agents lists and reads real definition files" do
+      {:ok, root} = ClaudeWrapper.Agents.home()
+      assert {:ok, agents} = ClaudeWrapper.Agents.list(root)
+      assert is_list(agents)
+
+      for a <- Enum.take(agents, 1) do
+        assert %ClaudeWrapper.Agents.Summary{file_stem: stem} = a
+        assert {:ok, %ClaudeWrapper.Agents.Definition{}} = ClaudeWrapper.Agents.get(root, stem)
+      end
+    end
+
+    test "Skills lists real skill dirs" do
+      {:ok, root} = ClaudeWrapper.Skills.home()
+      assert {:ok, skills} = ClaudeWrapper.Skills.list(root)
+      assert is_list(skills)
+    end
+
+    test "Jobs lists real job state" do
+      {:ok, root} = ClaudeWrapper.Jobs.home()
+      assert {:ok, jobs} = ClaudeWrapper.Jobs.list(root)
+      assert is_list(jobs)
+    end
+
+    test "Worktrees lists this repo's worktrees" do
+      assert {:ok, wt} = ClaudeWrapper.Worktrees.for_repo(File.cwd!())
+      assert {:ok, list} = ClaudeWrapper.Worktrees.list(wt)
+      assert Enum.any?(list, & &1.is_main?)
+    end
+
+    test "CliVersion parses the real --version" do
+      assert {:ok, %{version: raw}} = ClaudeWrapper.version()
+      assert {:ok, %ClaudeWrapper.CliVersion{} = v} = ClaudeWrapper.CliVersion.parse(raw)
+
+      assert ClaudeWrapper.CliVersion.satisfies_minimum?(
+               v,
+               ClaudeWrapper.CliVersion.new(2, 0, 0)
+             )
+    end
+  end
+
+  describe "command smokes (live, non-mutating)" do
+    alias ClaudeWrapper.Commands.{Mcp, Plugin}
+
+    test "mcp list", %{config: config} do
+      assert {:ok, output} = Mcp.list(config)
+      assert is_binary(output)
+    end
+
+    test "plugin list", %{config: config} do
+      assert {:ok, _plugins} = Plugin.list(config)
+    end
+
+    test "auth status" do
+      assert {:ok, status} = ClaudeWrapper.auth_status()
+      assert is_map(status)
     end
   end
 end


### PR DESCRIPTION
Running live integration tests (the user asked for live verification) surfaced two **real bugs** the fake-CLI unit tests could not catch, plus adds the live coverage.

### Bugs fixed (verified against claude 2.1.173)
- `auth status` was passing `--output-format json`, which the CLI rejects (`unknown option`). The correct flag is `--json`. Fixed.
- `mcp list` / `mcp get` were passing `--output-format json` and decoding JSON, but **those subcommands have no JSON mode** -- they emit human-readable text. `Commands.Mcp.list/2` and `get/3` now return `{:ok, raw_text}` (return type `String.t()`). The old JSON path never worked against the real CLI, so no working code relied on it.

### Live integration coverage added (`@tag :integration`)
- Read modules against **real `~/.claude` data**: History (list projects/sessions + read a real transcript), Settings, Agents (list + get real `.md`), Skills, Jobs, Worktrees (this repo), CliVersion (parses real `claude --version`).
- Non-mutating command smokes: `mcp list`, `plugin list`, `auth status`.

### Also
Updates the existing `turn_in_flight` integration assertion to the `%ClaudeWrapper.Error{}` shape from #92 (that file is excluded from CI, so the migration PR couldn't catch it).

### Verification
`mix test --include integration` run end-to-end against the real CLI: all read-module + command + model paths green. One pre-existing **session-resume** model test is timing-flaky (passes 2/2 in isolation); unrelated to these changes.

Unit suite 477 passing; credo/dialyzer clean.