### PR TITLE
feat: Prompt git_log/git_status/vars composition; unify git block headers

### DIFF
--- a/lib/claude_wrapper/iex.ex
+++ b/lib/claude_wrapper/iex.ex
@@ -75,7 +75,7 @@ defmodule ClaudeWrapper.IEx do
   @history_key :claude_wrapper_iex_history
 
   @config_keys [:binary, :working_dir, :env, :timeout, :verbose, :debug]
-  @composition_keys [:attach, :git_diff, :prepend, :append]
+  @composition_keys [:attach, :git_diff, :git_log, :git_status, :prepend, :append, :vars]
 
   @typedoc "A session row as returned by `sessions/0`."
   @type session_summary :: %{
@@ -395,8 +395,20 @@ defmodule ClaudeWrapper.IEx do
   defp apply_composition({:attach, values}, prompt),
     do: reduce_strings(prompt, values, &Prompt.attach/2)
 
+  defp apply_composition({:git_diff, false}, prompt), do: prompt
   defp apply_composition({:git_diff, true}, prompt), do: Prompt.git_diff(prompt, nil)
   defp apply_composition({:git_diff, ref}, prompt), do: Prompt.git_diff(prompt, ref)
+
+  defp apply_composition({:git_log, false}, prompt), do: prompt
+  defp apply_composition({:git_log, true}, prompt), do: Prompt.git_log(prompt)
+
+  defp apply_composition({:git_log, n}, prompt) when is_integer(n),
+    do: Prompt.git_log(prompt, n: n)
+
+  defp apply_composition({:git_status, false}, prompt), do: prompt
+  defp apply_composition({:git_status, _}, prompt), do: Prompt.git_status(prompt)
+
+  defp apply_composition({:vars, vars}, prompt), do: Prompt.vars(prompt, vars)
 
   # A composition value may be a single string or a list of them.
   defp reduce_strings(prompt, values, fun) when is_list(values) do
@@ -413,7 +425,13 @@ defmodule ClaudeWrapper.IEx do
     if attaches == 0 do
       nil
     else
-      files = rendered |> String.split("\n") |> Enum.count(&String.starts_with?(&1, "# "))
+      # Count attach headers (`# <path>`) only -- git context blocks now
+      # carry `# git <cmd>` headers too, which must not inflate the count.
+      files =
+        rendered
+        |> String.split("\n")
+        |> Enum.count(&(String.starts_with?(&1, "# ") and not String.starts_with?(&1, "# git ")))
+
       "(attached #{files} file#{plural(files)}, ~#{kb(byte_size(rendered))})"
     end
   end

--- a/lib/claude_wrapper/prompt.ex
+++ b/lib/claude_wrapper/prompt.ex
@@ -1,16 +1,17 @@
 defmodule ClaudeWrapper.Prompt do
   @moduledoc """
-  Composable prompt builder with deferred file / git-diff expansion.
+  Composable prompt builder with deferred file / git expansion.
 
   A `Prompt` is a pure value: the builders (`new/1`, `prepend/2`,
-  `append/2`, `attach/2`, `git_diff/2`) only record intent. All IO --
-  reading attached files, shelling out to `git diff` -- happens in
-  `render/1`, which assembles the final string in a **fixed order**:
+  `append/2`, `attach/2`, `git_diff/2`, `git_log/2`, `git_status/1`,
+  `vars/2`) only record intent. All IO -- reading attached files, shelling
+  out to git -- happens in `render/1`, which assembles the final string in
+  a **fixed order**:
 
-      prepends -> base -> attachments -> diffs -> appends
+      prepends -> base -> context (attach / git) -> appends
 
   Each section is separated from the next by a blank line, and within the
-  context section attachments and diffs appear in the order their builder
+  context section the attach/git blocks appear in the order their builder
   calls were made (interleaved exactly as you wrote them).
 
   This split keeps composition cheap and total -- you can build a prompt
@@ -25,13 +26,33 @@ defmodule ClaudeWrapper.Prompt do
       ...> |> ClaudeWrapper.Prompt.render()
       {:ok, "You are a careful reviewer.\\n\\nReview this change\\n\\nFocus on correctness."}
 
-  Attached files are emitted as fenced code blocks, each headed by a
-  `# <path>` comment line. Globs are expanded with `Path.wildcard/1` and
-  sorted; a glob that matches nothing is an error. Files that are not
-  valid UTF-8 text, or that exceed #{div(262_144, 1024)} KB, are skipped.
+  ## Context blocks
 
-  Git diffs are emitted inside a ```` ```diff ```` fence. `git_diff(p,
-  nil)` diffs the working tree; `git_diff(p, ref)` diffs against `ref`.
+  Attached files and git output are emitted as fenced blocks, each headed
+  by a `# <source>` comment line:
+
+    * `attach/2` -- one `# <path>` block per matched text file. Globs are
+      expanded with `Path.wildcard/1` and sorted; a glob matching nothing
+      is an error. Files that are not valid UTF-8, or exceed
+      #{div(262_144, 1024)} KB, are skipped.
+    * `git_diff/2` -- `# git diff` (working tree) or `# git diff <ref>`,
+      inside a ```` ```diff ```` fence.
+    * `git_log/2` -- `# git log --oneline -n N` (default 5).
+    * `git_status/1` -- `# git status --short`.
+
+  A git block whose output is empty (clean tree, no commits, no changes)
+  contributes nothing rather than an empty fence.
+
+  ## Template variables
+
+  `vars/2` records `{{key}}` substitutions applied to the **authored** text
+  (base / prepends / appends) at render time; captured context blocks are
+  left verbatim. Unknown `{{...}}` slots are left untouched.
+
+      iex> ClaudeWrapper.Prompt.new("Summarize {{file}} for a {{who}} reader")
+      ...> |> ClaudeWrapper.Prompt.vars(file: "config.ex", who: "beginner")
+      ...> |> ClaudeWrapper.Prompt.render()
+      {:ok, "Summarize config.ex for a beginner reader"}
   """
 
   alias ClaudeWrapper.Error
@@ -43,23 +64,33 @@ defmodule ClaudeWrapper.Prompt do
       a fenced, path-headed block.
     * `{:diff, ref}` -- a `git diff`; `nil` is the working tree, a binary
       is a ref/commit to diff against.
+    * `{:log, n}` -- a `git log --oneline -n n` block.
+    * `:status` -- a `git status --short` block.
   """
-  @type context_item :: {:attach, String.t()} | {:diff, String.t() | nil}
+  @type context_item ::
+          {:attach, String.t()}
+          | {:diff, String.t() | nil}
+          | {:log, pos_integer()}
+          | :status
 
   @type t :: %__MODULE__{
           base: String.t(),
           prepends: [String.t()],
           appends: [String.t()],
-          context: [context_item()]
+          context: [context_item()],
+          vars: %{optional(String.t()) => String.t()}
         }
 
   @enforce_keys [:base]
-  defstruct base: "", prepends: [], appends: [], context: []
+  defstruct base: "", prepends: [], appends: [], context: [], vars: %{}
 
   # Files larger than this are skipped during attach expansion. 256 KB is
   # generous for source files while keeping a single prompt from ballooning
   # on an accidentally-matched binary or build artifact.
   @max_attach_bytes 262_144
+
+  # Default commit count for git_log/2.
+  @default_log_count 5
 
   @doc """
   Start a new prompt from its base text.
@@ -97,8 +128,8 @@ defmodule ClaudeWrapper.Prompt do
 
   Nothing is read now; the glob is expanded at `render/1` time with
   `Path.wildcard/1`, sorted, and each text file is emitted as a fenced,
-  path-headed code block. Recorded in call order relative to
-  `git_diff/2`.
+  path-headed code block. Recorded in call order relative to the other
+  context builders.
   """
   @spec attach(t(), String.t()) :: t()
   def attach(%__MODULE__{} = prompt, glob) when is_binary(glob) do
@@ -109,9 +140,9 @@ defmodule ClaudeWrapper.Prompt do
   Record a git diff to include.
 
   `ref` is `nil` for the working tree, or a ref/commit string to diff
-  against (`git diff <ref>`). The diff is produced at `render/1` time and
-  emitted inside a ```` ```diff ```` fence. Recorded in call order
-  relative to `attach/2`.
+  against (`git diff <ref>`). Produced at `render/1` time under a
+  `# git diff` header inside a ```` ```diff ```` fence. Recorded in call
+  order relative to the other context builders.
   """
   @spec git_diff(t(), String.t() | nil) :: t()
   def git_diff(%__MODULE__{} = prompt, ref) when is_binary(ref) or is_nil(ref) do
@@ -119,24 +150,72 @@ defmodule ClaudeWrapper.Prompt do
   end
 
   @doc """
+  Record a `git log --oneline -n N` block (default N = #{@default_log_count}).
+
+  Options:
+
+    * `:n` -- number of commits (default #{@default_log_count}).
+
+  Produced at `render/1` time under a `# git log` header. Recorded in call
+  order relative to the other context builders.
+  """
+  @spec git_log(t(), keyword()) :: t()
+  def git_log(%__MODULE__{} = prompt, opts \\ []) when is_list(opts) do
+    n = Keyword.get(opts, :n, @default_log_count)
+    %{prompt | context: prompt.context ++ [{:log, n}]}
+  end
+
+  @doc """
+  Record a `git status --short` block.
+
+  Produced at `render/1` time under a `# git status` header. A clean
+  working tree contributes no block. Recorded in call order relative to
+  the other context builders.
+  """
+  @spec git_status(t()) :: t()
+  def git_status(%__MODULE__{} = prompt) do
+    %{prompt | context: prompt.context ++ [:status]}
+  end
+
+  @doc """
+  Record `{{key}}` template substitutions.
+
+  Applied at `render/1` time to the authored text (base, prepends,
+  appends) only -- captured context blocks (`attach`/`git_*`) are left
+  verbatim. Accepts a map or keyword list; keys and values are stringified.
+  Unknown `{{...}}` placeholders are left untouched. Repeatable (later
+  calls merge, last wins).
+
+      iex> ClaudeWrapper.Prompt.new("hi {{name}}").vars
+      %{}
+  """
+  @spec vars(t(), map() | keyword()) :: t()
+  def vars(%__MODULE__{} = prompt, vars) when is_map(vars) or is_list(vars) do
+    normalized = Map.new(vars, fn {k, v} -> {to_string(k), to_string(v)} end)
+    %{prompt | vars: Map.merge(prompt.vars, normalized)}
+  end
+
+  @doc """
   Render the prompt to its final string.
 
-  Performs all deferred IO -- reads attached files, runs `git diff` --
-  and joins the sections (prepends, base, attachments, diffs, appends)
-  with blank lines.
+  Performs all deferred IO -- reads attached files, runs git -- substitutes
+  template vars in the authored text, and joins the sections (prepends,
+  base, context, appends) with blank lines.
 
   Returns `{:error, %ClaudeWrapper.Error{}}` if a glob matches no files
-  (`:not_found`), or if a git diff fails (`:git_failed`) or `git` is
-  unavailable (`:git_unavailable`). The working directory for both file
-  globs and git is the current process cwd.
+  (`:not_found`), or if a git command fails (`:git_failed`) or `git` is
+  unavailable (`:git_unavailable`). The working directory for file globs
+  and git is the current process cwd.
   """
   @spec render(t()) :: {:ok, String.t()} | {:error, Error.t()}
   def render(%__MODULE__{} = prompt) do
     with {:ok, context} <- render_context(prompt.context) do
-      sections = prompt.prepends ++ [prompt.base] ++ context ++ prompt.appends
+      prepends = Enum.map(prompt.prepends, &substitute(&1, prompt.vars))
+      base = substitute(prompt.base, prompt.vars)
+      appends = Enum.map(prompt.appends, &substitute(&1, prompt.vars))
 
       rendered =
-        sections
+        (prepends ++ [base] ++ context ++ appends)
         |> Enum.reject(&(&1 == ""))
         |> Enum.join("\n\n")
 
@@ -154,6 +233,17 @@ defmodule ClaudeWrapper.Prompt do
       {:ok, rendered} -> rendered
       {:error, error} -> raise error
     end
+  end
+
+  # -- template substitution -----------------------------------------
+
+  # Single-pass `{{key}}` substitution over authored text. Unknown keys are
+  # left verbatim and substituted values are never re-scanned. A prompt
+  # with no vars is returned untouched.
+  defp substitute(text, vars) when map_size(vars) == 0, do: text
+
+  defp substitute(text, vars) do
+    Regex.replace(~r/\{\{(\w+)\}\}/, text, fn whole, key -> Map.get(vars, key, whole) end)
   end
 
   # -- context rendering ---------------------------------------------
@@ -174,10 +264,12 @@ defmodule ClaudeWrapper.Prompt do
   defp finalize_context({:ok, blocks}), do: {:ok, blocks}
   defp finalize_context({:error, _} = error), do: error
 
-  # An attach can yield several blocks (one per matched file); a diff
-  # yields at most one. Both return `{:ok, [block]}` or `{:error, _}`.
+  # Each item yields `{:ok, [block]}` (attach can be many; git is at most
+  # one) or `{:error, _}`.
   defp render_item({:attach, glob}), do: render_attach(glob)
   defp render_item({:diff, ref}), do: render_diff(ref)
+  defp render_item({:log, n}), do: render_log(n)
+  defp render_item(:status), do: render_status()
 
   # -- attach --------------------------------------------------------
 
@@ -204,23 +296,37 @@ defmodule ClaudeWrapper.Prompt do
 
   defp trim_trailing_newline(content), do: String.trim_trailing(content, "\n")
 
-  # -- git diff ------------------------------------------------------
+  # -- git -----------------------------------------------------------
 
   defp render_diff(ref) do
+    header = if ref, do: "# git diff #{ref}", else: "# git diff"
     args = ["diff"] ++ if(ref, do: [ref], else: [])
+    run_git_block(args, header, "diff")
+  end
 
+  defp render_log(n) do
+    run_git_block(["log", "--oneline", "-n", to_string(n)], "# git log --oneline -n #{n}", "")
+  end
+
+  defp render_status do
+    run_git_block(["status", "--short"], "# git status --short", "")
+  end
+
+  # Run a git command and wrap its stdout in a headed, fenced block. Empty
+  # output (clean tree, no commits, no changes) contributes no block rather
+  # than an empty fence. A non-zero exit is a tagged `:git_failed` error.
+  defp run_git_block(args, header, fence) do
     case safe_git(args) do
-      {:ok, {output, 0}} -> {:ok, diff_blocks(output)}
+      {:ok, {output, 0}} -> {:ok, context_block(header, fence, output)}
       {:ok, {output, status}} -> {:error, git_failed(status, output)}
       {:error, _} = error -> error
     end
   end
 
-  # An empty diff (no changes) contributes no block.
-  defp diff_blocks(output) do
+  defp context_block(header, fence, output) do
     case String.trim(output) do
       "" -> []
-      trimmed -> ["```diff\n#{trimmed}\n```"]
+      trimmed -> ["#{header}\n```#{fence}\n#{trimmed}\n```"]
     end
   end
 
@@ -228,7 +334,7 @@ defmodule ClaudeWrapper.Prompt do
   # instead of an ErlangError escaping the module. Mirrors
   # ClaudeWrapper.Worktrees. Git (like the attach globs) runs relative to
   # the current process cwd, passed explicitly via `:cd` so the working
-  # directory the diff is taken in is unambiguous.
+  # directory is unambiguous.
   defp safe_git(args) do
     {:ok, System.cmd("git", args, stderr_to_stdout: true, cd: File.cwd!())}
   rescue

--- a/test/claude_wrapper/iex_test.exs
+++ b/test/claude_wrapper/iex_test.exs
@@ -98,6 +98,24 @@ defmodule ClaudeWrapper.IExTest do
         assert error.reason == glob
       end)
     end
