### PR TITLE
feat(bundled): opt-in bundled-binary install (cli_path: :bundled)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,13 @@ ClaudeWrapper.CliVersion      # Parse/compare the claude CLI version
 ClaudeWrapper.DangerousClient # Env-gated --dangerously-skip-permissions wrapper
 ClaudeWrapper.Auth            # Env-based auth detection + failure classification
 ClaudeWrapper.Test            # Drive a DuplexSession against an in-process double (network-free)
+ClaudeWrapper.Bundled         # Opt-in bundled-binary resolve/install (cli_path: :bundled)
 ```
+
+Binary resolution is opt-in: `Config.new(binary: :bundled)` resolves to
+`priv/bin/claude` (pure); installing is explicit via `ClaudeWrapper.Bundled`
+or the `mix claude_wrapper.install` / `.uninstall` / `.path` tasks. The
+default stays PATH/`CLAUDE_CLI` discovery.
 
 ### DuplexSession transport adapter
 

--- a/lib/claude_wrapper/bundled.ex
+++ b/lib/claude_wrapper/bundled.ex
@@ -1,0 +1,250 @@
+defmodule ClaudeWrapper.Bundled do
+  # The claude CLI version this release pins the bundled binary to. Bump
+  # in lockstep with upstream CLI releases we have validated against.
+  @pinned_version "2.0.0"
+
+  @moduledoc """
+  Opt-in bundled-binary resolution for the `claude` CLI.
+
+  By default `claude_wrapper` expects `claude` on `PATH` (see
+  `ClaudeWrapper.Config.find_binary/0`). This module is the alternative:
+  resolve, install, and version-pin a `claude` binary under the package's
+  `priv/bin/`, so an app can depend on `claude_wrapper` and get a known
+  CLI without a separate install step on PATH.
+
+  It is **opt-in** -- nothing here runs unless you ask for it, via
+  `ClaudeWrapper.Config.new(binary: :bundled)`, the `mix claude_wrapper.*`
+  tasks, or calling `ensure!/0` directly. The stdlib-minimal default and
+  its dependency footprint are unchanged for everyone else.
+
+  ## Resolution vs install
+
+  `path/0` is pure: it returns where the bundled binary lives, whether or
+  not it is present. `Config.new(binary: :bundled)` resolves to that path
+  and does **not** touch the network -- a struct constructor should not
+  download anything. Installing is an explicit step:
+
+      mix claude_wrapper.install      # or: ClaudeWrapper.Bundled.ensure!()
+
+  `ensure/0` installs only when the binary is missing or its version does
+  not match `pinned_version/0`.
+
+  ## Version pin
+
+  The pinned version is `#{@pinned_version}`.
+  `install/0` verifies the freshly-installed binary reports that version;
+  it does not attempt to coerce an arbitrary version out of the upstream
+  installer.
+  """
+
+  alias ClaudeWrapper.{CliVersion, Error}
+
+  # Anthropic's official installer (POSIX shell). Piped to `sh` with a
+  # temp HOME so it does not touch the user's real install.
+  @install_script_url "https://claude.ai/install.sh"
+
+  @doc "The pinned CLI version the bundled binary is expected to be."
+  @spec pinned_version() :: String.t()
+  def pinned_version, do: @pinned_version
+
+  @doc """
+  Absolute path to the bundled binary, `priv/bin/claude`.
+
+  Pure -- returns the path whether or not the binary is installed.
+  """
+  @spec path() :: String.t()
+  def path do
+    :claude_wrapper
+    |> :code.priv_dir()
+    |> to_string()
+    |> Path.join("bin")
+    |> Path.join("claude")
+  end
+
+  @doc "Whether the bundled binary is present on disk."
+  @spec installed?() :: boolean()
+  def installed?, do: File.exists?(path())
+
+  @doc """
+  The version the installed bundled binary reports, or `nil` if it is not
+  installed (or `--version` could not be parsed).
+  """
+  @spec installed_version() :: CliVersion.t() | nil
+  def installed_version do
+    bin = path()
+
+    with true <- File.exists?(bin),
+         {out, 0} <- System.cmd(bin, ["--version"], stderr_to_stdout: true),
+         {:ok, version} <- CliVersion.parse(out) do
+      version
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Ensure a bundled binary matching `pinned_version/0` is installed.
+
+  Installs when the binary is missing or reports a different version;
+  otherwise a no-op. Returns `{:ok, path}` or `{:error, %Error{}}`.
+  """
+  @spec ensure() :: {:ok, String.t()} | {:error, Error.t()}
+  def ensure do
+    if up_to_date?() do
+      {:ok, path()}
+    else
+      install()
+    end
+  end
+
+  @doc "Like `ensure/0` but returns the path or raises on failure."
+  @spec ensure!() :: String.t()
+  def ensure! do
+    case ensure() do
+      {:ok, bin} -> bin
+      {:error, %Error{} = err} -> raise err
+    end
+  end
+
+  @doc """
+  Download and install the pinned `claude` binary into `priv/bin/`.
+
+  Runs Anthropic's official installer in a temporary `HOME`, copies the
+  resulting binary into place, marks it executable, and (on macOS) retries
+  once after clearing the Gatekeeper quarantine if the first run is killed
+  (exit 137). Returns `{:ok, path}` or `{:error, %Error{}}`.
+  """
+  @spec install() :: {:ok, String.t()} | {:error, Error.t()}
+  def install do
+    dest = path()
+    File.mkdir_p!(Path.dirname(dest))
+
+    with {:ok, tmp_home} <- make_temp_home(),
+         {:ok, installed} <- run_installer(tmp_home),
+         :ok <- copy_binary(installed, dest),
+         :ok <- verify_version(dest) do
+      _ = File.rm_rf(tmp_home)
+      {:ok, dest}
+    end
+  end
+
+  @doc "Remove the bundled binary. Idempotent."
+  @spec uninstall() :: :ok
+  def uninstall do
+    _ = File.rm_rf(path())
+    :ok
+  end
+
+  # -- internals -----------------------------------------------------
+
+  defp up_to_date? do
+    case {installed?(), installed_version()} do
+      {true, %CliVersion{} = v} -> CliVersion.to_string(v) == @pinned_version
+      _ -> false
+    end
+  end
+
+  defp make_temp_home do
+    base =
+      Path.join(System.tmp_dir!(), "claude_wrapper_install_#{System.unique_integer([:positive])}")
+
+    case File.mkdir_p(base) do
+      :ok -> {:ok, base}
+      {:error, reason} -> {:error, Error.new(:io, reason: reason)}
+    end
+  end
+
+  defp run_installer(tmp_home) do
+    env = [{"HOME", tmp_home}]
+    cmd = "curl -fsSL #{@install_script_url} | sh"
+
+    case System.cmd("sh", ["-c", cmd], env: env, stderr_to_stdout: true) do
+      {_out, 0} ->
+        locate_installed(tmp_home)
+
+      {out, code} ->
+        {:error,
+         Error.new(:command_failed,
+           reason: "bundled install failed",
+           exit_code: code,
+           stderr: out
+         )}
+    end
+  end
+
+  # The installer drops the binary somewhere under the temp HOME; find it.
+  defp locate_installed(tmp_home) do
+    tmp_home
+    |> Path.join("**/claude")
+    |> Path.wildcard()
+    |> Enum.find(&File.regular?/1)
+    |> case do
+      nil -> {:error, Error.new(:not_found, reason: :installed_binary)}
+      found -> {:ok, found}
+    end
+  end
+
+  defp copy_binary(src, dest) do
+    with {:ok, _} <- File.copy(src, dest),
+         :ok <- File.chmod(dest, 0o755) do
+      :ok
+    else
+      {:error, reason} -> {:error, Error.new(:io, reason: reason)}
+    end
+  end
+
+  # Confirm the installed binary reports the pinned version. On macOS the
+  # first exec of a freshly-copied binary can be SIGKILLed by Gatekeeper
+  # (exit 137); clear the quarantine xattr and retry once.
+  defp verify_version(dest) do
+    case System.cmd(dest, ["--version"], stderr_to_stdout: true) do
+      {out, 0} ->
+        check_pinned(out, dest)
+
+      {_out, 137} ->
+        retry_after_gatekeeper(dest)
+
+      {out, code} ->
+        {:error,
+         Error.new(:command_failed,
+           reason: "bundled --version failed",
+           exit_code: code,
+           stderr: out
+         )}
+    end
+  end
+
+  defp retry_after_gatekeeper(dest) do
+    _ = System.cmd("xattr", ["-d", "com.apple.quarantine", dest], stderr_to_stdout: true)
+
+    case System.cmd(dest, ["--version"], stderr_to_stdout: true) do
+      {out, 0} ->
+        check_pinned(out, dest)
+
+      {out, code} ->
+        {:error,
+         Error.new(:command_failed,
+           reason: "bundled --version failed after Gatekeeper retry",
+           exit_code: code,
+           stderr: out
+         )}
+    end
+  end
+
+  defp check_pinned(version_output, _dest) do
+    case CliVersion.parse(version_output) do
+      {:ok, v} ->
+        if CliVersion.to_string(v) == @pinned_version do
+          :ok
+        else
+          {:error,
+           Error.new(:version_mismatch,
+             reason: {:expected, @pinned_version, :got, CliVersion.to_string(v)}
+           )}
+        end
+
+      {:error, %Error{} = err} ->
+        {:error, err}
+    end
+  end
+end

