### PR TITLE
spike: ClaudeWrapper.Structured -- typed-function tasks over --json-schema

### DIFF
--- a/lib/claude_wrapper/error.ex
+++ b/lib/claude_wrapper/error.ex
@@ -93,6 +93,8 @@ defmodule ClaudeWrapper.Error do
           | :git_unavailable
           | :invalid_tool_pattern
           | :auth
+          | :invalid_render
+          | :no_structured_output
 
   @type t :: %__MODULE__{
           kind: kind(),
@@ -218,6 +220,12 @@ defmodule ClaudeWrapper.Error do
 
   defp default_message(%{kind: :auth, reason: reason}),
     do: "authentication error: #{inspect(reason)}"
+
+  defp default_message(%{kind: :invalid_render, reason: value}),
+    do: "Structured render/1 returned #{inspect(value)}; expected a Prompt or a string"
+
+  defp default_message(%{kind: :no_structured_output}),
+    do: "the result carried no structured_output (no JSON schema took effect)"
 
   defp default_message(%{kind: kind}), do: "claude_wrapper error: #{kind}"
 end

--- a/lib/claude_wrapper/structured.ex
+++ b/lib/claude_wrapper/structured.ex
@@ -42,6 +42,30 @@ defmodule ClaudeWrapper.Structured do
       {:ok, %{"name" => name}, %ClaudeWrapper.Result{}} =
         ClaudeWrapper.Structured.run(ExtractName, "Hi, I'm Ada Lovelace.")
 
+  ## Parsing into a domain value
+
+  An optional `parse/1` maps the validated object into whatever shape the
+  caller wants -- a struct, an Ecto schema, a normalized tuple. The model
+  still only returns the schema-validated object; `parse/1` is the
+  deterministic last step.
+
+      defmodule ExtractPerson do
+        @behaviour ClaudeWrapper.Structured
+
+        @impl true
+        def render(text), do: "Extract the person's full name from: " <> text
+
+        @impl true
+        def schema, do: ExtractName.schema()
+
+        @impl true
+        def parse(%{"name" => name}), do: {:ok, %Person{name: name}}
+        def parse(other), do: {:error, {:unexpected_shape, other}}
+      end
+
+      {:ok, %Person{name: "Ada Lovelace"}, %ClaudeWrapper.Result{}} =
+        ClaudeWrapper.Structured.run(ExtractPerson, "Hi, I'm Ada Lovelace.")
+
   ## Reasoning room
 
   A hard schema gives the model no space to think before answering. If a
@@ -107,10 +131,9 @@ defmodule ClaudeWrapper.Structured do
     end
   end
 
-  # Read the schema-validated object. Inline for now; becomes
-  # `Result.structured_output/1` once #142 lands.
-  defp extract_output(%Result{extra: extra} = result) do
-    case extra["structured_output"] do
+  # Read the schema-validated object via the typed accessor (#142).
+  defp extract_output(%Result{} = result) do
+    case Result.structured_output(result) do
       nil -> {:error, Error.new(:no_structured_output, reason: result)}
       output -> {:ok, output}
     end

--- a/lib/claude_wrapper/structured.ex
+++ b/lib/claude_wrapper/structured.ex
@@ -1,0 +1,126 @@
+defmodule ClaudeWrapper.Structured do
+  @moduledoc """
+  Run a Claude call as a typed function.
+
+  A `Structured` task turns **structured input** into a rendered prompt,
+  constrains the model's output to a **JSON Schema**, and parses the
+  validated object into a **domain value** -- returning the raw
+  `t:ClaudeWrapper.Result.t/0` alongside as an audit log. The model call is
+  the only stochastic step; prompt construction, output shape, and parsing
+  are deterministic and typed -- a deterministic envelope around a
+  stochastic core.
+
+  A task module implements:
+
+    * `render/1` -- input -> a `t:ClaudeWrapper.Prompt.t/0` or a string
+    * `schema/0` -- the JSON Schema the output must conform to (claude's
+      `--json-schema`); the validated object arrives as the result's
+      `structured_output`
+    * `parse/1` -- *optional*; map the validated object into a domain
+      value. Defaults to returning the object unchanged.
+
+  `run/3` wires them together.
+
+  ## Example
+
+      defmodule ExtractName do
+        @behaviour ClaudeWrapper.Structured
+
+        @impl true
+        def render(text), do: "Extract the person's name from: " <> text
+
+        @impl true
+        def schema do
+          %{
+            "type" => "object",
+            "properties" => %{"name" => %{"type" => "string"}},
+            "required" => ["name"]
+          }
+        end
+      end
+
+      {:ok, %{"name" => name}, %ClaudeWrapper.Result{}} =
+        ClaudeWrapper.Structured.run(ExtractName, "Hi, I'm Ada Lovelace.")
+
+  ## Reasoning room
+
+  A hard schema gives the model no space to think before answering. If a
+  task needs reasoning, add a field for it to the schema (e.g. a
+  `"reasoning"` string beside the `"answer"` object) rather than dropping
+  the schema -- you keep a guaranteed-parseable object *and* thinking room
+  in one deterministic call.
+  """
+
+  alias ClaudeWrapper.{Prompt, Result}
+
+  @doc "Turn the task input into a prompt (a `Prompt` struct or a string)."
+  @callback render(input :: term()) :: Prompt.t() | String.t()
+
+  @doc "The JSON Schema the model output must conform to."
+  @callback schema() :: map()
+
+  @doc """
+  Map the schema-validated object into a domain value. Optional; the
+  default returns the object unchanged.
+  """
+  @callback parse(structured_output :: map() | list()) :: {:ok, term()} | {:error, term()}
+
+  @optional_callbacks parse: 1
+
+  @doc """
+  Run `module` over `input`.
+
+  Returns `{:ok, parsed, result}` -- the parsed domain value plus the raw
+  `t:ClaudeWrapper.Result.t/0` (the audit log) -- or `{:error, reason}`.
+
+  `opts` are forwarded to `ClaudeWrapper.query/2` (e.g. `:model`,
+  `:working_dir`, `:timeout`); `:json_schema` is set from `schema/0`.
+
+  Error reasons:
+
+    * `{:invalid_render, value}` -- `render/1` returned neither a `Prompt`
+      nor a string
+    * a `Jason` encode error -- `schema/0` was not JSON-encodable
+    * a `ClaudeWrapper.Error` -- the prompt failed to render, or the CLI
+      call failed
+    * `:no_structured_output` -- the result carried no `structured_output`
+      (no schema took effect)
+    * whatever `parse/1` returned on `{:error, _}`
+  """
+  @spec run(module(), term(), keyword()) :: {:ok, term(), Result.t()} | {:error, term()}
+  def run(module, input, opts \\ []) when is_atom(module) and is_list(opts) do
+    with {:ok, rendered} <- render_input(module, input),
+         {:ok, schema_json} <- Jason.encode(module.schema()),
+         {:ok, result} <-
+           ClaudeWrapper.query(rendered, Keyword.put(opts, :json_schema, schema_json)),
+         {:ok, output} <- extract_output(result),
+         {:ok, parsed} <- parse_output(module, output) do
+      {:ok, parsed, result}
+    end
+  end
+
+  defp render_input(module, input) do
+    case module.render(input) do
+      %Prompt{} = prompt -> Prompt.render(prompt)
+      text when is_binary(text) -> {:ok, text}
+      other -> {:error, {:invalid_render, other}}
+    end
+  end
+
+  # Read the schema-validated object. Inline for now; becomes
+  # `Result.structured_output/1` once #142 lands.
+  defp extract_output(%Result{extra: extra}) do
+    case extra["structured_output"] do
+      nil -> {:error, :no_structured_output}
+      output -> {:ok, output}
+    end
+  end
+
+  defp parse_output(module, output) do
+    if function_exported?(module, :parse, 1) do
+      module.parse(output)
+    else
+      {:ok, output}
+    end
+  end
+end

--- a/lib/claude_wrapper/structured.ex
+++ b/lib/claude_wrapper/structured.ex
@@ -51,7 +51,7 @@ defmodule ClaudeWrapper.Structured do
   in one deterministic call.
   """
 
-  alias ClaudeWrapper.{Prompt, Result}
+  alias ClaudeWrapper.{Error, Prompt, Result}
 
   @doc "Turn the task input into a prompt (a `Prompt` struct or a string)."
   @callback render(input :: term()) :: Prompt.t() | String.t()
@@ -62,6 +62,8 @@ defmodule ClaudeWrapper.Structured do
   @doc """
   Map the schema-validated object into a domain value. Optional; the
   default returns the object unchanged.
+
+      def parse(%{"name" => name}), do: {:ok, %Person{name: name}}
   """
   @callback parse(structured_output :: map() | list()) :: {:ok, term()} | {:error, term()}
 
@@ -78,13 +80,11 @@ defmodule ClaudeWrapper.Structured do
 
   Error reasons:
 
-    * `{:invalid_render, value}` -- `render/1` returned neither a `Prompt`
-      nor a string
+    * a `ClaudeWrapper.Error` -- `render/1` returned a non-prompt
+      (`:invalid_render`), the prompt failed to render, the CLI call
+      failed, or the result carried no `structured_output`
+      (`:no_structured_output`)
     * a `Jason` encode error -- `schema/0` was not JSON-encodable
-    * a `ClaudeWrapper.Error` -- the prompt failed to render, or the CLI
-      call failed
-    * `:no_structured_output` -- the result carried no `structured_output`
-      (no schema took effect)
     * whatever `parse/1` returned on `{:error, _}`
   """
   @spec run(module(), term(), keyword()) :: {:ok, term(), Result.t()} | {:error, term()}
@@ -103,15 +103,15 @@ defmodule ClaudeWrapper.Structured do
     case module.render(input) do
       %Prompt{} = prompt -> Prompt.render(prompt)
       text when is_binary(text) -> {:ok, text}
-      other -> {:error, {:invalid_render, other}}
+      other -> {:error, Error.new(:invalid_render, reason: other)}
     end
   end
 
   # Read the schema-validated object. Inline for now; becomes
   # `Result.structured_output/1` once #142 lands.
-  defp extract_output(%Result{extra: extra}) do
+  defp extract_output(%Result{extra: extra} = result) do
     case extra["structured_output"] do
-      nil -> {:error, :no_structured_output}
+      nil -> {:error, Error.new(:no_structured_output, reason: result)}
       output -> {:ok, output}
     end
   end

--- a/test/claude_wrapper/structured_test.exs
+++ b/test/claude_wrapper/structured_test.exs
@@ -1,0 +1,60 @@
+defmodule ClaudeWrapper.StructuredTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.{Result, Structured}
+
+  defmodule ExtractName do
+    @behaviour Structured
+
+    @impl true
+    def render(text),
+      do: "Extract the person's full name from this text. Text: " <> text
+
+    @impl true
+    def schema do
+      %{
+        "type" => "object",
+        "properties" => %{"name" => %{"type" => "string"}},
+        "required" => ["name"],
+        "additionalProperties" => false
+      }
+    end
+  end
+
+  defmodule BadRender do
+    @behaviour Structured
+
+    @impl true
+    def render(_input), do: :not_a_prompt
+
+    @impl true
+    def schema, do: %{"type" => "object"}
+  end
+
+  describe "run/3 (no CLI)" do
+    test "an invalid render value errors before any CLI call" do
+      assert {:error, {:invalid_render, :not_a_prompt}} = Structured.run(BadRender, "x")
+    end
+  end
+
+  describe "task callbacks" do
+    test "render and schema are plain, testable functions" do
+      assert ExtractName.render("hi") =~ "Extract the person's full name"
+      assert %{"type" => "object", "required" => ["name"]} = ExtractName.schema()
+    end
+  end
+
+  describe "run/3 (live)" do
+    @tag :integration
+    test "extracts a schema-constrained object and returns the Result as audit log" do
+      assert {:ok, output, %Result{} = result} =
+               Structured.run(ExtractName, "Hi, I'm Ada Lovelace, nice to meet you.")
+
+      assert %{"name" => name} = output
+      assert name =~ "Ada"
+      # The raw Result is the audit log: it still carries session_id / usage
+      # even though the textual `result` is empty under a schema.
+      assert is_binary(result.session_id)
+    end
+  end
+end

--- a/test/claude_wrapper/structured_test.exs
+++ b/test/claude_wrapper/structured_test.exs
@@ -1,14 +1,17 @@
 defmodule ClaudeWrapper.StructuredTest do
   use ExUnit.Case, async: true
 
-  alias ClaudeWrapper.{Result, Structured}
+  alias ClaudeWrapper.{Error, Result, Structured}
+
+  defmodule Person do
+    defstruct [:name]
+  end
 
   defmodule ExtractName do
     @behaviour Structured
 
     @impl true
-    def render(text),
-      do: "Extract the person's full name from this text. Text: " <> text
+    def render(text), do: "Extract the person's full name from this text. Text: " <> text
 
     @impl true
     def schema do
@@ -19,6 +22,20 @@ defmodule ClaudeWrapper.StructuredTest do
         "additionalProperties" => false
       }
     end
