### PR TITLE
feat: typed Result accessors (usage/1, stop_reason/1, structured_output/1)

### DIFF
--- a/lib/claude_wrapper/result.ex
+++ b/lib/claude_wrapper/result.ex
@@ -16,6 +16,18 @@ defmodule ClaudeWrapper.Result do
           extra: map()
         }
 
+  @typedoc """
+  Normalized token usage from `usage/1`. `total` is throughput
+  (`input + output + cache_creation`) and excludes cache reads.
+  """
+  @type usage :: %{
+          input: non_neg_integer(),
+          output: non_neg_integer(),
+          cache_creation: non_neg_integer(),
+          cache_read: non_neg_integer(),
+          total: non_neg_integer()
+        }
+
   defstruct [
     :result,
     :session_id,
@@ -50,4 +62,72 @@ defmodule ClaudeWrapper.Result do
         ])
     }
   end
+
+  @doc """
+  Token usage for the turn, read from `extra["usage"]`.
+
+  Returns `nil` when the result carries no usage (e.g. some error
+  results). `total` is `input + output + cache_creation` -- it **excludes**
+  cache reads, which re-count context already tallied when it was first
+  cached (consistent with `ClaudeWrapper.History.SessionSummary`'s
+  `total_tokens`).
+
+      iex> ClaudeWrapper.Result.usage(%ClaudeWrapper.Result{result: "", extra: %{}})
+      nil
+  """
+  @spec usage(t()) :: usage() | nil
+  def usage(%__MODULE__{extra: extra}) do
+    case extra["usage"] do
+      %{} = u -> build_usage(u)
+      _ -> nil
+    end
+  end
+
+  @doc """
+  The turn's stop reason (e.g. `"end_turn"`, `"max_tokens"`), read from
+  `extra["stop_reason"]`. Returns `nil` when absent.
+  """
+  @spec stop_reason(t()) :: String.t() | nil
+  def stop_reason(%__MODULE__{extra: extra}) do
+    case extra["stop_reason"] do
+      reason when is_binary(reason) -> reason
+      _ -> nil
+    end
+  end
+
+  @doc """
+  The schema-validated structured output, read from
+  `extra["structured_output"]`.
+
+  Present (a JSON object or array) when the turn ran with a JSON schema
+  (claude's `--json-schema`); `nil` otherwise.
+  """
+  @spec structured_output(t()) :: map() | list() | nil
+  def structured_output(%__MODULE__{extra: extra}) do
+    case extra["structured_output"] do
+      %{} = output -> output
+      output when is_list(output) -> output
+      _ -> nil
+    end
+  end
+
+  # Sum a usage map into the normalized shape. Missing / non-integer fields
+  # count as 0; `total` excludes cache reads (see usage/1).
+  defp build_usage(u) do
+    input = int(u["input_tokens"])
+    output = int(u["output_tokens"])
+    cache_creation = int(u["cache_creation_input_tokens"])
+    cache_read = int(u["cache_read_input_tokens"])
+
+    %{
+      input: input,
+      output: output,
+      cache_creation: cache_creation,
+      cache_read: cache_read,
+      total: input + output + cache_creation
+    }
+  end
+
+  defp int(n) when is_integer(n), do: n
+  defp int(_), do: 0
 end