+
+    test "git_log / git_status / vars compose without error (wired as composition keys)" do
+      glob =
+        Path.join(System.tmp_dir!(), "cwx_iex_comp_#{System.unique_integer([:positive])}/*")
+
+      # The bad-glob attach raises :not_found at render -- but only after
+      # compose/2 applies the other composition keys. A missing apply_composition
+      # clause would raise FunctionClauseError instead, so reaching a typed
+      # ClaudeWrapper.Error proves git_log/git_status/vars are all wired.
+      capture_io(fn ->
+        error =
+          assert_raise Error, fn ->
+            CIEx.chat("go", git_log: 5, git_status: true, vars: %{x: "y"}, attach: glob)
+          end
+
+        assert error.kind == :not_found
+      end)
+    end
   end
 
   describe "per-call options never leak into ambient (regression: composition leak)" do

--- a/test/claude_wrapper/prompt_test.exs
+++ b/test/claude_wrapper/prompt_test.exs
@@ -4,6 +4,8 @@ defmodule ClaudeWrapper.PromptTest do
   # cwd), which is global state that cannot be shared across async tests.
   use ExUnit.Case, async: false
 
+  doctest ClaudeWrapper.Prompt
+
   alias ClaudeWrapper.{Error, Prompt}
 
   setup do