+  end
+
+  defmodule ExtractPerson do
+    @behaviour Structured
+
+    @impl true
+    def render(text), do: "Extract the person's full name from this text. Text: " <> text
+
+    @impl true
+    def schema, do: ExtractName.schema()
+
+    @impl true
+    def parse(%{"name" => name}), do: {:ok, %Person{name: name}}
+    def parse(other), do: {:error, {:unexpected_shape, other}}
   end
 
   defmodule BadRender do
@@ -32,8 +49,9 @@ defmodule ClaudeWrapper.StructuredTest do
   end
 
   describe "run/3 (no CLI)" do
-    test "an invalid render value errors before any CLI call" do
-      assert {:error, {:invalid_render, :not_a_prompt}} = Structured.run(BadRender, "x")
+    test "an invalid render value is a ClaudeWrapper.Error before any CLI call" do
+      assert {:error, %Error{kind: :invalid_render, reason: :not_a_prompt}} =
+               Structured.run(BadRender, "x")
     end
   end
 
@@ -42,18 +60,24 @@ defmodule ClaudeWrapper.StructuredTest do
       assert ExtractName.render("hi") =~ "Extract the person's full name"
       assert %{"type" => "object", "required" => ["name"]} = ExtractName.schema()
     end
+
+    test "parse/1 maps the validated object into a domain struct" do
+      assert {:ok, %Person{name: "Ada Lovelace"}} =
+               ExtractPerson.parse(%{"name" => "Ada Lovelace"})
+
+      assert {:error, {:unexpected_shape, _}} = ExtractPerson.parse(%{"nope" => 1})
+    end
   end
 
   describe "run/3 (live)" do
     @tag :integration
