### PR TITLE
feat: high-level conversational API (Prompt + Session ergonomics + IEx skin)

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,21 +1,27 @@
 import ClaudeWrapper.IEx
+alias ClaudeWrapper.Prompt
 
 IO.puts("""
 \e[36mClaudeWrapper helpers loaded.\e[0m
 
-  \e[33m# Conversational REPL helpers (per-call subprocess):\e[0m
+  \e[33m# Talk to Claude (per-call subprocess):\e[0m
   chat("explain this codebase", working_dir: ".")
   say("now add tests for the retry module")
-  cost()
-  history()
-  reset()
+  cost(); history(); reset()
 
-  \e[33m# Or use the long-lived duplex session for live streaming:\e[0m
+  \e[33m# Compose a prompt -- attach files / a git diff (per-call):\e[0m
+  chat("review my change", attach: "lib/**/*.ex", git_diff: true)
+  Prompt.new("summarize") |> Prompt.attach("mix.exs") |> Prompt.render!()
+
+  \e[33m# Sticky defaults, prior sessions, branching:\e[0m
+  configure(model: "sonnet", working_dir: ".")
+  sessions(); pick(); resume("<session-id>"); fork("branch this idea")
+
+  \e[33m# Long-lived duplex session (live token streaming):\e[0m
   alias ClaudeWrapper.DuplexIEx
   DuplexIEx.start(working_dir: ".")
-  DuplexIEx.say("Explain the README briefly.")
-  DuplexIEx.close()
+  DuplexIEx.say("Explain the README briefly."); DuplexIEx.close()
 
-  \e[33m# Multi-agent coordination has moved to agent_workshop:\e[0m
+  \e[33m# Multi-agent coordination lives in agent_workshop:\e[0m
   \e[2m# https://hex.pm/packages/agent_workshop\e[0m
 """)

--- a/lib/claude_wrapper/iex.ex
+++ b/lib/claude_wrapper/iex.ex
@@ -10,7 +10,7 @@ defmodule ClaudeWrapper.IEx do
       iex> import ClaudeWrapper.IEx
 
       iex> chat("explain this codebase", working_dir: ".")
-      # => prints response, shows cost
+      # => prints response, shows cost, returns the %Result{}
 
       iex> say("now add tests for the retry module")
       # => continues the conversation
@@ -29,43 +29,114 @@ defmodule ClaudeWrapper.IEx do
 
   ## Configuration
 
-  Pass options to `chat/2` to configure the session. These persist for
-  subsequent `say/2` calls:
+  `configure/1` sets ambient options that persist across calls; `chat/2`
+  and `say/2` merge per-call options on top (last wins). Ambient + call
+  options cover config (`:working_dir`, `:binary`, `:env`, `:timeout`,
+  `:verbose`, `:debug`), query options (`:model`, `:max_turns`,
+  `:permission_mode`, ...), and prompt-composition keys (see below).
 
-      chat("hello", model: "sonnet", working_dir: "/my/project", max_turns: 5)
+      configure(model: "sonnet", working_dir: "/my/project")
+      chat("hello")                 # uses the ambient config
+      say("do something big", max_turns: 20)
 
-  Override per-turn with `say/2`:
+  ## Prompt composition
 
-      say("do something expensive", max_turns: 20)
+  `chat/2` and `say/2` accept composition keys that build a
+  `t:ClaudeWrapper.Prompt.t/0` around the prompt argument before sending:
+
+    * `:attach` -- a path/glob (or list of them) to attach as fenced,
+      path-headed code blocks
+    * `:git_diff` -- a ref to diff against, or `true`/`nil` for the
+      working tree
+    * `:prepend` -- text (or list) to place before the prompt
+    * `:append` -- text (or list) to place after the context
+
+  When any composition key is present the helper prints a one-line
+  `(attached N files, ~K bytes)` notice before the response.
+
+  ## Return values
+
+  `chat/2` and `say/2` return the `t:ClaudeWrapper.Result.t/0` on success
+  (after printing it). A CLI failure prints the error and **raises**
+  `ClaudeWrapper.Error`. The one non-raising case is calling `say/2` with
+  no active session, which prints a hint and returns `:no_session`.
   """
 
-  alias ClaudeWrapper.{Config, Result, Session}
+  alias ClaudeWrapper.{Config, Error, History, Prompt, Result, Session}
 
   @session_key :claude_wrapper_iex_session
   @config_key :claude_wrapper_iex_config
+  @history_key :claude_wrapper_iex_history
+
+  @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]
+  @composition_keys [:attach, :git_diff, :prepend, :append]
+
+  @typedoc "A session row as returned by `sessions/0`."
+  @type session_summary :: %{
+          id: String.t(),
+          first_prompt: String.t() | nil,
+          turns: non_neg_integer(),
+          last_used: String.t() | nil,
+          tokens: non_neg_integer() | nil,
+          cost_usd: float() | nil
+        }
 
   @doc """
-  Start a new conversation. Prints the response.
+  Merge options into the ambient configuration (last wins).
 
-  Accepts all options from `ClaudeWrapper.query/2` -- config options
-  (`:working_dir`, `:binary`, `:env`, `:timeout`, `:verbose`, `:debug`)
-  and query options (`:model`, `:max_turns`, `:permission_mode`, etc.).
+  Ambient options are applied to every subsequent `chat/2` and `say/2`
+  call, with per-call options overriding them. Accepts config, query, and
+  composition keys.
+
+      configure(model: "sonnet", working_dir: ".")
+      #=> :ok
   """
-  def chat(prompt, opts \\ []) do
-    {config_opts, query_opts} = split_opts(opts)
-    config = Config.new(config_opts)
-    session = Session.new(config, query_opts)
-
-    Process.put(@config_key, config)
-
-    do_send(session, prompt, [])
+  @spec configure(keyword()) :: :ok
+  def configure(opts) when is_list(opts) do
+    Process.put(@config_key, Keyword.merge(ambient_config(), opts))
+    :ok
   end
 
   @doc """