@@ -32,6 +34,23 @@ defmodule ClaudeWrapper.PromptTest do
       assert prompt.prepends == ["p1", "p2"]
       assert prompt.appends == ["ap1"]
       assert prompt.context == [{:attach, "a/*.ex"}, {:diff, nil}, {:diff, "HEAD~1"}]
+    end
+
+    test "git_log / git_status / vars accumulate" do
+      prompt =
+        "base"
+        |> Prompt.new()
+        |> Prompt.git_log(n: 3)
+        |> Prompt.git_status()
+        |> Prompt.vars(a: 1, b: "two")
+        |> Prompt.vars(%{"a" => "override"})
+
+      assert prompt.context == [{:log, 3}, :status]
+      assert prompt.vars == %{"a" => "override", "b" => "two"}
+    end
+
+    test "git_log defaults to 5 commits" do
+      assert %Prompt{context: [{:log, 5}]} = "x" |> Prompt.new() |> Prompt.git_log()
     end
   end
 
@@ -200,6 +219,114 @@ defmodule ClaudeWrapper.PromptTest do
         end)
 
       assert {:error, %Error{kind: :git_failed}} = rendered
+    end
+
+    test "the diff block is headed `# git diff`", %{base: base} do
+      init_repo(base)
+      File.write!(Path.join(base, "t.txt"), "a\n")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "c"])
+      File.write!(Path.join(base, "t.txt"), "b\n")
+
+      assert {:ok, text} =
+               in_dir(base, fn ->
+                 "r" |> Prompt.new() |> Prompt.git_diff(nil) |> Prompt.render()
+               end)
+
+      assert text =~ "# git diff\n```diff"
+    end
+  end
+
+  describe "render/1 git_log" do
+    test "renders a headed, fenced oneline log", %{base: base} do
+      init_repo(base)
+      File.write!(Path.join(base, "f.txt"), "x")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "first commit"])
+
+      assert {:ok, text} =
+               in_dir(base, fn ->
+                 "review" |> Prompt.new() |> Prompt.git_log(n: 1) |> Prompt.render()
+               end)
+
+      assert text =~ "# git log --oneline -n 1"
+      assert text =~ "first commit"
+    end
+
+    test "a non-repo directory is a :git_failed error", %{base: base} do
+      assert {:error, %Error{kind: :git_failed}} =
+               in_dir(base, fn ->
+                 "review" |> Prompt.new() |> Prompt.git_log() |> Prompt.render()
+               end)
+    end
+  end
+
+  describe "render/1 git_status" do
+    test "renders a headed, fenced short status", %{base: base} do
+      init_repo(base)
+      File.write!(Path.join(base, "tracked.txt"), "v1\n")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "init"])
+      File.write!(Path.join(base, "new.txt"), "untracked\n")
+
+      assert {:ok, text} =
+               in_dir(base, fn ->
+                 "review" |> Prompt.new() |> Prompt.git_status() |> Prompt.render()
+               end)
+
+      assert text =~ "# git status --short"
+      assert text =~ "new.txt"
+    end
+
+    test "a clean working tree contributes no block", %{base: base} do
+      init_repo(base)
+      File.write!(Path.join(base, "f.txt"), "stable\n")
+      git!(base, ["add", "."])
+      git!(base, ["commit", "-m", "c1"])
+
+      assert {:ok, "review"} =
+               in_dir(base, fn ->
+                 "review" |> Prompt.new() |> Prompt.git_status() |> Prompt.render()
+               end)
+    end
+  end
+
+  describe "render/1 vars" do
+    test "substitutes {{key}} in base, prepends, and appends" do
+      assert {:ok, "Hi Ada --\n\nbase for Ada\n\n-- bye Ada"} =
+               "base for {{name}}"
+               |> Prompt.new()
+               |> Prompt.prepend("Hi {{name}} --")
+               |> Prompt.append("-- bye {{name}}")
+               |> Prompt.vars(name: "Ada")
+               |> Prompt.render()
+    end
+
+    test "unknown placeholders are left verbatim" do
+      assert {:ok, "fill A leave {{b}}"} =
+               "fill {{a}} leave {{b}}"
+               |> Prompt.new()
+               |> Prompt.vars(a: "A")
+               |> Prompt.render()
+    end
+
+    test "does not substitute inside captured context blocks", %{base: base} do
+      file = Path.join(base, "f.txt")
+      File.write!(file, "literal {{name}} in file")
+
+      assert {:ok, text} =
+               "greet {{name}}"
+               |> Prompt.new()
+               |> Prompt.attach(file)
+               |> Prompt.vars(name: "Ada")
+               |> Prompt.render()
+
+      assert text =~ "greet Ada"
+      assert text =~ "literal {{name}} in file"
+    end
+
+    test "a prompt with no vars is unchanged" do
+      assert {:ok, "raw {{x}}"} = "raw {{x}}" |> Prompt.new() |> Prompt.render()
     end
   end
 


