### PR TITLE
fix: emit --debug instead of invalid --debug-filter flag

### DIFF
--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -636,7 +636,7 @@ defmodule ClaudeWrapper.Query do
     |> add_bool("--fork-session", q.fork_session)
     |> add_worktree(q.worktree)
     |> add_bool("--brief", q.brief)
-    |> add_opt("--debug-filter", q.debug_filter)
+    |> add_opt("--debug", q.debug_filter)
     |> add_opt("--debug-file", q.debug_file)
     |> add_opt("--betas", q.betas)
     |> add_list("--plugin-dir", q.plugin_dirs)

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -115,6 +115,19 @@ defmodule ClaudeWrapperTest do
       assert "--continue" in args
     end
 
+    test "build_args emits --debug with the filter value (not --debug-filter)" do
+      args =
+        Query.new("p")
+        |> Query.debug_filter("api,hooks")
+        |> Query.build_args()
+
+      # Regression for #156: the CLI flag is `--debug [filter]`, not `--debug-filter`.
+      refute "--debug-filter" in args
+      idx = Enum.find_index(args, &(&1 == "--debug"))
+      assert idx != nil
+      assert Enum.at(args, idx + 1) == "api,hooks"
+    end
+
     test "to_command_string" do
       config = Config.new()
 


### PR DESCRIPTION
Closes #156.

## Problem

`Query.build_args/1` emitted `--debug-filter <value>` when `debug_filter/2` was set, but no such flag exists in the `claude` CLI. The flag is `--debug [filter]` (an optional value passed to `--debug`), so any query using a debug filter passed an unrecognized flag.

## Change

`lib/claude_wrapper/query.ex`: emit `--debug <filter>` instead of `--debug-filter <filter>`, matching the CLI and the Rust `claude-wrapper` crate (`src/command/query.rs`). The struct field and setter name `debug_filter` are unchanged; only the emitted arg string changes.

## Test

Added a regression test in `test/claude_wrapper_test.exs` asserting `build_args` emits `--debug` immediately followed by the filter value and never `--debug-filter`.

## Checks

- `mix format`
- `mix compile --warnings-as-errors`
- `mix credo --strict` (no issues)
- `mix test` (556 passed)