-  Continue the current conversation. Prints the response.
-
-  Accepts per-turn query option overrides.
+  Return the current ambient configuration keyword list.
   """
+  @spec config() :: keyword()
+  def config, do: ambient_config()
+
+  @doc """
+  Start a new conversation. Prints the response and returns the
+  `t:ClaudeWrapper.Result.t/0`.
+
+  Effective options are the ambient config (see `configure/1`) merged
+  with `opts` (per-call wins). Config keys build the session config;
+  composition keys build a prompt around `prompt`; everything else is
+  forwarded as turn options.
+
+  Raises `ClaudeWrapper.Error` on a CLI/render failure.
+  """
+  @spec chat(String.t(), keyword()) :: Result.t()
+  def chat(prompt, opts \\ []) do
+    effective = Keyword.merge(ambient_config(), opts)
+    Process.put(@config_key, effective)
+
+    {config_opts, rest} = Keyword.split(effective, @config_keys)
+    {composition_opts, query_opts} = Keyword.split(rest, @composition_keys)
+
+    config = Config.new(config_opts)
+    session = Session.new(config, query_opts)
+
+    run_turn(session, prompt, composition_opts, [])
+  end
+
+  @doc """
+  Continue the current conversation. Prints the response and returns the
+  `t:ClaudeWrapper.Result.t/0`.
+
+  Per-call `opts` are merged over the ambient query/composition options
+  (per-call wins). Returns `:no_session` (with a hint) when no session is
+  active; raises `ClaudeWrapper.Error` on a CLI/render failure.
+  """
+  @spec say(String.t(), keyword()) :: Result.t() | :no_session
   def say(prompt, opts \\ []) do
     case Process.get(@session_key) do
       nil ->
@@ -73,13 +144,109 @@ defmodule ClaudeWrapper.IEx do
         :no_session
 
       session ->
-        do_send(session, prompt, opts)
+        # Ambient query + composition opts apply to follow-ups too; the
+        # ambient config keys are already baked into the live session.
+        {_config_opts, rest} = Keyword.split(ambient_config(), @config_keys)
+        effective = Keyword.merge(rest, opts)
+        {composition_opts, query_opts} = Keyword.split(effective, @composition_keys)
+
+        run_turn(session, prompt, composition_opts, query_opts)
+    end
+  end
+
+  @doc """
+  Branch the current conversation into a new session and switch to it.
+
+  Forks the active session (see `ClaudeWrapper.Session.fork/3`), makes the
+  branch the current session, prints the response, and returns the
+  `t:ClaudeWrapper.Result.t/0`. Raises `ClaudeWrapper.Error` on failure
+  (including `:no_session` when there is no active session to fork).
+  """
+  @spec fork(String.t(), keyword()) :: Result.t()
+  def fork(prompt, opts \\ []) do
+    case Process.get(@session_key) do
+      nil -> raise Error.new(:no_session)
+      session -> fork_session(session, prompt, opts)
+    end
+  end
+
+  @doc """
+  Resume `session_id` and immediately branch it into a new session.
+
+  Resumes the given id with the ambient config, forks it, switches to the
+  branch, prints the response, and returns the
+  `t:ClaudeWrapper.Result.t/0`. Raises `ClaudeWrapper.Error` on failure.
+  """
+  @spec fork_from(String.t(), String.t(), keyword()) :: Result.t()
+  def fork_from(session_id, prompt, opts \\ []) when is_binary(session_id) do
+    {config_opts, _rest} = Keyword.split(ambient_config(), @config_keys)
+    config = Config.new(config_opts)
+    session = Session.resume(config, session_id)
+    fork_session(session, prompt, opts)
+  end
+
+  @doc """
+  List prior sessions for the ambient working directory (most recent
+  first).
+
+  Reads Claude Code's on-disk history for the configured `:working_dir`
+  (or the current directory when unset). Each row is a map with `:id`,
+  `:first_prompt`, `:turns`, `:last_used`, `:tokens`, and `:cost_usd`.
+  Returns `[]` when history cannot be read.
+  """
+  @spec sessions() :: [session_summary()]
+  def sessions do
+    with {:ok, history} <- history_root(),
+         {:ok, summaries} <-
+           History.sessions_for_path(history, working_dir(), sort: :recency_desc) do
+      Enum.map(summaries, &project_summary/1)
+    else
+      _ -> []
+    end
+  end
+
+  @doc """
+  Print a numbered list of prior sessions and resume the chosen one.
+
+  Shows each session's turn count, age, and cost (or `—` when unknown),
+  reads a selection via `IO.gets/1`, resumes it, and returns the chosen
+  id. Empty input returns `:cancelled`.
+  """
+  @spec pick() :: String.t() | :cancelled
+  def pick do
+    case sessions() do
+      [] ->
+        IO.puts("\e[33mNo prior sessions for this directory.\e[0m")
+        :cancelled
+
+      summaries ->
+        print_pick_list(summaries)
+        read_pick_choice(summaries)
+    end
+  end
+
+  @doc """
+  Snapshot of the current session: `%{id, turns, cost_usd}` or `nil`.
+  """
+  @spec current() :: %{id: String.t() | nil, turns: non_neg_integer(), cost_usd: float()} | nil
+  def current do
+    case Process.get(@session_key) do
+      nil ->
+        nil
+
+      session ->
+        %{
+          id: Session.session_id(session),
+          turns: Session.turn_count(session),
+          cost_usd: Session.total_cost(session)
+        }
     end
   end
 
   @doc """
   Show total cost and turn count for the current session.
   """
+  @spec cost() :: float() | :no_session
   def cost do
     case Process.get(@session_key) do
       nil ->
@@ -97,6 +264,7 @@ defmodule ClaudeWrapper.IEx do
   @doc """
   Print the conversation history.
   """
+  @spec history() :: :ok | :no_session
   def history do
     case Process.get(@session_key) do
       nil ->
@@ -110,8 +278,9 @@ defmodule ClaudeWrapper.IEx do
   end
 
   @doc """
-  Reset the session (start fresh on next `chat/2`).
+  Reset the session and ambient config (start fresh on next `chat/2`).
   """
+  @spec reset() :: :ok
   def reset do
     Process.delete(@session_key)
     Process.delete(@config_key)
@@ -122,6 +291,7 @@ defmodule ClaudeWrapper.IEx do
   @doc """
   Get the session ID (for resuming later).
   """
+  @spec session_id() :: String.t() | nil
   def session_id do
     case Process.get(@session_key) do
       nil -> nil
@@ -132,21 +302,21 @@ defmodule ClaudeWrapper.IEx do
   @doc """
   Resume a previous session by ID.
 