-    test "extracts a schema-constrained object and returns the Result as audit log" do
-      assert {:ok, output, %Result{} = result} =
-               Structured.run(ExtractName, "Hi, I'm Ada Lovelace, nice to meet you.")
+    test "extracts, parses into a struct, and returns the Result as audit log" do
+      assert {:ok, %Person{name: name}, %Result{} = result} =
+               Structured.run(ExtractPerson, "Hi, I'm Ada Lovelace, nice to meet you.")
 
-      assert %{"name" => name} = output
       assert name =~ "Ada"
-      # The raw Result is the audit log: it still carries session_id / usage
-      # even though the textual `result` is empty under a schema.
+      # The raw Result is the audit log: session_id is present even though
+      # the textual `result` is empty under a schema.
       assert is_binary(result.session_id)
     end
   end


### PR DESCRIPTION
**Spike for reaction** -- the north-star "structured I/O" layer. Schema-only v1, per our discussion.

## What it is

A behaviour for running a Claude call as a *typed function*: structured input -> rendered prompt -> schema-constrained output -> parsed domain value, with the raw `Result` returned alongside as an **audit log**. The model call is the only stochastic step; everything around it (prompt construction, output shape, parsing) is deterministic and typed.

```elixir
defmodule ExtractName do
  @behaviour ClaudeWrapper.Structured
  @impl true
  def render(text), do: "Extract the person's full name from this text. Text: " <> text
  @impl true
  def schema, do: %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}, "required" => ["name"]}
end

{:ok, %{"name" => name}, %ClaudeWrapper.Result{}} =
  ClaudeWrapper.Structured.run(ExtractName, "Hi, I'm Ada Lovelace.")
#=> name = "Ada Lovelace"
```

