### PR TITLE
feat(history): last_answer/1 and assistant_texts/1 over SessionLog

### DIFF
--- a/lib/claude_wrapper/history.ex
+++ b/lib/claude_wrapper/history.ex
@@ -289,6 +289,47 @@ defmodule ClaudeWrapper.History do
   end
 
   @doc """
+  Every assistant text answer in a session, in order.
+
+  Each `:assistant` entry's `message["content"]` is reduced to its text
+  blocks (string content is taken verbatim; a content list keeps only
+  `"text"` blocks, joined). Entries with no text (tool-use-only turns,
+  say) contribute nothing.
+
+      {:ok, log} = ClaudeWrapper.History.read_session(root, id)
+      ClaudeWrapper.History.assistant_texts(log)
+      #=> ["First answer.", "Second answer."]
+  """
+  @spec assistant_texts(SessionLog.t()) :: [String.t()]
+  def assistant_texts(%SessionLog{entries: entries}) do
+    entries
+    |> Enum.flat_map(fn
+      {:assistant, %{message: message}} -> [message_text(message)]
+      _ -> []
+    end)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  @doc """
+  The last assistant text answer in a session.
+
+  Returns `{:ok, text}`, or `{:error, :no_answer}` when the session has
+  no assistant entry carrying text. Pairs with a `show`/`last` style
+  command reconstructing a stored session's answer from disk.
+
+      {:ok, log} = ClaudeWrapper.History.read_session(root, id)
+      ClaudeWrapper.History.last_answer(log)
+      #=> {:ok, "The answer."}
+  """
+  @spec last_answer(SessionLog.t()) :: {:ok, String.t()} | {:error, :no_answer}
+  def last_answer(%SessionLog{} = log) do
+    case List.last(assistant_texts(log)) do
+      nil -> {:error, :no_answer}
+      text -> {:ok, text}
+    end
+  end
+
+  @doc """
   Locate the on-disk path and project slug for a session id, searching
   every project directory.
 
@@ -524,6 +565,19 @@ defmodule ClaudeWrapper.History do
 
   defp text_block(%{"type" => "text", "text" => t}) when is_binary(t), do: t
   defp text_block(_), do: ""
+
+  # Reduce a message map to its text: string content verbatim, a content
+  # list to its joined `"text"` blocks, anything else to "".
+  defp message_text(%{"content" => content}) when is_binary(content), do: content
+
+  defp message_text(%{"content" => content}) when is_list(content) do
+    content
+    |> Enum.map(&text_block/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp message_text(_), do: ""
 
   # -- full session parse --------------------------------------------
 

--- a/test/claude_wrapper/history_test.exs
+++ b/test/claude_wrapper/history_test.exs
@@ -237,6 +237,62 @@ defmodule ClaudeWrapper.HistoryTest do
     end
   end
 
+  describe "assistant_texts/1 and last_answer/1" do
+    defp asst(content),
+      do: {:assistant, %{uuid: "a", timestamp: nil, message: %{"content" => content}}}
+
+    defp usr(content),
+      do:
+        {:user,
+         %{uuid: "u", timestamp: nil, cwd: nil, git_branch: nil, message: %{"content" => content}}}
+
+    defp log(entries), do: %SessionLog{session_id: "s", project_slug: "-p", entries: entries}
+
+    test "assistant_texts returns each answer in order, ignoring user turns" do
+      l = log([usr("q1"), asst("a1"), usr("q2"), asst("a2")])
+      assert History.assistant_texts(l) == ["a1", "a2"]
+    end
+
+    test "a content list keeps only text blocks, joined by newline" do
+      content = [
+        %{"type" => "text", "text" => "line one"},
+        %{"type" => "tool_use", "name" => "Read", "input" => %{}},
+        %{"type" => "text", "text" => "line two"}
+      ]
+
+      assert History.assistant_texts(log([asst(content)])) == ["line one\nline two"]
+    end
+
+    test "a tool-use-only assistant turn contributes nothing" do
+      tool_only = [%{"type" => "tool_use", "name" => "Read", "input" => %{}}]
+      l = log([asst("real answer"), asst(tool_only)])
+
+      assert History.assistant_texts(l) == ["real answer"]
+      assert History.last_answer(l) == {:ok, "real answer"}
+    end
+
+    test "last_answer returns the final assistant text" do
+      assert History.last_answer(log([asst("first"), asst("last")])) == {:ok, "last"}
+    end
+
+    test "last_answer is :no_answer when no assistant entry carries text" do
+      assert History.last_answer(log([usr("q")])) == {:error, :no_answer}
+      assert History.assistant_texts(log([usr("q")])) == []
+    end
+
+    test "round-trips from a parsed session on disk", %{root: root} do
+      dir = Path.join(root, "-ans")
+
+      write_session(dir, "s-ans", [
+        user("2026-03-01T00:00:00Z", "hi"),
+        assistant("2026-03-01T00:00:01Z", "hello there")
+      ])
+
+      {:ok, l} = History.read_session(History.at(root), "s-ans")
+      assert History.last_answer(l) == {:ok, "hello there"}
+    end
+  end
+
   describe "project_slug/1 and sessions_for_path/3" do
     test "encodes '/', '.', and '_' as '-' (matching the CLI)" do
       tmp = Path.join(System.tmp_dir!(), "cwx_slug_#{System.unique_integer([:positive])}")


### PR DESCRIPTION
Closes #148.

After `History.read_session/2`, a `SessionLog`'s `entries` are tagged tuples (`{:assistant, ...}`, `{:user, ...}`, `{:other, ...}`). There was no public way to pull the assistant answer out, so a caller reconstructing "the answer" had to walk the tuples and re-extract text blocks from `message["content"]` themselves, duplicating the private `text_block/1`.

## New accessors

| function | returns |
|---|---|
| `assistant_texts/1` | `[String.t()]` -- every assistant text answer in order |
| `last_answer/1` | `{:ok, String.t()}` / `{:error, :no_answer}` -- the last one |

```elixir
{:ok, log} = ClaudeWrapper.History.read_session(root, id)
ClaudeWrapper.History.last_answer(log)      #=> {:ok, "The answer."}
ClaudeWrapper.History.assistant_texts(log)  #=> ["First.", "Second."]
```

- A private `message_text/1` reduces a message map to its text: string content verbatim; a content list to its joined `"text"` blocks (tool-use blocks dropped). The extraction now lives in one place.
- A tool-use-only assistant turn contributes nothing; `last_answer/1` skips past it to the last turn that actually carried text.
- `last_answer/1` is `{:error, :no_answer}` when no assistant entry carries text.

Pairs with the reconstructed `--json` envelope a `roba show <id>` / `roba last` style command wants.

## Testing

`format` / `compile --warnings-as-errors` / `credo --strict` / `dialyzer` clean. New network-free `describe` block builds `SessionLog` structs directly (string content, content-list with text blocks, tool-use-only turn, empty case) plus a parsed-from-disk round-trip. Suite **542 passed**.