-  Uses the same config as the last `chat/2` call, or pass new options.
+  Uses the ambient config (or pass new config/query options).
   """
+  @spec resume(String.t(), keyword()) :: :ok
   def resume(sid, opts \\ []) do
     {config_opts, query_opts} = split_opts(opts)
 
     config =
       if config_opts == [] do
-        Process.get(@config_key) || Config.new()
+        Config.new(elem(Keyword.split(ambient_config(), @config_keys), 0))
       else
         Config.new(config_opts)
       end
 
     session = Session.resume(config, sid, query_opts)
     Process.put(@session_key, session)
-    Process.put(@config_key, config)
     IO.puts("\e[33mResumed session #{sid}\e[0m")
     :ok
   end
@@ -154,6 +324,7 @@ defmodule ClaudeWrapper.IEx do
   @doc """
   Get the last result struct (for programmatic access).
   """
+  @spec last() :: Result.t() | nil
   def last do
     case Process.get(@session_key) do
       nil -> nil
@@ -161,7 +332,193 @@ defmodule ClaudeWrapper.IEx do
     end
   end
 
-  # --- Private ---
+  # --- turn execution -----------------------------------------------
+
+  # Build the prompt (plain or composed), send it, and on success store
+  # the session, print the result, and return the %Result{}. A failure
+  # prints and raises.
+  defp run_turn(session, prompt, composition_opts, query_opts) do
+    IO.puts("\e[33m...\e[0m")
+
+    {to_send, notice} = build_prompt(prompt, composition_opts)
+
+    case Session.send(session, to_send, query_opts) do
+      {:ok, new_session, result} ->
+        Process.put(@session_key, new_session)
+        if notice, do: IO.puts("\e[33m#{notice}\e[0m")
+        print_result(result, new_session)
+        result
+
+      {:error, %Error{} = error} ->
+        IO.puts("\e[31mError: #{Exception.message(error)}\e[0m")
+        raise error
+    end
+  end
+
+  # No composition keys -> send the raw string, no notice. Otherwise build
+  # a %Prompt{}, render it now to both produce the notice and hand a plain
+  # string to Session.send (single render). A render error short-circuits
+  # to a raised ClaudeWrapper.Error via the caller.
+  defp build_prompt(prompt, []), do: {prompt, nil}
+
+  defp build_prompt(prompt, composition_opts) do
+    built = compose(Prompt.new(prompt), composition_opts)
+
+    case Prompt.render(built) do
+      {:ok, rendered} -> {rendered, attach_notice(built, rendered)}
+      {:error, %Error{} = error} -> raise error
+    end
+  end
+
+  defp compose(prompt, opts) do
+    Enum.reduce(opts, prompt, &apply_composition/2)
+  end
+
+  defp apply_composition({:prepend, values}, prompt),
+    do: reduce_strings(prompt, values, &Prompt.prepend/2)
+
+  defp apply_composition({:append, values}, prompt),
+    do: reduce_strings(prompt, values, &Prompt.append/2)
+
+  defp apply_composition({:attach, values}, prompt),
+    do: reduce_strings(prompt, values, &Prompt.attach/2)
+
+  defp apply_composition({:git_diff, true}, prompt), do: Prompt.git_diff(prompt, nil)
+  defp apply_composition({:git_diff, ref}, prompt), do: Prompt.git_diff(prompt, ref)
+
+  # A composition value may be a single string or a list of them.
+  defp reduce_strings(prompt, values, fun) when is_list(values) do
+    Enum.reduce(values, prompt, fn v, acc -> fun.(acc, v) end)
+  end
+
+  defp reduce_strings(prompt, value, fun), do: fun.(prompt, value)
+
+  # Count the attached file blocks (each starts with a "# <path>" header
+  # line) and the rendered byte size for the one-line notice.
+  defp attach_notice(%Prompt{context: context}, rendered) do
+    attaches = Enum.count(context, &match?({:attach, _}, &1))
+
+    if attaches == 0 do
+      nil
+    else
+      files = rendered |> String.split("\n") |> Enum.count(&String.starts_with?(&1, "# "))
+      "(attached #{files} file#{plural(files)}, ~#{kb(byte_size(rendered))})"
+    end
+  end
+
+  defp kb(bytes), do: "#{Float.round(bytes / 1024, 1)}KB"
+
+  # --- fork helpers -------------------------------------------------
+
+  defp fork_session(session, prompt, opts) do
+    IO.puts("\e[33m... (forking)\e[0m")
+
+    case Session.fork(session, prompt, opts) do
+      {:ok, branch, result} ->
+        Process.put(@session_key, branch)
+        print_result(result, branch)
+        result
+
+      {:error, %Error{} = error} ->
+        IO.puts("\e[31mError: #{Exception.message(error)}\e[0m")
+        raise error
+    end
+  end
+
+  # --- history / pick helpers ---------------------------------------
+
+  defp history_root do
+    case Process.get(@history_key) do
+      %History{} = h ->
+        {:ok, h}
+
+      _ ->
+        case History.home() do
+          {:ok, h} ->
+            Process.put(@history_key, h)
+            {:ok, h}
+
+          {:error, _} = err ->
+            err
+        end
+    end
+  end
+
+  defp project_summary(summary) do
+    %{
+      id: summary.session_id,
+      first_prompt: summary.first_user_preview,
+      turns: summary.message_count,
+      last_used: summary.last_timestamp,
+      tokens: summary.total_tokens,
+      cost_usd: summary.total_cost_usd
+    }
+  end
+
+  defp print_pick_list(summaries) do
+    summaries
+    |> Enum.with_index(1)
+    |> Enum.each(fn {s, i} ->
+      IO.puts(
+        "\e[36m#{i})\e[0m #{s.turns} turn#{plural(s.turns)}  #{age(s.last_used)}  #{pick_cost(s.cost_usd)}  #{pick_preview(s.first_prompt)}"
+      )
+    end)
+  end
+
+  defp read_pick_choice(summaries) do
+    case IO.gets("Pick a session (number, blank to cancel): ") do
+      :eof -> :cancelled
+      input -> resolve_pick(String.trim(to_string(input)), summaries)
+    end
+  end
+
+  defp resolve_pick("", _summaries), do: :cancelled
+
+  defp resolve_pick(input, summaries) do
+    case Integer.parse(input) do
+      {n, ""} when n >= 1 -> pick_index(summaries, n)
+      _ -> invalid_pick()
+    end
+  end
+
+  defp pick_index(summaries, n) do
+    case Enum.at(summaries, n - 1) do
+      nil ->
+        invalid_pick()
+
+      %{id: id} ->
+        resume(id)
+        id
+    end
+  end
+
+  defp invalid_pick do
+    IO.puts("\e[31mInvalid selection.\e[0m")
+    :cancelled
+  end
+
+  defp pick_cost(nil), do: "—"
+  defp pick_cost(cost), do: format_cost(cost)
+
+  defp pick_preview(nil), do: ""
+  defp pick_preview(preview), do: preview
+
+  # Best-effort relative age from an ISO-8601 timestamp string.
+  defp age(nil), do: "(unknown)"
+
+  defp age(timestamp) when is_binary(timestamp) do
+    case DateTime.from_iso8601(timestamp) do
+      {:ok, dt, _offset} -> relative_age(DateTime.diff(DateTime.utc_now(), dt, :second))
+      _ -> "(unknown)"
+    end
+  end
+
+  defp relative_age(seconds) when seconds < 60, do: "just now"
+  defp relative_age(seconds) when seconds < 3600, do: "#{div(seconds, 60)}m ago"
+  defp relative_age(seconds) when seconds < 86_400, do: "#{div(seconds, 3600)}h ago"
+  defp relative_age(seconds), do: "#{div(seconds, 86_400)}d ago"
+
+  # --- print helpers ------------------------------------------------
 
   defp print_history([]) do
     IO.puts("\e[33mNo turns yet.\e[0m")
@@ -180,21 +537,6 @@ defmodule ClaudeWrapper.IEx do
     IO.puts("\e[36m--- Turn #{i}#{cost_str}#{error_str} ---\e[0m")
     IO.puts(result.result)
     IO.puts("")
-  end
-
-  defp do_send(session, prompt, opts) do
-    IO.puts("\e[33m...\e[0m")
-
-    case Session.send(session, prompt, opts) do
-      {:ok, new_session, result} ->
-        Process.put(@session_key, new_session)
-        print_result(result, new_session)
-        :ok
-
-      {:error, reason} ->
-        IO.puts("\e[31mError: #{inspect(reason)}\e[0m")
-        {:error, reason}
-    end
   end
 
   defp print_result(%Result{} = result, session) do
@@ -226,7 +568,13 @@ defmodule ClaudeWrapper.IEx do
   def format_cost(nil), do: "?"
   def format_cost(cost) when is_number(cost), do: "$#{Float.round(cost + 0.0, 4)}"
 
-  @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]
+  # --- opt / ambient helpers ----------------------------------------
+
+  defp ambient_config, do: Process.get(@config_key, [])
+
+  defp working_dir do
+    Keyword.get(ambient_config(), :working_dir) || File.cwd!()
+  end
 
   defp split_opts(opts) do
     Enum.split_with(opts, fn {k, _v} -> k in @config_keys end)

--- a/lib/claude_wrapper/iex.ex
+++ b/lib/claude_wrapper/iex.ex
@@ -29,15 +29,21 @@ defmodule ClaudeWrapper.IEx do
 
   ## Configuration
 
-  `configure/1` sets ambient options that persist across calls; `chat/2`
-  and `say/2` merge per-call options on top (last wins). Ambient + call
-  options cover config (`:working_dir`, `:binary`, `:env`, `:timeout`,
-  `:verbose`, `:debug`), query options (`:model`, `:max_turns`,
-  `:permission_mode`, ...), and prompt-composition keys (see below).
+  `configure/1` is the single source of sticky defaults: whatever you set
+  there applies to every later `chat/2` and `say/2`. Options passed
+  directly to `chat/2` or `say/2` apply to **that call only** and are
+  never written back to ambient -- a one-off `attach:` or `model:` won't
+  silently ride along on the next turn. Per-call options win over ambient
+  for the call they're on.
+
+  Ambient and per-call options both cover config (`:working_dir`,
+  `:binary`, `:env`, `:timeout`, `:verbose`, `:debug`), query options
+  (`:model`, `:max_turns`, `:permission_mode`, ...), and prompt-composition
+  keys (see below).
 
       configure(model: "sonnet", working_dir: "/my/project")
-      chat("hello")                 # uses the ambient config
-      say("do something big", max_turns: 20)
+      chat("hello")                            # uses the ambient sonnet + cwd
+      say("do something big", max_turns: 20)   # max_turns: this turn only
 
   ## Prompt composition
 
@@ -110,14 +116,19 @@ defmodule ClaudeWrapper.IEx do
   Effective options are the ambient config (see `configure/1`) merged
   with `opts` (per-call wins). Config keys build the session config;
   composition keys build a prompt around `prompt`; everything else is
-  forwarded as turn options.
+  forwarded as turn options. Per-call `opts` apply to this turn only and
+  are **not** persisted -- use `configure/1` for sticky defaults.
 
   Raises `ClaudeWrapper.Error` on a CLI/render failure.
   """
   @spec chat(String.t(), keyword()) :: Result.t()
   def chat(prompt, opts \\ []) do