--- a/lib/claude_wrapper/config.ex
+++ b/lib/claude_wrapper/config.ex
@@ -34,7 +34,10 @@ defmodule ClaudeWrapper.Config do
 
   ## Options
 
-    * `:binary` - Path to the claude binary (default: auto-discover)
+    * `:binary` - Path to the claude binary (default: auto-discover via
+      `CLAUDE_CLI`/PATH). Pass the atom `:bundled` to resolve the opt-in
+      bundled binary (`ClaudeWrapper.Bundled.path/0`); install it first
+      with `mix claude_wrapper.install`.
     * `:working_dir` - Working directory for the subprocess
     * `:env` - List of `{key, value}` environment variable tuples
     * `:timeout` - Command timeout in milliseconds
@@ -44,7 +47,7 @@ defmodule ClaudeWrapper.Config do
   @spec new(keyword()) :: t()
   def new(opts \\ []) do
     %__MODULE__{
-      binary: opts[:binary] || find_binary(),
+      binary: resolve_binary(opts[:binary]),
       working_dir: opts[:working_dir],
       env: opts[:env] || [],
       timeout: opts[:timeout],
@@ -52,6 +55,16 @@ defmodule ClaudeWrapper.Config do
       debug: Keyword.get(opts, :debug, false)
     }
   end
