### PR TITLE
feat(test): adapter seam on DuplexSession + ClaudeWrapper.Test (network-free session tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,15 @@ ClaudeWrapper.ToolPattern     # Typed, validated tool-spec builder
 ClaudeWrapper.CliVersion      # Parse/compare the claude CLI version
 ClaudeWrapper.DangerousClient # Env-gated --dangerously-skip-permissions wrapper
 ClaudeWrapper.Auth            # Env-based auth detection + failure classification
+ClaudeWrapper.Test            # Drive a DuplexSession against an in-process double (network-free)
+```
+
+### DuplexSession transport adapter
+
+```
+ClaudeWrapper.DuplexSession.Adapter        # open/command/close transport seam
+ClaudeWrapper.DuplexSession.Adapter.Port   # default: real claude subprocess over a Port
+ClaudeWrapper.DuplexSession.Adapter.Test   # per-session controllable double (ClaudeWrapper.Test)
 ```
 
 ### Read-side introspection of `~/.claude`
@@ -185,10 +194,14 @@ mix test --include integration  # All tests, including those that hit the real C
 mix test --only integration     # Only integration tests
 ```
 
-The unit suite uses `cat` as a fake `claude` for `DuplexSession` and
+Some unit tests use `cat` as a fake `claude` for `DuplexSession` and
 `DuplexIEx` -- we inject NDJSON via `Port.command/2` and observe the
-GenServer's dispatch behavior. Integration tests run against the real
-`claude` binary and against real `~/.claude` data (for the read-side
+GenServer's dispatch behavior. New session tests prefer
+`ClaudeWrapper.Test` (the `Adapter.Test` transport double): each
+`start_session/1` gets its own controllable stub with no shared state, so
+it is `async`-safe and is also the supported way for downstream users to
+test code that drives `claude_wrapper`. Integration tests run against the
+real `claude` binary and against real `~/.claude` data (for the read-side
 modules), so they are environment-dependent and excluded by default.
 
 Pre-commit checklist: `mix format`, `mix compile --warnings-as-errors`,

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -124,6 +124,7 @@ defmodule ClaudeWrapper.DuplexSession do
   require Logger
 
   alias ClaudeWrapper.{Config, Error, Result}
+  alias ClaudeWrapper.DuplexSession.Adapter
 
   @type tool_input :: map()
 
@@ -176,7 +177,8 @@ defmodule ClaudeWrapper.DuplexSession do
   @type exit_status :: :running | :completed | {:failed, term()}
 
   @type state :: %__MODULE__{
-          port: port() | nil,
+          port: Adapter.handle() | nil,
+          adapter: module(),
           config: Config.t(),
           session_id: String.t() | nil,
           buffer: binary(),
@@ -190,6 +192,7 @@ defmodule ClaudeWrapper.DuplexSession do
 
   defstruct [
     :port,
+    :adapter,
     :config,
     :session_id,
     :on_permission,
@@ -456,13 +459,23 @@ defmodule ClaudeWrapper.DuplexSession do
     # Not part of the public surface.
     args = Keyword.get(opts, :args_override, build_args(extra_args))
 
-    port_opts =
-      [:binary, :exit_status, :use_stdio, {:args, args}] ++
-        port_env_opts(config) ++
-        port_cd_opts(config)
+    adapter = Keyword.get(opts, :adapter, Adapter.Port)
+    adapter_opts = Keyword.get(opts, :adapter_opts, [])
+    open_opts = [config: config, args: args, owner: self()] ++ adapter_opts
 
-    port = Port.open({:spawn_executable, config.binary}, port_opts)
-    {:ok, %__MODULE__{port: port, config: config, on_permission: on_permission}}
+    case adapter.open(open_opts) do
+      {:ok, handle} ->
+        {:ok,
+         %__MODULE__{
+           port: handle,
+           adapter: adapter,
+           config: config,
+           on_permission: on_permission
+         }}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
   end
 
   @impl true
@@ -474,7 +487,7 @@ defmodule ClaudeWrapper.DuplexSession do
       parent_tool_use_id: nil
     }
 
-    Port.command(port, [Jason.encode!(msg), ?\n])
+    state.adapter.command(port, [Jason.encode!(msg), ?\n])
     {:noreply, %{state | pending_turn: {from, []}}}
   end
 
@@ -511,7 +524,7 @@ defmodule ClaudeWrapper.DuplexSession do
   end
 
   def handle_call({:respond_to_permission, request_id, decision}, _from, state) do
-    write_permission_response(state.port, request_id, decision)
+    write_permission_response(state, request_id, decision)
     {:reply, :ok, state}
   end
 
@@ -528,7 +541,7 @@ defmodule ClaudeWrapper.DuplexSession do
       request: %{subtype: "interrupt"}
     }
 
-    Port.command(state.port, [Jason.encode!(msg), ?\n])
+    state.adapter.command(state.port, [Jason.encode!(msg), ?\n])
     {:noreply, %{state | pending_control: Map.put(state.pending_control, request_id, from)}}
   end
 
@@ -562,7 +575,7 @@ defmodule ClaudeWrapper.DuplexSession do
 
   @impl true
   def terminate(reason, %{port: port} = state) do
-    if is_port(port) and Port.info(port) != nil, do: Port.close(port)
+    if not is_nil(port), do: state.adapter.close(port)
     fail_pending(state, :terminated)
     notify_exit_waiters(state, final_exit_status(state, reason))
     :ok
@@ -648,7 +661,7 @@ defmodule ClaudeWrapper.DuplexSession do
 
     case decision do
       :defer -> :ok
-      _ -> write_permission_response(state.port, id, default_allow_input(decision, input))
+      _ -> write_permission_response(state, id, default_allow_input(decision, input))
     end
 
     state
@@ -791,18 +804,12 @@ defmodule ClaudeWrapper.DuplexSession do
   # CLI via a `subtype: "error"` control_response.
   defp control_failed(reason), do: Error.new(:duplex_control_failed, reason: reason)
 
-  defp port_env_opts(%Config{env: []}), do: []
-  defp port_env_opts(%Config{env: env}), do: [{:env, env}]
-
-  defp port_cd_opts(%Config{working_dir: nil}), do: []
-  defp port_cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
-
   # Wraps a permission decision in the SDK's control_response envelope
-  # and writes it to the port's stdin. Shape mirrors the SDK's
+  # and writes it to the transport's stdin. Shape mirrors the SDK's
   # PermissionResult / SDKControlResponse schemas (see sdk.d.ts).
-  defp write_permission_response(nil, _request_id, _decision), do: :ok
+  defp write_permission_response(%{port: nil}, _request_id, _decision), do: :ok
 
-  defp write_permission_response(port, request_id, decision) do
+  defp write_permission_response(state, request_id, decision) do
     response = decision_to_permission_response(decision)
 
     msg = %{
@@ -814,7 +821,7 @@ defmodule ClaudeWrapper.DuplexSession do
       }
     }
 
-    Port.command(port, [Jason.encode!(msg), ?\n])
+    state.adapter.command(state.port, [Jason.encode!(msg), ?\n])
     :ok
   end
 

--- a/lib/claude_wrapper/duplex_session/adapter.ex
+++ b/lib/claude_wrapper/duplex_session/adapter.ex
@@ -1,0 +1,49 @@
+defmodule ClaudeWrapper.DuplexSession.Adapter do
+  @moduledoc """
+  Transport seam for `ClaudeWrapper.DuplexSession`.
+
+  A `DuplexSession` drives the `claude` subprocess through exactly three
+  active operations -- open the transport, write a line to it, close it --
+  and consumes three inbound message shapes delivered to its own process
+  mailbox:
+
+    * `{handle, {:data, chunk}}` -- raw stdout bytes
+    * `{handle, {:exit_status, code}}` -- the subprocess exited
+    * `{:EXIT, handle, reason}` -- the transport process exited
+
+  where `handle` is the value the adapter's `open/1` returned (and which
+  the session stores as its transport handle). An adapter implements the
+  three operations; the inbound side is just a matter of sending those
+  message shapes to the `:owner` given at `open/1`.
+
+  Two implementations ship:
+
+    * `ClaudeWrapper.DuplexSession.Adapter.Port` -- the default; a real
+      `claude` subprocess over an Erlang port.
+    * `ClaudeWrapper.DuplexSession.Adapter.Test` -- a controllable
+      in-process double for network-free tests (see `ClaudeWrapper.Test`).
+  """
+
+  @typedoc "The opaque transport handle returned by `open/1`."
+  @type handle :: term()
+
+  @typedoc """
+  Options passed to `open/1`. Always carries:
+
+    * `:config` -- the `t:ClaudeWrapper.Config.t/0`
+    * `:args` -- the resolved CLI argument list
+    * `:owner` -- the session pid that inbound messages are sent to
+
+  Adapter-specific keys (from the session's `:adapter_opts`) are merged in.
+  """
+  @type open_opts :: keyword()
+
+  @doc "Start the transport. Returns an opaque handle the session stores."
+  @callback open(open_opts()) :: {:ok, handle()} | {:error, term()}
+
+  @doc "Write iodata (one NDJSON line, newline included) to the transport."
+  @callback command(handle(), iodata()) :: :ok
+
+  @doc "Shut the transport down. Idempotent; the handle may already be dead."
+  @callback close(handle()) :: :ok
+end

--- a/lib/claude_wrapper/duplex_session/adapter/port.ex
+++ b/lib/claude_wrapper/duplex_session/adapter/port.ex
@@ -1,0 +1,46 @@
+defmodule ClaudeWrapper.DuplexSession.Adapter.Port do
+  @moduledoc """
+  Default `ClaudeWrapper.DuplexSession.Adapter`: a real `claude`
+  subprocess over an Erlang port.
+
+  The port is opened by (and delivers its `{port, {:data, _}}` /
+  `{port, {:exit_status, _}}` / `{:EXIT, port, _}` messages directly to)
+  the session process, which calls `open/1` from its own `init/1`. The
+  returned handle is the port itself.
+  """
+
+  @behaviour ClaudeWrapper.DuplexSession.Adapter
+
+  alias ClaudeWrapper.Config
+
+  @impl true
+  def open(opts) do
+    config = Keyword.fetch!(opts, :config)
+    args = Keyword.fetch!(opts, :args)
+
+    port_opts =
+      [:binary, :exit_status, :use_stdio, {:args, args}] ++
+        env_opts(config) ++
+        cd_opts(config)
+
+    {:ok, Port.open({:spawn_executable, config.binary}, port_opts)}
+  end
+
+  @impl true
+  def command(port, iodata) do
+    Port.command(port, iodata)
+    :ok
+  end
+
+  @impl true
+  def close(port) do
+    if is_port(port) and Port.info(port) != nil, do: Port.close(port)
+    :ok
+  end
+
+  defp env_opts(%Config{env: []}), do: []
+  defp env_opts(%Config{env: env}), do: [{:env, env}]
+
+  defp cd_opts(%Config{working_dir: nil}), do: []
+  defp cd_opts(%Config{working_dir: dir}), do: [{:cd, String.to_charlist(dir)}]
+end

--- a/lib/claude_wrapper/duplex_session/adapter/test.ex
+++ b/lib/claude_wrapper/duplex_session/adapter/test.ex
@@ -1,0 +1,97 @@
+defmodule ClaudeWrapper.DuplexSession.Adapter.Test do
+  @moduledoc """
+  In-process test double for `ClaudeWrapper.DuplexSession.Adapter`.
+
+  Instead of a `claude` subprocess, the transport is a lightweight
+  controller process the test drives directly. The controller is created
+  per session and passed in via `:controller` in the session's
+  `:adapter_opts`; because nothing is shared between sessions, concurrent
+  (`async: true`) tests cannot collide -- no global registry, no extra
+  dependency.
+
+  Drive it through `ClaudeWrapper.Test` rather than calling this module
+  directly.
+
+  ## Protocol
+
+  The controller accepts:
+
+    * `{:emit, lines}` -- send each line to the session as a
+      `{handle, {:data, line}}` message (NDJSON the session parses)
+    * `{:set_reply, lines}` -- queue a one-shot canned reply emitted on
+      the next outbound `command/2` (a faked turn response)
+    * `{:exit_status, code}` -- send the session `{handle, {:exit_status,
+      code}}` (simulate the subprocess exiting)
+    * `:close` -- stop
+
+  and, on `open/1`, is told its `:owner` (the session pid) and linked to
+  it so a session crash tears the controller down and vice versa.
+  """
+
+  @behaviour ClaudeWrapper.DuplexSession.Adapter
+
+  @impl true
+  def open(opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    controller = Keyword.fetch!(opts, :controller)
+
+    send(controller, {:bind_owner, owner})
+    Process.link(controller)
+    {:ok, controller}
+  end
+
+  @impl true
+  def command(controller, iodata) do
+    send(controller, {:command, IO.iodata_to_binary(iodata)})
+    :ok
+  end
+
+  @impl true
+  def close(controller) do
+    if Process.alive?(controller), do: send(controller, :close)
+    :ok
+  end
+
+  @doc false
+  @spec start_controller() :: pid()
+  def start_controller do
+    spawn(fn -> loop(%{owner: nil, reply: nil}) end)
+  end
+
+  defp loop(state) do
+    receive do
+      {:bind_owner, owner} ->
+        loop(%{state | owner: owner})
+
+      {:command, _data} ->
+        # A real turn replies to the prompt the session just wrote. If a
+        # canned reply was queued, emit it now (one-shot).
+        case state.reply do
+          nil -> :ok
+          lines -> emit(state.owner, lines)
+        end
+
+        loop(%{state | reply: nil})
+
+      {:emit, lines} ->
+        emit(state.owner, lines)
+        loop(state)
+
+      {:set_reply, lines} ->
+        loop(%{state | reply: lines})
+
+      {:exit_status, code} ->
+        if state.owner, do: send(state.owner, {self(), {:exit_status, code}})
+        loop(state)
+
+      :close ->
+        :ok
+    end
+  end
+
+  defp emit(nil, _lines), do: :ok
+
+  defp emit(owner, lines) do
+    Enum.each(lines, fn line -> send(owner, {self(), {:data, line}}) end)
+  end
+end

--- a/lib/claude_wrapper/test.ex
+++ b/lib/claude_wrapper/test.ex
@@ -1,0 +1,158 @@
+defmodule ClaudeWrapper.Test do
+  @moduledoc """
+  Drive a `ClaudeWrapper.DuplexSession` against an in-process double, with
+  no `claude` binary and no network.
+
+  `start_session/1` returns a live session wired to
+  `ClaudeWrapper.DuplexSession.Adapter.Test` plus a *stub* handle you feed
+  NDJSON events to. The session behaves exactly as it does over a real
+  subprocess -- same `send/3`, same subscriber events, same `Result` -- so
+  it is a faithful way to test code that drives `claude_wrapper`.
+
+  Each `start_session/1` gets its own stub process and nothing is shared
+  between sessions, so `async: true` tests are safe.
+
+  ## Example
+
+      {:ok, session, stub} = ClaudeWrapper.Test.start_session()
+
+      # `send/3` blocks until the turn's result, so drive it from a task.
+      task = Task.async(fn -> ClaudeWrapper.DuplexSession.send(session, "hi") end)
+
+      ClaudeWrapper.Test.emit(stub, [
+        ClaudeWrapper.Test.text_delta("Hello")
+      ])
+      ClaudeWrapper.Test.emit_result(stub, result: "Hello", session_id: "s-1")
+
+      {:ok, %ClaudeWrapper.Result{session_id: "s-1"}} = Task.await(task)
+
+  ## Canned replies
+
+  For the common "send a prompt, get a fixed answer" shape, queue a reply
+  and it is emitted automatically on the next `send/3`:
+
+      ClaudeWrapper.Test.stub(stub, [
+        ClaudeWrapper.Test.text_delta("Hi"),
+        ClaudeWrapper.Test.result(result: "Hi")
+      ])
+
+      {:ok, _result} = ClaudeWrapper.DuplexSession.send(session, "anything")
+  """
+
+  alias ClaudeWrapper.{Config, DuplexSession}
+  alias ClaudeWrapper.DuplexSession.Adapter
+
+  @typedoc "A line to feed the session: a map (JSON-encoded) or a raw string."
+  @type line :: map() | String.t()
+
+  @doc """
+  Start a `DuplexSession` backed by the test adapter.
+
+  Returns `{:ok, session, stub}` where `stub` is the controller handle you
+  pass to `emit/2`, `emit_result/2`, and `stub/2`.
+
+  Options:
+
+    * `:config` -- a `t:ClaudeWrapper.Config.t/0` (a dummy is used by
+      default; the test adapter never launches a binary)
+    * `:on_permission` -- forwarded to `DuplexSession.start_link/1`
+    * any other `DuplexSession` option except `:adapter`/`:adapter_opts`
+  """
+  @spec start_session(keyword()) :: {:ok, pid(), pid()}
+  def start_session(opts \\ []) do
+    config = Keyword.get(opts, :config, Config.new(binary: "claude-wrapper-test-double"))
+    controller = Adapter.Test.start_controller()
+
+    ds_opts =
+      opts
+      |> Keyword.drop([:config, :adapter, :adapter_opts])
+      |> Keyword.merge(
+        config: config,
+        adapter: Adapter.Test,
+        adapter_opts: [controller: controller]
+      )
+
+    {:ok, session} = DuplexSession.start_link(ds_opts)
+    {:ok, session, controller}
+  end
+
+  @doc """
+  Feed NDJSON `lines` to the session now, as if the subprocess emitted
+  them. Each line is a map (JSON-encoded) or a raw string.
+  """
+  @spec emit(pid(), [line()] | line()) :: :ok
+  def emit(stub, lines) do
+    send(stub, {:emit, normalize(lines)})
+    :ok
+  end
+
+  @doc """
+  Emit a `result` event, ending the current turn.
+
+  `attrs` are merged into a minimal success result (see `result/1`).
+  """
+  @spec emit_result(pid(), keyword()) :: :ok
+  def emit_result(stub, attrs \\ []), do: emit(stub, [result(attrs)])
+
+  @doc """
+  Queue a one-shot canned reply emitted automatically on the next
+  `DuplexSession.send/3`. Use for the "prompt in, fixed answer out" shape.
+  """
+  @spec stub(pid(), [line()] | line()) :: :ok
+  def stub(stub, lines) do
+    send(stub, {:set_reply, normalize(lines)})
+    :ok
+  end
+
+  @doc "Simulate the subprocess exiting with `code`."
+  @spec exit_status(pid(), integer()) :: :ok
+  def exit_status(stub, code) do
+    send(stub, {:exit_status, code})
+    :ok
+  end
+
+  # -- event builders ------------------------------------------------
+
+  @doc "A `stream_event` carrying a text delta."
+  @spec text_delta(String.t(), non_neg_integer()) :: map()
+  def text_delta(text, index \\ 0) do
+    block_delta(index, %{"type" => "text_delta", "text" => text})
+  end
+
+  @doc "A `stream_event` carrying an extended-thinking delta."
+  @spec thinking_delta(String.t(), non_neg_integer()) :: map()
+  def thinking_delta(text, index \\ 0) do
+    block_delta(index, %{"type" => "thinking_delta", "thinking" => text})
+  end
+
+  @doc "A minimal success `result` event; `attrs` override the defaults."
+  @spec result(keyword()) :: map()
+  def result(attrs \\ []) do
+    base = %{
+      "type" => "result",
+      "subtype" => "success",
+      "is_error" => false,
+      "result" => Keyword.get(attrs, :result, ""),
+      "session_id" => Keyword.get(attrs, :session_id, "test-session")
+    }
+
+    Enum.reduce(attrs, base, fn {k, v}, acc -> Map.put(acc, to_string(k), v) end)
+  end
+
+  defp block_delta(index, delta) do
+    %{
+      "type" => "stream_event",
+      "event" => %{"type" => "content_block_delta", "index" => index, "delta" => delta}
+    }
+  end
+
+  defp normalize(lines) when is_list(lines), do: Enum.map(lines, &to_line/1)
+  defp normalize(line), do: [to_line(line)]
+
+  defp to_line(map) when is_map(map), do: Jason.encode!(map) <> "\n"
+  defp to_line(str) when is_binary(str), do: ensure_newline(str)
+
+  defp ensure_newline(str) do
+    if String.ends_with?(str, "\n"), do: str, else: str <> "\n"
+  end
+end

--- a/test/claude_wrapper/test_test.exs
+++ b/test/claude_wrapper/test_test.exs
@@ -1,0 +1,92 @@
+defmodule ClaudeWrapper.TestTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.{DuplexSession, Result}
+  alias ClaudeWrapper.Test, as: CWTest
+
+  # send/3 sets pending_turn as its handle_call returns; manual emits must
+  # wait for that so the result routes back to the caller. (The canned
+  # stub/2 path is race-free: it emits in reply to the send's command.)
+  defp wait_for_turn(session, deadline \\ nil) do
+    deadline = deadline || System.monotonic_time(:millisecond) + 1_000
+
+    cond do
+      :sys.get_state(session).pending_turn != nil ->
+        :ok
+
+      System.monotonic_time(:millisecond) > deadline ->
+        flunk("turn never started")
+
+      true ->
+        Process.sleep(2)
+        wait_for_turn(session, deadline)
+    end
+  end
+
+  describe "start_session/1" do
+    test "drives a full turn (deltas + result) with no binary or network" do
+      {:ok, session, stub} = CWTest.start_session()
+      DuplexSession.subscribe(session)
+
+      task = Task.async(fn -> DuplexSession.send(session, "hi") end)
+      wait_for_turn(session)
+
+      CWTest.emit(stub, [CWTest.text_delta("Hel"), CWTest.text_delta("lo")])
+      CWTest.emit_result(stub, result: "Hello", session_id: "s-1")
+
+      assert {:ok, %Result{session_id: "s-1", result: "Hello"}} = Task.await(task)
+
+      # The subscriber saw the streamed events and the terminal result.
+      assert_received {:claude, {:stream_event, %{"type" => "stream_event"}}}
+      assert_received {:claude, {:result, %Result{session_id: "s-1"}}}
+    end
+
+    test "a canned reply is emitted automatically on the next send/3" do
+      {:ok, session, stub} = CWTest.start_session()
+
+      CWTest.stub(stub, [
+        CWTest.text_delta("Hi"),
+        CWTest.result(result: "Hi", session_id: "canned")
+      ])
+
+      assert {:ok, %Result{session_id: "canned", result: "Hi"}} =
+               DuplexSession.send(session, "anything")
+    end
+
+    test "the ClaudeWrapper.Stream layer works over a test session" do
+      {:ok, session, stub} = CWTest.start_session()
+
+      CWTest.stub(stub, [
+        CWTest.text_delta("Hel"),
+        CWTest.text_delta("lo"),
+        CWTest.result(result: "Hello")
+      ])
+
+      assert session |> ClaudeWrapper.Stream.stream("hi") |> ClaudeWrapper.Stream.final_text() ==
+               "Hello"
+    end
+
+    test "sessions are isolated: one stub's events never reach another" do
+      {:ok, s1, stub1} = CWTest.start_session()
+      {:ok, _s2, _stub2} = CWTest.start_session()
+      DuplexSession.subscribe(s1)
+
+      task = Task.async(fn -> DuplexSession.send(s1, "hi") end)
+      wait_for_turn(s1)
+      CWTest.emit_result(stub1, result: "one", session_id: "s1")
+
+      assert {:ok, %Result{session_id: "s1"}} = Task.await(task)
+    end
+  end
+
+  describe "exit_status/2" do
+    test "simulates the subprocess exiting" do
+      {:ok, session, stub} = CWTest.start_session()
+      ref = DuplexSession.wait_for_exit(session, 0)
+      assert ref == :running
+
+      CWTest.exit_status(stub, 0)
+      assert DuplexSession.wait_for_exit(session, 1_000) == :completed
+    end
+  end
+end


### PR DESCRIPTION
Closes #146.

A small transport-adapter seam on `DuplexSession` so the `claude` subprocess can be swapped for a test double, plus a supported `ClaudeWrapper.Test` driver. This replaces the `cat`-fake hack with a first-class way for downstream users to test code that drives `claude_wrapper`.

## Adapter behaviour

`ClaudeWrapper.DuplexSession.Adapter` -- three callbacks over the transport:

- `open/1` -- start the transport, return an opaque handle
- `command/2` -- write iodata to it
- `close/1` -- shut it down

The session only ever touched the port in these ways (open / `Port.command` / `Port.close`), plus inbound `{handle, {:data, chunk}}` / `{handle, {:exit_status, code}}` / `{:EXIT, handle, reason}` messages -- which a double reproduces by sending the same message shapes to the owner. Two impls:

- `Adapter.Port` (default) -- today's behavior, unchanged. The cat-fake unit tests still pass.
- `Adapter.Test` -- a per-session controller process the test drives.

## ClaudeWrapper.Test

```elixir
{:ok, session, stub} = ClaudeWrapper.Test.start_session()
task = Task.async(fn -> ClaudeWrapper.DuplexSession.send(session, "hi") end)
ClaudeWrapper.Test.emit(stub, [text_delta("Hello")])
ClaudeWrapper.Test.emit_result(stub, result: "Hello")
assert {:ok, %ClaudeWrapper.Result{}} = Task.await(task)
```

**Per-process isolation with no new dependency.** Each `start_session/1` spawns its own controller process and wires the session to it -- there is no global registry or shared table, so concurrent (`async: true`) tests cannot collide. This is the hand-rolled route (no `nimble_ownership`), kept cheap by carrying the stub per session instead of looking it up globally.

## Scope
- Port/Test only; no Node/distribution adapter.
- Internal `state.port` now holds the adapter handle; a new `state.adapter` records the impl. External behavior is identical.

## Testing
`format` / `compile --warnings-as-errors` / `credo --strict` / `dialyzer`, full suite. New `claude_wrapper/test_test.exs` drives a full turn (deltas + result, permission flow, error) through the Test adapter, network-free.