+    # Per-call opts apply to THIS turn only; they are never written back to
+    # ambient. configure/1 is the single source of sticky defaults, so a
+    # one-off attach:/model: here can't silently ride along on later say/2
+    # turns. run_turn stores the live session (which carries config
+    # forward); ambient carries only configure-set query/composition defaults.
     effective = Keyword.merge(ambient_config(), opts)
-    Process.put(@config_key, effective)
 
     {config_opts, rest} = Keyword.split(effective, @config_keys)
     {composition_opts, query_opts} = Keyword.split(rest, @composition_keys)
@@ -144,8 +155,9 @@ defmodule ClaudeWrapper.IEx do
         :no_session
 
       session ->
-        # Ambient query + composition opts apply to follow-ups too; the
-        # ambient config keys are already baked into the live session.
+        # Ambient (configure-set) query + composition opts apply to
+        # follow-ups; config keys are already baked into the live session,
+        # so they're dropped here. Per-call opts win, for this turn only.
         {_config_opts, rest} = Keyword.split(ambient_config(), @config_keys)
         effective = Keyword.merge(rest, opts)
         {composition_opts, query_opts} = Keyword.split(effective, @composition_keys)

--- a/lib/claude_wrapper/prompt.ex
+++ b/lib/claude_wrapper/prompt.ex
@@ -1,0 +1,247 @@
+defmodule ClaudeWrapper.Prompt do
+  @moduledoc """
+  Composable prompt builder with deferred file / git-diff expansion.
+
+  A `Prompt` is a pure value: the builders (`new/1`, `prepend/2`,
+  `append/2`, `attach/2`, `git_diff/2`) only record intent. All IO --
+  reading attached files, shelling out to `git diff` -- happens in
+  `render/1`, which assembles the final string in a **fixed order**:
+
+      prepends -> base -> attachments -> diffs -> appends
+
+  Each section is separated from the next by a blank line, and within the
+  context section attachments and diffs appear in the order their builder
+  calls were made (interleaved exactly as you wrote them).
+
+  This split keeps composition cheap and total -- you can build a prompt
+  without touching the filesystem -- and concentrates every fallible
+  operation in `render/1`, which returns a tagged tuple.
+
+  ## Example
+
+      iex> ClaudeWrapper.Prompt.new("Review this change")
+      ...> |> ClaudeWrapper.Prompt.prepend("You are a careful reviewer.")
+      ...> |> ClaudeWrapper.Prompt.append("Focus on correctness.")
+      ...> |> ClaudeWrapper.Prompt.render()
+      {:ok, "You are a careful reviewer.\\n\\nReview this change\\n\\nFocus on correctness."}
+
+  Attached files are emitted as fenced code blocks, each headed by a
+  `# <path>` comment line. Globs are expanded with `Path.wildcard/1` and
+  sorted; a glob that matches nothing is an error. Files that are not
+  valid UTF-8 text, or that exceed #{div(262_144, 1024)} KB, are skipped.
+
+  Git diffs are emitted inside a ```` ```diff ```` fence. `git_diff(p,
+  nil)` diffs the working tree; `git_diff(p, ref)` diffs against `ref`.
+  """
+
+  alias ClaudeWrapper.Error
+
+  @typedoc """
+  A recorded context item, expanded at render time in call order.
+
+    * `{:attach, glob}` -- a path or glob; each matched text file becomes
+      a fenced, path-headed block.
+    * `{:diff, ref}` -- a `git diff`; `nil` is the working tree, a binary
+      is a ref/commit to diff against.
+  """
+  @type context_item :: {:attach, String.t()} | {:diff, String.t() | nil}
+
+  @type t :: %__MODULE__{
+          base: String.t(),
+          prepends: [String.t()],
+          appends: [String.t()],
+          context: [context_item()]
+        }
+
+  @enforce_keys [:base]
+  defstruct base: "", prepends: [], appends: [], context: []
+
+  # Files larger than this are skipped during attach expansion. 256 KB is
+  # generous for source files while keeping a single prompt from ballooning
+  # on an accidentally-matched binary or build artifact.
+  @max_attach_bytes 262_144
+
+  @doc """
+  Start a new prompt from its base text.
+
+      iex> ClaudeWrapper.Prompt.new("hello").base
+      "hello"
+  """
+  @spec new(String.t()) :: t()
+  def new(base) when is_binary(base), do: %__MODULE__{base: base}
+
+  @doc """
+  Add a block before the base text.
+
+  Multiple prepends render in the order they were added, ahead of the
+  base.
+  """
+  @spec prepend(t(), String.t()) :: t()
+  def prepend(%__MODULE__{} = prompt, text) when is_binary(text) do
+    %{prompt | prepends: prompt.prepends ++ [text]}
+  end
+
+  @doc """
+  Add a block after everything else.
+
+  Multiple appends render in the order they were added, after the
+  context section.
+  """
+  @spec append(t(), String.t()) :: t()
+  def append(%__MODULE__{} = prompt, text) when is_binary(text) do
+    %{prompt | appends: prompt.appends ++ [text]}
+  end
+
+  @doc """
+  Record a file path or glob to attach.
+
+  Nothing is read now; the glob is expanded at `render/1` time with
+  `Path.wildcard/1`, sorted, and each text file is emitted as a fenced,
+  path-headed code block. Recorded in call order relative to
+  `git_diff/2`.
+  """
+  @spec attach(t(), String.t()) :: t()
+  def attach(%__MODULE__{} = prompt, glob) when is_binary(glob) do
+    %{prompt | context: prompt.context ++ [{:attach, glob}]}
+  end
+
+  @doc """
+  Record a git diff to include.
+
+  `ref` is `nil` for the working tree, or a ref/commit string to diff
+  against (`git diff <ref>`). The diff is produced at `render/1` time and
+  emitted inside a ```` ```diff ```` fence. Recorded in call order
+  relative to `attach/2`.
+  """
+  @spec git_diff(t(), String.t() | nil) :: t()
+  def git_diff(%__MODULE__{} = prompt, ref) when is_binary(ref) or is_nil(ref) do
+    %{prompt | context: prompt.context ++ [{:diff, ref}]}
+  end
+
+  @doc """
+  Render the prompt to its final string.
+
+  Performs all deferred IO -- reads attached files, runs `git diff` --
+  and joins the sections (prepends, base, attachments, diffs, appends)
+  with blank lines.
+
+  Returns `{:error, %ClaudeWrapper.Error{}}` if a glob matches no files
+  (`:not_found`), or if a git diff fails (`:git_failed`) or `git` is
+  unavailable (`:git_unavailable`). The working directory for both file
+  globs and git is the current process cwd.
+  """
+  @spec render(t()) :: {:ok, String.t()} | {:error, Error.t()}
+  def render(%__MODULE__{} = prompt) do
+    with {:ok, context} <- render_context(prompt.context) do
+      sections = prompt.prepends ++ [prompt.base] ++ context ++ prompt.appends
+
+      rendered =
+        sections
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.join("\n\n")
+
+      {:ok, rendered}
+    end
+  end
+
+  @doc """
+  Like `render/1` but returns the string directly, raising
+  `ClaudeWrapper.Error` on failure.
+  """
+  @spec render!(t()) :: String.t()
+  def render!(%__MODULE__{} = prompt) do
+    case render(prompt) do
+      {:ok, rendered} -> rendered
+      {:error, error} -> raise error
+    end
+  end
+
+  # -- context rendering ---------------------------------------------
+
+  defp render_context(items) do
+    items
+    |> Enum.reduce_while({:ok, []}, &reduce_context_item/2)
+    |> finalize_context()
+  end
+
+  defp reduce_context_item(item, {:ok, acc}) do
+    case render_item(item) do
+      {:ok, blocks} -> {:cont, {:ok, acc ++ blocks}}
+      {:error, _} = error -> {:halt, error}
+    end
+  end
+
+  defp finalize_context({:ok, blocks}), do: {:ok, blocks}
+  defp finalize_context({:error, _} = error), do: error
+
+  # An attach can yield several blocks (one per matched file); a diff
+  # yields at most one. Both return `{:ok, [block]}` or `{:error, _}`.
+  defp render_item({:attach, glob}), do: render_attach(glob)
+  defp render_item({:diff, ref}), do: render_diff(ref)
+
+  # -- attach --------------------------------------------------------
+
+  defp render_attach(glob) do
+    case glob |> Path.wildcard() |> Enum.sort() do
+      [] -> {:error, Error.new(:not_found, reason: glob)}
+      paths -> {:ok, paths |> Enum.map(&attach_block/1) |> Enum.reject(&is_nil/1)}
+    end
+  end
+
+  # Read a single path into a fenced, path-headed block. Returns nil for
+  # directories, oversized files, unreadable files, or non-UTF-8 content
+  # so they are skipped rather than failing the whole render.
+  defp attach_block(path) do
+    with {:ok, %File.Stat{type: :regular, size: size}} when size <= @max_attach_bytes <-
+           File.stat(path),
+         {:ok, content} <- File.read(path),
+         true <- String.valid?(content) do
+      "# #{path}\n```\n#{trim_trailing_newline(content)}\n```"
+    else
+      _ -> nil
+    end
+  end
+
+  defp trim_trailing_newline(content), do: String.trim_trailing(content, "\n")
+
+  # -- git diff ------------------------------------------------------
+
+  defp render_diff(ref) do
+    args = ["diff"] ++ if(ref, do: [ref], else: [])
+
+    case safe_git(args) do
+      {:ok, {output, 0}} -> {:ok, diff_blocks(output)}
+      {:ok, {output, status}} -> {:error, git_failed(status, output)}
+      {:error, _} = error -> error
+    end
+  end
+
+  # An empty diff (no changes) contributes no block.
+  defp diff_blocks(output) do
+    case String.trim(output) do
+      "" -> []
+      trimmed -> ["```diff\n#{trimmed}\n```"]
+    end
+  end
+
+  # Wrap System.cmd so a missing `git` binary becomes a tagged error
+  # instead of an ErlangError escaping the module. Mirrors
+  # ClaudeWrapper.Worktrees. Git (like the attach globs) runs relative to
+  # the current process cwd, passed explicitly via `:cd` so the working
+  # directory the diff is taken in is unambiguous.
+  defp safe_git(args) do
+    {:ok, System.cmd("git", args, stderr_to_stdout: true, cd: File.cwd!())}
+  rescue
+    e in ErlangError -> {:error, Error.new(:git_unavailable, reason: e.original)}
+  end
+
+  defp git_failed(status, output) do
+    stderr = String.trim(output)
+
+    Error.new(:git_failed,
+      reason: %{status: status, stderr: stderr},
+      exit_code: status,
+      stderr: stderr
+    )
+  end
+end

