### PR TITLE
fix: exclude cache-read tokens from session total_tokens; document cost gap

### DIFF
--- a/lib/claude_wrapper/history.ex
+++ b/lib/claude_wrapper/history.ex
@@ -22,6 +22,17 @@ defmodule ClaudeWrapper.History.SessionSummary do
   Summary of one session `.jsonl` file.
 
   See `ClaudeWrapper.History` for how these are produced.
+
+  Two fields deserve a note:
+
+    * `total_tokens` counts throughput -- fresh input, output, and cache
+      *creation* -- and **excludes** cache-read tokens. Cache reads re-count
+      context already tallied when it was first cached, so including them
+      inflates a long session 10-100x and makes the figure track
+      conversation length rather than work done. The raw per-turn usage is
+      still available via `ClaudeWrapper.History.read_session/2`.
+    * `total_cost_usd` is almost always `nil`: Claude Code does not persist
+      per-message cost in its transcripts, only token usage.
   """
 
   @enforce_keys [:session_id, :project_slug, :message_count, :size_bytes]
@@ -448,6 +459,9 @@ defmodule ClaudeWrapper.History do
     end
   end
 
+  # Interactive Claude Code transcripts persist token usage but not cost,
+  # so `total_cost_usd` is nil for virtually every real session. Kept for
+  # the rare transcript that does carry a `total_cost_usd`.
   defp add_cost(current, usage) do
     case usage["total_cost_usd"] do
       c when is_number(c) -> (current || 0.0) + c
@@ -455,9 +469,15 @@ defmodule ClaudeWrapper.History do
     end
   end
 
+  # Sum only throughput tokens: fresh input, output, and cache *creation*
+  # (first-time processing of context). cache_read_input_tokens is
+  # deliberately excluded -- it re-counts context already tallied on the
+  # turn it was cached, so including it inflates a long session 10-100x
+  # (re-reads dominate) and makes the total track conversation length
+  # rather than work done.
   defp add_tokens(current, usage) do
     sum =
-      ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"]
+      ["input_tokens", "output_tokens", "cache_creation_input_tokens"]
       |> Enum.reduce(0, fn k, t ->
         case usage[k] do
           n when is_integer(n) -> t + n

--- a/test/claude_wrapper/history_test.exs
+++ b/test/claude_wrapper/history_test.exs
@@ -136,7 +136,8 @@ defmodule ClaudeWrapper.HistoryTest do
   end
 
   describe "summary details" do
-    test "ai-title accepts camelCase and legacy title; sums usage tokens", %{root: root} do
+    test "ai-title accepts camelCase and legacy title; sums throughput tokens (excludes cache reads)",
+         %{root: root} do
       dir = Path.join(root, "-p")
 
       write_session(dir, "camel", [
@@ -150,7 +151,7 @@ defmodule ClaudeWrapper.HistoryTest do
       ])
 
       write_session(dir, "tokens", [
-        ~s({"type":"assistant","timestamp":"2026-05-01T00:00:00Z","message":{"usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":2}}})
+        ~s({"type":"assistant","timestamp":"2026-05-01T00:00:00Z","message":{"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":3,"cache_read_input_tokens":2}}})
       ])
 
       {:ok, sessions} = History.list_sessions(History.at(root), slug: "-p")
@@ -158,7 +159,9 @@ defmodule ClaudeWrapper.HistoryTest do
 
       assert by_id["camel"].title == "Camel Title"
       assert by_id["legacy"].title == "Legacy Title"
-      assert by_id["tokens"].total_tokens == 17
+      # input 10 + output 5 + cache_creation 3 = 18; cache_read (2) excluded
+      assert by_id["tokens"].total_tokens == 18
+      assert by_id["tokens"].total_cost_usd == nil
     end
 
     test "include_empty: false drops zero-message orphan sessions", %{root: root} do


### PR DESCRIPTION
## Two `History` metadata fixes, surfaced while reviewing `IEx.sessions/0`

### 1. `total_tokens` was 90%+ cache re-reads

`SessionSummary.total_tokens` summed all four usage token types, including `cache_read_input_tokens`. Cache reads re-count context that was already tallied when it was first cached, so on a long session they dominate and the figure tracks conversation length rather than work done.

Measured on a real transcript in this repo's history:

| token type | count | share |
|---|---|---|
| input | 367 | ~0% |
| output | 128,877 | 0.6% |
| cache_creation | 1,333,505 | 6.5% |
| **cache_read** | **18,904,748** | **93%** |
| blended total (old `total_tokens`) | 20,367,497 | |
| input+output+cache_creation (new) | 1,462,749 | |

Fix: sum only throughput tokens (`input + output + cache_creation`). The raw per-turn usage is still available via `read_session/2` for anyone who wants cache reads.

### 2. `total_cost_usd` is ~always nil — now documented

Claude Code does not persist per-message cost in its transcripts (confirmed: no `*cost*` field of any kind appears in real transcripts), only token usage. So `add_cost/2` can only ever yield nil for real sessions. No logic change — just a doc note on the field and a comment on `add_cost/2` so it doesn't read as broken, plus a test asserting `total_cost_usd == nil`.

## Notes
- `SessionSummary.total_tokens` semantics change (now excludes cache reads). The struct shape is unchanged; this is a young read-side API with no known external consumers depending on the inflated value.
- Extends the existing token test to include a `cache_creation` token and assert cache reads are excluded (`10 + 5 + 3 = 18`, not `20`).

## Testing
`mix format` / `compile --warnings-as-errors` / `credo --strict` / `dialyzer` clean; suite **479 passed (22 doctests)**.