- `render/1` -- input -> `Prompt.t()` or string
- `schema/0` -- JSON Schema (claude's `--json-schema`)
- `parse/1` -- *optional*; `structured_output` -> domain value (default identity)
- `run/3` -- wires them; `{:ok, parsed, %Result{}} | {:error, reason}`

## Validated live

The round-trip works against the real CLI: `--json-schema` returns `structured_output`, and `run/3` surfaces it (`Ada Lovelace -> %{"name" => "Ada Lovelace"}`) with the `Result` (session_id, usage) as the audit log even though the textual `result` is empty under a schema. (`@tag :integration`.)

## Decisions locked (from our chat)

- Name `ClaudeWrapper.Structured`; returns `{:ok, parsed, %Result{}}` (Result surfaced); `parse/1` optional/identity; **schema-only v1** (no free-text mode -- reasoning is handled by a `reasoning` field in the schema, see moduledoc).

## Spike caveats (pre-merge cleanup, want your read)

1. **Reads `result.extra["structured_output"]` inline** -- swap for `Result.structured_output/1` once #142 merges (the spike stands alone off `main` so it's reviewable now).
2. **Structured-specific errors are plain tagged tuples** (`{:invalid_render, _}`, `:no_structured_output`) rather than `ClaudeWrapper.Error`. Unify into `Error` with new kinds before merge? (The query/render errors already come through as `%Error{}`.)
3. **Schema passes inline** (claude's `--json-schema` takes inline JSON via `Query.json_schema`, which is a `String.t()`); `run/3` `Jason.encode`s the map. No temp-file/path needed.

## Testing

`mix format` / `compile --warnings-as-errors` / `credo --strict` / `dialyzer` clean. Unit: invalid-render-before-CLI + callback shape (network-free); live: the schema round-trip. **509 passed** + the integration test.

## Open question for you

Does the shape feel right to build out (more worked examples, the `parse/1` -> Ecto/struct path, error unification), or want to adjust the surface first?