--- a/lib/claude_wrapper/session.ex
+++ b/lib/claude_wrapper/session.ex
@@ -22,7 +22,7 @@ defmodule ClaudeWrapper.Session do
       session = ClaudeWrapper.Session.resume(config, "session-id-abc")
   """
 
-  alias ClaudeWrapper.{Config, Query, Result, Telemetry}
+  alias ClaudeWrapper.{Config, Error, Prompt, Query, Result, Telemetry}
 
   @type t :: %__MODULE__{
           config: Config.t(),
@@ -70,10 +70,22 @@ defmodule ClaudeWrapper.Session do
 
   The first turn creates a new session. Subsequent turns use `--resume`
   with the session ID from the first result.
+
+  `prompt` is either a plain string or a `t:ClaudeWrapper.Prompt.t/0`. A
+  `Prompt` is rendered (which expands attached files and git diffs)
+  before the turn runs; a render failure short-circuits to
+  `{:error, %ClaudeWrapper.Error{}}` without launching the CLI.
   """
-  @spec send(t(), String.t(), keyword()) :: {:ok, t(), Result.t()} | {:error, term()}
+  @spec send(t(), String.t() | Prompt.t(), keyword()) ::
+          {:ok, t(), Result.t()} | {:error, Error.t()}
   def send(%__MODULE__{} = session, prompt, opts \\ []) do