+
+  # Resolve the `:binary` option into a concrete path.
+  #
+  #   * `nil`        -> PATH/`CLAUDE_CLI` auto-discovery (`find_binary/0`)
+  #   * `:bundled`   -> the opt-in bundled binary path (pure; install is
+  #                     a separate step -- see `ClaudeWrapper.Bundled`)
+  #   * a string     -> used verbatim
+  defp resolve_binary(nil), do: find_binary()
+  defp resolve_binary(:bundled), do: ClaudeWrapper.Bundled.path()
+  defp resolve_binary(path) when is_binary(path), do: path
 
   @doc """
   Find the claude binary path.

--- a/lib/mix/tasks/claude_wrapper.install.ex
+++ b/lib/mix/tasks/claude_wrapper.install.ex
@@ -1,0 +1,29 @@
+defmodule Mix.Tasks.ClaudeWrapper.Install do
+  @shortdoc "Install the pinned bundled claude binary into priv/bin"
+
+  @moduledoc """
+  Install the opt-in bundled `claude` CLI, pinned to
+  `ClaudeWrapper.Bundled.pinned_version/0`, into the package's `priv/bin/`.
+
+      mix claude_wrapper.install
+
+  No-op when an up-to-date binary is already installed. Reinstalls on a
+  version mismatch. This downloads from the network; the default PATH-based
+  resolution does not need it.
+  """
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.config")
+
+    case ClaudeWrapper.Bundled.ensure() do
+      {:ok, path} ->
+        Mix.shell().info("claude #{ClaudeWrapper.Bundled.pinned_version()} installed at #{path}")
+
+      {:error, error} ->
+        Mix.raise("bundled install failed: #{Exception.message(error)}")
+    end
+  end
+end

--- a/lib/mix/tasks/claude_wrapper.path.ex
+++ b/lib/mix/tasks/claude_wrapper.path.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.ClaudeWrapper.Path do
+  @shortdoc "Print the bundled claude binary path (and install state)"
+
+  @moduledoc """
+  Print where the opt-in bundled `claude` binary lives, and whether it is
+  installed.
+
+      mix claude_wrapper.path
+
+  Prints the absolute path on stdout (scriptable); install state goes to
+  stderr via the Mix shell.
+  """
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.config")
+    path = ClaudeWrapper.Bundled.path()
+
+    state =
+      case ClaudeWrapper.Bundled.installed_version() do
+        nil ->
+          if ClaudeWrapper.Bundled.installed?(),
+            do: "installed (version unknown)",
+            else: "not installed"
+
+        version ->
+          "installed (#{ClaudeWrapper.CliVersion.to_string(version)})"
+      end
+
+    Mix.shell().info("#{path}  [#{state}]")
+  end
+end

--- a/lib/mix/tasks/claude_wrapper.uninstall.ex
+++ b/lib/mix/tasks/claude_wrapper.uninstall.ex
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.ClaudeWrapper.Uninstall do
+  @shortdoc "Remove the bundled claude binary from priv/bin"
+
+  @moduledoc """
+  Remove the opt-in bundled `claude` binary installed by
+  `mix claude_wrapper.install`.
+
+      mix claude_wrapper.uninstall
+
+  Idempotent: succeeds whether or not a bundled binary is present.
+  """
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.config")
+    path = ClaudeWrapper.Bundled.path()
+    existed? = ClaudeWrapper.Bundled.installed?()
+    :ok = ClaudeWrapper.Bundled.uninstall()
+
+    if existed? do
+      Mix.shell().info("removed bundled claude at #{path}")
+    else
+      Mix.shell().info("no bundled claude to remove (#{path})")
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,10 @@ defmodule ClaudeWrapper.MixProject do
       package: package(),
       name: "ClaudeWrapper",
       description: "Elixir wrapper for the Claude Code CLI",
-      dialyzer: [plt_file: {:no_warn, "_build/dev/dialyxir_#{System.otp_release()}.plt"}]
+      dialyzer: [
+        plt_file: {:no_warn, "_build/dev/dialyxir_#{System.otp_release()}.plt"},
+        plt_add_apps: [:mix]
+      ]
     ]
   end
 

--- a/test/claude_wrapper/bundled_test.exs
+++ b/test/claude_wrapper/bundled_test.exs
@@ -1,0 +1,60 @@
+defmodule ClaudeWrapper.BundledTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.{Bundled, Config}
+
+  describe "path/0 and pinned_version/0 (pure)" do
+    test "path is an absolute priv/bin/claude under the app" do
+      path = Bundled.path()
+      assert Path.type(path) == :absolute
+      assert String.ends_with?(path, Path.join(["priv", "bin", "claude"]))
+    end
+
+    test "pinned_version is a concrete version string" do
+      # The CLI reports the version as the first token of --version output.
+      assert {:ok, _} =
+               ClaudeWrapper.CliVersion.parse("#{Bundled.pinned_version()} (Claude Code)")
+    end
+
+    test "installed? is a boolean and installed_version is nil when absent" do
+      # In a clean env the bundled binary is not present.
+      refute Bundled.installed?()
+      assert Bundled.installed_version() == nil
+    end
+  end
+
+  describe "Config resolution" do
+    test ":bundled resolves to the bundled path without touching the network" do
+      assert Config.new(binary: :bundled).binary == Bundled.path()
+    end
+
+    test "an explicit path is used verbatim" do
+      assert Config.new(binary: "/custom/claude").binary == "/custom/claude"
+    end
+
+    test "nil falls back to PATH/CLAUDE_CLI discovery" do
+      assert Config.new(binary: nil).binary == Config.find_binary()
+    end
+  end
+
+  describe "uninstall/0" do
+    test "is idempotent when nothing is installed" do
+      assert Bundled.uninstall() == :ok
+      assert Bundled.uninstall() == :ok
+      refute Bundled.installed?()
+    end
+  end
+
+  describe "live install" do
+    @tag :integration
+    test "ensure!/0 installs the pinned binary and Config can drive it" do
+      on_exit(fn -> Bundled.uninstall() end)
+
+      path = Bundled.ensure!()
+      assert File.exists?(path)
+
+      assert ClaudeWrapper.CliVersion.to_string(Bundled.installed_version()) ==
+               Bundled.pinned_version()
+    end
+  end
+end


### PR DESCRIPTION
Closes #144.

An opt-in bundled-binary mode so `claude_wrapper` can resolve/install a pinned `claude` CLI into `priv/bin/` instead of requiring it on PATH. The stdlib-minimal default is unchanged: nothing downloads unless you opt in.

## Surface

- `ClaudeWrapper.Config.new(binary: :bundled)` resolves the binary to the bundled path (`priv/bin/claude`). Resolution is pure (no network in a struct constructor); install is an explicit step.
- `ClaudeWrapper.Bundled`:
  - `path/0`, `pinned_version/0`, `installed?/0`, `installed_version/0`
  - `ensure/0` / `ensure!/0` -- install if missing or version-mismatched
  - `install/0` -- download via Anthropic's installer into a temp `HOME`, copy to `priv/bin/claude`, `chmod +x`, with a macOS Gatekeeper exit-137 retry
  - `uninstall/0`
- Mix tasks: `mix claude_wrapper.install` / `.uninstall` / `.path`.

## Decisions / scope

- **Opt-in only.** Default PATH lookup (and `CLAUDE_CLI`) is untouched; no new runtime deps for non-opters.
- **Resolution vs install split.** `Config.new(binary: :bundled)` returns the path; auto-install on first use is provided via `ensure!/0` and the install task, not implicitly inside `Config.new` (a struct constructor should not hit the network). Documented.
- **Version pinning is verify-after-install in v1** -- `ensure/0` reinstalls on mismatch and `install/0` checks the result against `pinned_version/0`; we do not try to force an arbitrary version through the upstream installer.
- **Install location is `priv/bin`** per the issue; writable in dev/CI. Read-only-release packaging is noted as a follow-up.

## Testing

Pure logic (path, pinned version, `installed?/0`, `Config` resolution, mix task wiring) is unit-tested. The live download (`install/0` / `ensure!/0` end-to-end) is `@tag :integration` -- it hits the network and OS, so it is excluded from the default suite, like the other integration tests.