--- a/test/claude_wrapper/result_test.exs
+++ b/test/claude_wrapper/result_test.exs
@@ -1,0 +1,91 @@
+defmodule ClaudeWrapper.ResultTest do
+  use ExUnit.Case, async: true
+
+  doctest ClaudeWrapper.Result
+
+  alias ClaudeWrapper.Result
+
+  defp result(extra), do: %Result{result: "", extra: extra}
+
+  describe "usage/1" do
+    test "normalizes a full usage map; total excludes cache reads" do
+      r =
+        result(%{
+          "usage" => %{
+            "input_tokens" => 10,
+            "output_tokens" => 5,
+            "cache_creation_input_tokens" => 3,
+            "cache_read_input_tokens" => 100
+          }
+        })
+
+      assert Result.usage(r) == %{
+               input: 10,
+               output: 5,
+               cache_creation: 3,
+               cache_read: 100,
+               total: 18
+             }
+    end
+
+    test "missing / non-integer fields count as zero" do
+      assert Result.usage(result(%{"usage" => %{"output_tokens" => 7}})) == %{
+               input: 0,
+               output: 7,
+               cache_creation: 0,
+               cache_read: 0,
+               total: 7
+             }
+    end
+
+    test "returns nil when there is no usage map" do
+      assert Result.usage(result(%{})) == nil
+      assert Result.usage(result(%{"usage" => "nope"})) == nil
+    end
+  end
+
+  describe "stop_reason/1" do
+    test "returns the reason string" do
+      assert Result.stop_reason(result(%{"stop_reason" => "end_turn"})) == "end_turn"
+      assert Result.stop_reason(result(%{"stop_reason" => "max_tokens"})) == "max_tokens"
+    end
+
+    test "returns nil when absent or non-string" do
+      assert Result.stop_reason(result(%{})) == nil
+      assert Result.stop_reason(result(%{"stop_reason" => nil})) == nil
+    end
+  end
+
+  describe "structured_output/1" do
+    test "returns a JSON object" do
+      assert Result.structured_output(result(%{"structured_output" => %{"a" => 1}})) ==
+               %{"a" => 1}
+    end
+
+    test "returns a JSON array" do
+      assert Result.structured_output(result(%{"structured_output" => [1, 2]})) == [1, 2]
+    end
+
+    test "returns nil when absent" do
+      assert Result.structured_output(result(%{})) == nil
+    end
+  end
+
+  describe "from_json/1 routes the extras these accessors read" do
+    test "usage / stop_reason / structured_output survive into extra" do
+      r =
+        Result.from_json(%{
+          "result" => "hi",
+          "session_id" => "s1",
+          "usage" => %{"input_tokens" => 1, "output_tokens" => 2},
+          "stop_reason" => "end_turn",
+          "structured_output" => %{"ok" => true}
+        })
+
+      assert r.result == "hi"
+      assert Result.stop_reason(r) == "end_turn"
+      assert Result.structured_output(r) == %{"ok" => true}
+      assert Result.usage(r).total == 3
+    end
+  end
+end


### PR DESCRIPTION
Closes #139.

`ClaudeWrapper.Result` exposes 6 typed fields and drops everything else from the CLI result JSON into `extra` (a raw, string-keyed map) -- as does the Rust `QueryResult`. This adds typed accessors for the three most commonly-needed `extra` values, following the existing `StreamEvent.partial_message/1` pattern: **accessors over the raw map, not new struct fields.** The struct stays equal to the CLI's documented core, and the accessor's contract -- not the JSON's presence guarantees -- is what callers rely on.

| accessor | reads | returns |
|---|---|---|
| `usage/1` | `extra["usage"]` | `%{input, output, cache_creation, cache_read, total}` or `nil` |
| `stop_reason/1` | `extra["stop_reason"]` | `"end_turn"` / `"max_tokens"` / ... or `nil` |
| `structured_output/1` | `extra["structured_output"]` | the schema-validated object/array, or `nil` |

```elixir
{:ok, r} = ClaudeWrapper.query("...")
ClaudeWrapper.Result.usage(r)         #=> %{input: 13_191, output: 85, cache_creation: 25_265, cache_read: 15_583, total: 38_541}
ClaudeWrapper.Result.stop_reason(r)   #=> "end_turn"
ClaudeWrapper.Result.structured_output(r)  #=> %{...} when run with --json-schema
```

## Notes

- **`total` excludes cache reads** (`input + output + cache_creation`), consistent with the `History.SessionSummary.total_tokens` decision in #137 -- cache reads re-count context already tallied when first cached.
- **`structured_output/1`** is the typed payoff of claude's `--json-schema`, which `claude_wrapper` already wires at the Query level (surfaced while picking through roba's surface). It's the most north-star-aligned of the three.
- Each accessor returns `nil` (never crashes) when its field is absent -- e.g. an `is_error` result that omits `usage`.
- **Additive / non-breaking** to the released `Result` struct.
- **Parity:** mirror as `QueryResult::usage` / `::stop_reason` / `::structured_output` in the Rust crate (separate issue to file).

## Testing

`mix format` / `compile --warnings-as-errors` / `credo --strict` / `dialyzer` clean. New `result_test.exs` (9 tests + doctest) covers normalization, the cache-read exclusion, nil fallbacks, object/array structured output, and the `from_json/1 -> accessor` round-trip. Suite **517 passed**.