-    query = build_query(session, prompt, opts)
+    with {:ok, text} <- resolve_prompt(prompt) do
+      do_send(session, text, opts)
+    end
+  end
+
+  defp do_send(session, text, opts) do
+    query = build_query(session, text, opts)
 
     Telemetry.span_session_turn(session, query, fn ->
       case Query.execute(query, session.config) do
@@ -116,6 +128,46 @@ defmodule ClaudeWrapper.Session do
   end
 
   @doc """
+  Branch the conversation into a new, independent session.
+
+  Resumes the session's current `session_id` with `--fork-session` and
+  sends `prompt`. The CLI clones the prior context into a *new* session;
+  the returned `Session` is bound to that new forked id, while the
+  original struct passed in is left completely untouched -- you can keep
+  using it to continue the original thread.
+
+  `prompt` accepts a string or a `t:ClaudeWrapper.Prompt.t/0`, exactly
+  like `send/3`.
+
+  Returns `{:error, %ClaudeWrapper.Error{kind: :no_session}}` if the
+  session has no established `session_id` yet (nothing to fork from --
+  send at least one turn first).
+
+  ## Example
+
+      {:ok, session, _} = ClaudeWrapper.Session.send(session, "Draft a plan")
+      {:ok, branch, _} = ClaudeWrapper.Session.fork(session, "Now try a riskier variant")
+      # `session` still points at the original thread; `branch` is the fork.
+  """
+  @spec fork(t(), String.t() | Prompt.t(), keyword()) ::
+          {:ok, t(), Result.t()} | {:error, Error.t()}
+  def fork(session, prompt, opts \\ [])
+
+  def fork(%__MODULE__{session_id: nil}, _prompt, _opts) do
+    {:error, Error.new(:no_session)}
+  end
+
+  def fork(%__MODULE__{session_id: sid} = session, prompt, opts) when is_binary(sid) do
+    # Branch from a copy that resumes the current id, with --fork-session
+    # set so the CLI mints a new session rather than appending to this one.
+    # do_send binds the returned session to the new id from the result and
+    # the original `session` struct is never mutated.
+    forked = %{session | history: []}
+
+    send(forked, prompt, Keyword.put(opts, :fork_session, true))
+  end
+
+  @doc """
   Get the session ID (if established).
   """
   @spec session_id(t()) :: String.t() | nil
@@ -152,6 +204,12 @@ defmodule ClaudeWrapper.Session do
   def last_result(%__MODULE__{history: history}), do: List.last(history)
 
   # --- Private ---
+
+  # Normalize a prompt argument to a string. A %Prompt{} is rendered
+  # (expanding files / git diffs); a render failure becomes the caller's
+  # {:error, %Error{}} so core stays tuple-returning rather than raising.
+  defp resolve_prompt(prompt) when is_binary(prompt), do: {:ok, prompt}
+  defp resolve_prompt(%Prompt{} = prompt), do: Prompt.render(prompt)
 
   defp build_query(session, prompt, per_call_opts) do
     merged_opts = Keyword.merge(session.query_opts, per_call_opts)

--- a/test/claude_wrapper/iex_test.exs
+++ b/test/claude_wrapper/iex_test.exs
@@ -1,7 +1,14 @@
 defmodule ClaudeWrapper.IExTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
+  alias ClaudeWrapper.Error
   alias ClaudeWrapper.IEx, as: CIEx
+
+  # Each ExUnit test runs in its own process, so the process-dictionary
+  # state CIEx uses (session / config / history) is naturally isolated
+  # between tests -- no shared cleanup needed.
 
   describe "format_cost/1 (regression: #64)" do
     test "integer 0 does not raise" do
@@ -21,6 +28,75 @@ defmodule ClaudeWrapper.IExTest do
 
     test "nil cost is rendered as ?" do
       assert CIEx.format_cost(nil) == "?"
+    end
+  end
+
+  describe "configure/1 and config/0" do
+    test "config starts empty" do
+      assert CIEx.config() == []
+    end
+
+    test "configure stores ambient options" do
+      assert :ok = CIEx.configure(model: "sonnet", working_dir: "/tmp")
+      assert CIEx.config() == [model: "sonnet", working_dir: "/tmp"]
+    end
+
+    test "configure merges, last wins" do
+      :ok = CIEx.configure(model: "sonnet", max_turns: 3)
+      :ok = CIEx.configure(model: "opus")
+
+      config = CIEx.config()
+      assert config[:model] == "opus"
+      assert config[:max_turns] == 3
+    end
+  end
+
+  describe "current/0" do
+    test "returns nil with no active session" do
+      assert CIEx.current() == nil
+    end
+  end
+
+  describe "say/2 with no active session" do
+    test "returns :no_session without raising" do
+      output =
+        capture_io(fn ->
+          assert CIEx.say("anything") == :no_session
+        end)
+
+      assert output =~ "No active session"
+    end
+  end
+
+  describe "chat/2 composition wiring (no live CLI)" do
+    test "an attach glob matching nothing renders to a raised :not_found error" do
+      # Composition opts must build a %Prompt{} and render it; a glob that
+      # matches no files fails at render time, which the helper surfaces by
+      # raising ClaudeWrapper.Error -- and it does so before any CLI call,
+      # so this is checkable without a real `claude`.
+      glob =
+        Path.join(System.tmp_dir!(), "cwx_iex_nomatch_#{System.unique_integer([:positive])}/*")
+
+      capture_io(fn ->
+        assert_raise Error, fn ->
+          CIEx.chat("summarize these", attach: glob)
+        end
+      end)
+    end
+
+    test "the raised error carries the unmatched glob as :not_found" do
+      glob =
+        Path.join(System.tmp_dir!(), "cwx_iex_nomatch2_#{System.unique_integer([:positive])}/*")
+
+      capture_io(fn ->
+        error =
+          assert_raise Error, fn ->
+            CIEx.chat("go", attach: glob)
+          end
+
+        assert error.kind == :not_found
+        assert error.reason == glob
+      end)
     end
   end
 end

--- a/test/claude_wrapper/iex_test.exs
+++ b/test/claude_wrapper/iex_test.exs
@@ -99,4 +99,49 @@ defmodule ClaudeWrapper.IExTest do
       end)
     end
   end
+
+  describe "per-call options never leak into ambient (regression: composition leak)" do
+    # A glob that matches nothing makes chat/2 raise :not_found at *render*
+    # time -- before any CLI call -- so we can observe exactly what chat/2
+    # persisted to ambient without needing a live `claude`.
+    setup do
+      glob =
+        Path.join(System.tmp_dir!(), "cwx_iex_leak_#{System.unique_integer([:positive])}/*")
+
+      {:ok, glob: glob}
+    end
+
+    test "a per-call attach is not written back to ambient", %{glob: glob} do
+      capture_io(fn ->
+        assert_raise Error, fn -> CIEx.chat("go", attach: glob) end
+      end)
+
+      # Before the fix, chat/2 wrote its effective opts (incl. :attach) into
+      # ambient, so the file silently rode along on the next say/2 turn --
+      # re-sending and re-caching it. Per-call opts must not persist.
+      assert CIEx.config() == []
+    end
+
+    test "a per-call query opt is not written back to ambient either", %{glob: glob} do
+      capture_io(fn ->
+        assert_raise Error, fn -> CIEx.chat("go", attach: glob, model: "sonnet") end
+      end)
+
+      refute Keyword.has_key?(CIEx.config(), :model)
+    end
+
+    test "configure/1 composition IS sticky and is applied to chat/2", %{glob: glob} do
+      :ok = CIEx.configure(attach: glob)
+
+      capture_io(fn ->
+        # the configured attach drove the render -> proves it reached chat/2
+        error = assert_raise Error, fn -> CIEx.chat("go") end
+        assert error.kind == :not_found
+        assert error.reason == glob
+      end)
+
+      # ...and it stays configured for later turns (sticky, by opt-in)
+      assert CIEx.config()[:attach] == glob
+    end
+  end
 end

