### PR TITLE
fix: match CLI slug encoding for all non-alphanumeric path chars

### DIFF
--- a/lib/claude_wrapper/history.ex
+++ b/lib/claude_wrapper/history.ex
@@ -97,11 +97,17 @@ defmodule ClaudeWrapper.History do
   ## Slug encoding
 
   Project directory names are filesystem-safe encodings of an absolute
-  path: every `/` and `.` becomes `-` (so `/Users/josh/Code/foo` becomes
-  `-Users-josh-Code-foo`). `project_slug/1` is the forward derivation
-  (canonicalize + encode); `ProjectSummary.decoded_path` is a best-effort
-  inverse that anchors on the real filesystem to disambiguate literal
-  hyphens in directory names.
+  path: every character that is not a letter or digit becomes `-` (so
+  `/Users/josh/Code/foo_bar` becomes `-Users-josh-Code-foo-bar`).
+  `project_slug/1` is the forward derivation (canonicalize + encode);
+  `ProjectSummary.decoded_path` is a best-effort inverse that anchors on
+  the real filesystem to disambiguate literal hyphens in directory names.
+
+  The encoding is lossy -- a `-` in a slug may have been a `/`, `.`, `_`,
+  space, or a literal hyphen -- so the inverse cannot always be exact.
+  When `decode_slug_anchored` cannot confirm a decoded path against the
+  filesystem it sets `ProjectSummary.decode_verified?` to `false`. The
+  forward direction has no such ambiguity and always matches the CLI.
 
   ## Example
 
@@ -298,11 +304,15 @@ defmodule ClaudeWrapper.History do
   @doc """
   Derive Claude Code's project-directory slug for a filesystem path,
   matching the CLI: the path is canonicalized (best-effort symlink
-  resolution) and then every `/` and `.` is encoded as `-`.
+  resolution) and then every character that is not a letter or digit
+  (`/`, `.`, `_`, space, ...) is encoded as `-`.
 
   This is the reliable way to locate the project directory for a working
   directory -- see `sessions_for_path/3`. Falls back to the expanded path
   when it cannot be canonicalized.
+
+      iex> ClaudeWrapper.History.project_slug("/Users/josh/Code/foo_bar")
+      "-Users-josh-Code-foo-bar"
   """
   @spec project_slug(String.t()) :: String.t()
   def project_slug(path) when is_binary(path) do
@@ -536,7 +546,13 @@ defmodule ClaudeWrapper.History do
 
   # -- slug encode / decode ------------------------------------------
 
-  defp encode_path_slug(path), do: String.replace(path, ["/", "."], "-")
+  # Claude Code sanitizes the absolute path into a directory name by
+  # replacing every character that is not a letter or digit with `-` --
+  # not just `/` and `.` but `_`, spaces, and any other separator too.
+  # Match that exactly, or the derived slug won't find sessions for paths
+  # that contain underscores (e.g. `claude_wrapper_ex` -> the real dir is
+  # `...-claude-wrapper-ex`, not `...-claude_wrapper_ex`).
+  defp encode_path_slug(path), do: String.replace(path, ~r/[^A-Za-z0-9]/, "-")
 
   # Decode a slug back to a path, anchoring on the real filesystem to
   # disambiguate literal hyphens in directory names. Returns

--- a/test/claude_wrapper/history_test.exs
+++ b/test/claude_wrapper/history_test.exs
@@ -1,6 +1,8 @@
 defmodule ClaudeWrapper.HistoryTest do
   use ExUnit.Case, async: true
 
+  doctest ClaudeWrapper.History, import: true
+
   alias ClaudeWrapper.History
   alias ClaudeWrapper.History.{ProjectSummary, SessionLog, SessionSummary}
 
@@ -233,16 +235,25 @@ defmodule ClaudeWrapper.HistoryTest do
   end
 
   describe "project_slug/1 and sessions_for_path/3" do
-    test "encodes both '/' and '.' as '-'" do
+    test "encodes '/', '.', and '_' as '-' (matching the CLI)" do
       tmp = Path.join(System.tmp_dir!(), "cwx_slug_#{System.unique_integer([:positive])}")
-      cwd = Path.join(tmp, "my.proj")
+      # Mix all three separators the CLI collapses to '-': a dotted dir and
+      # an underscored dir. Regression for the slug missing '_' (which made
+      # sessions_for_path silently miss any underscored project dir).
+      cwd = Path.join([tmp, "my.proj", "claude_wrapper_ex"])
       File.mkdir_p!(cwd)
       on_exit(fn -> File.rm_rf!(tmp) end)
 
       slug = History.project_slug(cwd)
       assert slug =~ "my-proj"
+      assert slug =~ "claude-wrapper-ex"
       refute slug =~ "."
       refute slug =~ "/"
+      refute slug =~ "_"
+    end
+
+    test "encodes every non-alphanumeric character as '-'" do
+      assert History.project_slug("/Users/josh/Code/foo_bar") == "-Users-josh-Code-foo-bar"
     end
 
     test "sessions_for_path derives the slug and finds sessions", %{root: root} do


### PR DESCRIPTION
## Bug

`ClaudeWrapper.History.project_slug/1` only collapsed `/` and `.` to `-`, but Claude Code's CLI sanitizes the absolute path into a project-directory name by replacing **every** non-alphanumeric character (`/`, `.`, `_`, space, ...) with `-`.

Because of the gap, `project_slug/1` — and `sessions_for_path/3`, which derives the slug — silently missed any project whose path contains an underscore. For this very repo:

- derived slug: `…-genagent-claude_wrapper_ex`
- real `~/.claude/projects` dir: `…-genagent-claude-wrapper-ex`

so `sessions_for_path/3` looked in a directory that doesn't exist and returned `[]`. Surfaced live while testing the high-level `IEx.sessions/0` / `pick/0` helpers against this directory.

## Fix

Encode every `[^A-Za-z0-9]` character as `-`, matching the CLI exactly:

```elixir
defp encode_path_slug(path), do: String.replace(path, ~r/[^A-Za-z0-9]/, "-")
```

Verified:

```
$ mix run -e 'IO.puts(ClaudeWrapper.History.project_slug(File.cwd!()))'
-Users-joshrotenberg-Code-active-elixir-genagent-claude-wrapper-ex   # matches ~/.claude/projects
```

## Also

- Updated the moduledoc "Slug encoding" section and the `project_slug/1` `@doc` (both previously said "every `/` and `.`"), and noted the inverse is lossy/best-effort (the decode already flags unverified paths via `decode_verified?`).
- Added a `project_slug/1` doctest and wired `doctest ClaudeWrapper.History`.
- Extended the slug test to cover `_` and added an explicit `[^A-Za-z0-9] -> -` case.

The decode direction (`decode_slug_anchored`) is unchanged — it is already best-effort and honestly reports `decode_verified? = false` when it can't confirm a path against the filesystem.

## Testing

`mix format` / `mix compile --warnings-as-errors` / `mix credo --strict` clean; full suite **504 passed (22 doctests)**.

> Note: the Rust `claude-wrapper` crate has the identical `'/' | '.'` logic and the same bug; tracking upstream separately.