### PR DESCRIPTION
Closes #140.

Completes roba parity for prompt context and adds template vars.

## New `Prompt` builders

| builder | block |
|---|---|
| `git_log/2` | `git log --oneline -n N` (default 5), under a `# git log` header |
| `git_status/1` | `git status --short`, under a `# git status` header |
| `vars/2` | `{{key}}` substitution over **authored** text (base/prepends/appends) |

```elixir
Prompt.new("what changed?") |> Prompt.git_status() |> Prompt.git_log(n: 10) |> Prompt.render!()

Prompt.new("Summarize {{file}} for a {{who}} reader")
|> Prompt.vars(file: "config.ex", who: "beginner")
|> Prompt.render!()
#=> "Summarize config.ex for a beginner reader"
```

Wired as IEx composition keys alongside `git_diff:`:

```elixir
chat("review my recent work", git_diff: true, git_log: 5, git_status: true, vars: %{focus: "errors"})
```

## Dependency-free

`git_log`/`git_status` follow the existing `git_diff` path (`System.cmd` via `safe_git`, deferred to `render/1`). The `git` hex package is **not** used -- it returns typed structs, and prompt context wants raw porcelain text (see #140 for the rationale).

## Header unification (pre-0.9.0, no released-behavior change)

All git context blocks now carry a `# git <cmd>` header, matching `attach`'s `# <path>` convention. `git_diff` previously emitted a bare ` ```diff ` fence; it now reads `# git diff` / `# git diff <ref>` then the fence. The IEx attached-files notice excludes `# git ` headers so they don't inflate the count.

## Sub-decisions settled (from the issue's open list)

- **Headers:** unified to `# git <cmd>` across diff/log/status.
- **Empty output:** `git_log`/`git_status` mirror `git_diff` -- a clean tree / no changes contributes no block.
- **Substitution scope:** authored text only; captured context blocks stay verbatim.
- **Unfilled `{{...}}`:** left verbatim (single-pass), **not** an error -- chosen over the issue's "lean: error" so legitimate brace content (Handlebars, template questions) never breaks. A strict mode could be added later if wanted.

## Testing

`mix format` / `compile --warnings-as-errors` / `credo --strict` / `dialyzer` clean. Suite **523 passed (26 doctests)** -- new coverage for the three builders, the unified header, the vars scope/verbatim behavior, and an IEx test proving the new composition keys wire through (network-free via the bad-glob-raises-at-render seam). `Prompt` doctests are now run.