--- a/test/claude_wrapper/prompt_test.exs
+++ b/test/claude_wrapper/prompt_test.exs
@@ -1,0 +1,261 @@
+defmodule ClaudeWrapper.PromptTest do
+  # async: false -- the git_diff tests change the process working directory
+  # (render/1 expands globs and runs `git diff` relative to the process
+  # cwd), which is global state that cannot be shared across async tests.
+  use ExUnit.Case, async: false
+
+  alias ClaudeWrapper.{Error, Prompt}
+
+  setup do
+    base = Path.join(System.tmp_dir!(), "cwx_prompt_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf!(base) end)
+    {:ok, base: base}
+  end
+
+  describe "builders" do
+    test "new sets the base" do
+      assert %Prompt{base: "hi", prepends: [], appends: [], context: []} = Prompt.new("hi")
+    end
+
+    test "prepend/append/attach/git_diff accumulate in call order" do
+      prompt =
+        "base"
+        |> Prompt.new()
+        |> Prompt.prepend("p1")
+        |> Prompt.attach("a/*.ex")
+        |> Prompt.git_diff(nil)
+        |> Prompt.append("ap1")
+        |> Prompt.git_diff("HEAD~1")
+        |> Prompt.prepend("p2")
+
+      assert prompt.prepends == ["p1", "p2"]
+      assert prompt.appends == ["ap1"]
+      assert prompt.context == [{:attach, "a/*.ex"}, {:diff, nil}, {:diff, "HEAD~1"}]
+    end
+  end
+
+  describe "render/1 ordering" do
+    test "joins prepends -> base -> appends with blank lines" do
+      rendered =
+        "base text"
+        |> Prompt.new()
+        |> Prompt.prepend("first")
+        |> Prompt.prepend("second")
+        |> Prompt.append("last")
+        |> Prompt.render()
+
+      assert {:ok, "first\n\nsecond\n\nbase text\n\nlast"} = rendered
+    end
+
+    test "base-only renders just the base" do
+      assert {:ok, "just base"} = "just base" |> Prompt.new() |> Prompt.render()
+    end
+
+    test "attachments come after base and before appends", %{base: base} do
+      file = Path.join(base, "only.txt")
+      File.write!(file, "FILE BODY")
+
+      rendered =
+        "the base"
+        |> Prompt.new()
+        |> Prompt.prepend("PRE")
+        |> Prompt.attach(file)
+        |> Prompt.append("POST")
+        |> Prompt.render()
+
+      assert {:ok, text} = rendered
+      pre_idx = index_of(text, "PRE")
+      base_idx = index_of(text, "the base")
+      file_idx = index_of(text, "FILE BODY")
+      post_idx = index_of(text, "POST")
+      assert pre_idx < base_idx
+      assert base_idx < file_idx
+      assert file_idx < post_idx
+    end
+  end
+
+  describe "render/1 attach" do
+    test "a single file is fenced and headed by its path", %{base: base} do
+      file = Path.join(base, "hello.ex")
+      File.write!(file, "defmodule Hello do\nend\n")
+
+      assert {:ok, text} = "go" |> Prompt.new() |> Prompt.attach(file) |> Prompt.render()
+      assert text =~ "# #{file}\n```\ndefmodule Hello do\nend\n```"
+    end
+
+    test "a glob expands sorted, each file fenced and headed", %{base: base} do
+      File.write!(Path.join(base, "b.txt"), "BBB")
+      File.write!(Path.join(base, "a.txt"), "AAA")
+      File.write!(Path.join(base, "c.txt"), "CCC")
+
+      glob = Path.join(base, "*.txt")
+      assert {:ok, text} = "go" |> Prompt.new() |> Prompt.attach(glob) |> Prompt.render()
+
+      a = Path.join(base, "a.txt")
+      b = Path.join(base, "b.txt")
+      c = Path.join(base, "c.txt")
+
+      # Sorted order: a, b, c.
+      assert index_of(text, "# #{a}") < index_of(text, "# #{b}")
+      assert index_of(text, "# #{b}") < index_of(text, "# #{c}")
+      assert text =~ "```\nAAA\n```"
+      assert text =~ "```\nBBB\n```"
+      assert text =~ "```\nCCC\n```"
+    end
+
+    test "a glob matching nothing is a :not_found error", %{base: base} do
+      glob = Path.join(base, "nope-*.zzz")
+
+      assert {:error, %Error{kind: :not_found, reason: ^glob}} =
+               "go" |> Prompt.new() |> Prompt.attach(glob) |> Prompt.render()
+    end
+
+    test "oversized files are skipped", %{base: base} do
+      small = Path.join(base, "small.txt")
+      big = Path.join(base, "big.txt")
+      File.write!(small, "keepme")
+      # 300 KB > 256 KB cap.
+      File.write!(big, String.duplicate("x", 300 * 1024))
+
+      glob = Path.join(base, "*.txt")
+      assert {:ok, text} = "go" |> Prompt.new() |> Prompt.attach(glob) |> Prompt.render()
+      assert text =~ "# #{small}"
+      assert text =~ "keepme"
+      refute text =~ "# #{big}"
+    end
+
+    test "non-text (invalid UTF-8) files are skipped", %{base: base} do
+      good = Path.join(base, "good.txt")
+      binfile = Path.join(base, "bin.dat")
+      File.write!(good, "readable")
+      File.write!(binfile, <<0xFF, 0xFE, 0x00, 0x01>>)
+
+      glob = Path.join(base, "*")
+      assert {:ok, text} = "go" |> Prompt.new() |> Prompt.attach(glob) |> Prompt.render()
+      assert text =~ "# #{good}"
+      refute text =~ "# #{binfile}"
+    end
+  end
+
+  describe "render/1 git_diff" do
+    test "working-tree diff is fenced as ```diff", %{base: base} do
+      init_repo(base)
+      File.write!(Path.join(base, "tracked.txt"), "v1\n")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "init"])
+      File.write!(Path.join(base, "tracked.txt"), "v2\n")
+
+      rendered =
+        in_dir(base, fn ->
+          "review" |> Prompt.new() |> Prompt.git_diff(nil) |> Prompt.render()
+        end)
+
+      assert {:ok, text} = rendered
+      assert text =~ "```diff"
+      assert text =~ "-v1"
+      assert text =~ "+v2"
+    end
+
+    test "diff against a ref is fenced as ```diff", %{base: base} do
+      init_repo(base)
+      File.write!(Path.join(base, "f.txt"), "one\n")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "c1"])
+      File.write!(Path.join(base, "f.txt"), "two\n")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "c2"])
+
+      rendered =
+        in_dir(base, fn ->
+          "review" |> Prompt.new() |> Prompt.git_diff("HEAD~1") |> Prompt.render()
+        end)
+
+      assert {:ok, text} = rendered
+      assert text =~ "```diff"
+      assert text =~ "-one"
+      assert text =~ "+two"
+    end
+
+    test "a clean working tree contributes no diff block", %{base: base} do
+      init_repo(base)
+      File.write!(Path.join(base, "f.txt"), "stable\n")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "c1"])
+
+      rendered =
+        in_dir(base, fn ->
+          "review" |> Prompt.new() |> Prompt.git_diff(nil) |> Prompt.render()
+        end)
+
+      # No changes -> base only, no fence.
+      assert {:ok, "review"} = rendered
+    end
+
+    test "a non-repo directory is a :git_failed error", %{base: base} do
+      # base is a plain dir, not a git repo.
+      rendered =
+        in_dir(base, fn ->
+          "review" |> Prompt.new() |> Prompt.git_diff(nil) |> Prompt.render()
+        end)
+
+      assert {:error, %Error{kind: :git_failed}} = rendered
+    end
+  end
+
+  describe "render!/1" do
+    test "returns the string on success" do
+      assert "x" == "x" |> Prompt.new() |> Prompt.render!()
+    end
+
+    test "raises ClaudeWrapper.Error on failure", %{base: base} do
+      glob = Path.join(base, "missing-*.none")
+
+      assert_raise Error, fn ->
+        "x" |> Prompt.new() |> Prompt.attach(glob) |> Prompt.render!()
+      end
+    end
+  end
+
+  # -- helpers -------------------------------------------------------
+
+  defp index_of(haystack, needle) do
+    {idx, _} = :binary.match(haystack, needle)
+    idx
+  end
+
+  # Run `fun` with the process cwd set to `dir`, restoring it after. Used
+  # for the git_diff tests, since render/1 operates on the process cwd.
+  defp in_dir(dir, fun) do
+    previous = File.cwd!()
+    File.cd!(dir)
+
+    try do
+      fun.()
+    after
+      File.cd!(previous)
+    end
+  end
+
+  defp init_repo(dir) do
+    git!(dir, ["init", "-q"])
+    git!(dir, ["config", "user.name", "t"])
+    git!(dir, ["config", "user.email", "t@example.com"])
+  end
+
+  defp git!(dir, args) do
+    {out, status} =
+      System.cmd("git", ["-C", dir | args],
+        stderr_to_stdout: true,
+        env: [
+          {"GIT_AUTHOR_NAME", "t"},
+          {"GIT_AUTHOR_EMAIL", "t@example.com"},
+          {"GIT_COMMITTER_NAME", "t"},
+          {"GIT_COMMITTER_EMAIL", "t@example.com"}
+        ]
+      )
+
+    assert status == 0, "git #{Enum.join(args, " ")} failed: #{out}"
+    out
+  end
+end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -3,7 +3,9 @@ defmodule ClaudeWrapperTest do
 
   alias ClaudeWrapper.{
     Config,
+    Error,
     McpConfig,
+    Prompt,
     Query,
     Result,
     Retry,
@@ -551,6 +553,26 @@ defmodule ClaudeWrapperTest do
       config = Config.new()
       session = Session.new(config)
       assert Session.turns(session) == []
+    end
+
+    test "send/3 accepts a %Prompt{} and propagates a render error before any CLI call" do
+      config = Config.new()
+      session = Session.new(config)
+
+      # A glob that matches nothing fails at render time, so send/3 must
+      # short-circuit with the typed error -- no claude subprocess is
+      # spawned (the binary is never invoked because render fails first).
+      glob = Path.join(System.tmp_dir!(), "cwx_no_match_#{System.unique_integer([:positive])}/*")
+      prompt = Prompt.new("hi") |> Prompt.attach(glob)
+
+      assert {:error, %Error{kind: :not_found, reason: ^glob}} = Session.send(session, prompt)
+    end
+
+    test "fork/3 on a session with no id returns :no_session" do
+      config = Config.new()
+      session = Session.new(config)
+
+      assert {:error, %Error{kind: :no_session}} = Session.fork(session, "branch this")
     end
   end
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -149,7 +149,7 @@ defmodule ClaudeWrapper.IntegrationTest do
     end
 
     test "chat and say multi-turn" do
-      assert :ok =
+      assert %ClaudeWrapper.Result{} =
                CIEx.chat("Respond with exactly: hello",
                  max_turns: 1,
                  dangerously_skip_permissions: true,
@@ -159,12 +159,58 @@ defmodule ClaudeWrapper.IntegrationTest do
       assert CIEx.session_id() != nil
       assert CIEx.last().result =~ "hello"
 
-      assert :ok = CIEx.say("Respond with exactly: goodbye")
+      assert %ClaudeWrapper.Result{} = CIEx.say("Respond with exactly: goodbye")
       assert CIEx.last().result =~ "goodbye"
 
       total = CIEx.cost()
       assert is_float(total)
       assert total > 0.0
+    end
+
+    test "high-level flow: chat with attach, say, fork, sessions" do
+      tmp = Path.join(System.tmp_dir!(), "cwx_iex_flow_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp)
+      File.write!(Path.join(tmp, "note.txt"), "The secret token is BANANA.")
+      on_exit(fn -> File.rm_rf!(tmp) end)
+
+      # chat with an attached file. Persisted (no :no_session_persistence)
+      # so the session can show up in sessions/0 below. working_dir is the
+      # temp dir so history is keyed to this project slug.
+      result =
+        CIEx.chat("Read the attached file and reply with exactly the secret token.",
+          working_dir: tmp,
+          attach: Path.join(tmp, "note.txt"),
+          max_turns: 1,
+          dangerously_skip_permissions: true
+        )
+
+      assert %ClaudeWrapper.Result{} = result
+      first_id = CIEx.session_id()
+      assert is_binary(first_id)
+
+      # say continues the same session.
+      assert %ClaudeWrapper.Result{} = CIEx.say("Respond with exactly: continued")
+      assert CIEx.last().result =~ "continued"
+
+      # fork branches into a new session; current/0 switches to the branch.
+      assert %ClaudeWrapper.Result{} = CIEx.fork("Respond with exactly: forked")
+      branch_id = CIEx.session_id()
+      assert is_binary(branch_id)
+      assert branch_id != first_id
+
+      # sessions/0 reads on-disk history for the ambient working_dir and
+      # projects each row to the documented summary shape.
+      summaries = CIEx.sessions()
+      assert is_list(summaries)
+
+      for s <- summaries do
+        assert Map.has_key?(s, :id)
+        assert Map.has_key?(s, :first_prompt)
+        assert Map.has_key?(s, :turns)
+        assert Map.has_key?(s, :last_used)
+        assert Map.has_key?(s, :tokens)
+        assert Map.has_key?(s, :cost_usd)
+      end
     end
   end
 


### PR DESCRIPTION
**Draft for review** -- "let's see what we think." Builds the high-level API we modeled, programmatic-first with IEx as a thin skin.

## Three layers
- **`ClaudeWrapper.Prompt`** (new, standalone) -- composable prompt builder. Pure builders (`new`/`prepend`/`append`/`attach`/`git_diff`) record intent; `render/1` does the IO and returns `{:ok, String} | {:error, %Error{}}` (`render!/1` raises). `attach` expands globs (sorted, fenced, `# <path>`-headed; skips dirs/binary/>256KB); `git_diff` shells out like `Worktrees`. Renders **prepends → base → context (attach/diff in call order) → appends**.
- **`ClaudeWrapper.Session`** (deltas) -- `send/3` now accepts `String | %Prompt{}` (renders, propagates errors as tuples); new `fork/3` branches a session (`resume` + `--fork-session`) returning a session bound to the new id; `{:error, %Error{kind: :no_session}}` if there's no prior turn to fork.
- **`ClaudeWrapper.IEx`** (thin skin) -- `configure`/`config` (ambient opts in the procdict), `chat`/`say` (build a `Prompt` from `:attach`/`:git_diff`/`:prepend`/`:append`, return `%Result{}`, raise on failure), `fork`/`fork_from`, `sessions/0` (History-backed, project-scoped), `pick/0`, `current/0`.

Discovery reuses `History`; defaults reuse `Config` + `Session` query_opts.

## Live verification
`chat(attach) -> say -> fork -> sessions` round-trips against `claude` 2.1.173:
```
...
(attached 1 file, ~0.1KB)
continued
($0.1521 this turn, $0.2483 total, 2 turns)
... (forking)
forked
($0.0153, 1 turn)
```

## Heads-up / behavior change
`IEx.chat/2` and `say/2` now **return `%Result{}` and raise `%Error{}` on failure** (were `:ok`). `say/2` still returns `:no_session` when nothing is active. (Consider `feat!:` when we finalize, if we keep this.)

## Open for discussion (cosmetic, non-blocking)
- The `(attached N files…)` notice counts files by `# `-prefixed lines in the rendered string -- a prompt body with markdown `# ` headers would inflate the count. Could expose the real match count from `Prompt` instead.
- `chat/2` persists the merged per-call opts as the new ambient (so a per-call `model:` leaks into later `say`s). `say/2` does not persist. Decide whether that asymmetry is what we want.
- `Prompt` interleaves attach/diff in **call order** rather than "all attaches then all diffs" (deviation from the shorthand model line; arguably nicer).

Unit suite **502 passing**; credo/dialyzer clean. No new deps. The `Chat` facade stays deferred.