### PR TITLE
feat(query): add --name, --plugin-url, --safe-mode flags

### DIFF
--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -69,6 +69,9 @@ defmodule ClaudeWrapper.Query do
           debug_file: String.t() | nil,
           betas: String.t() | nil,
           plugin_dirs: [String.t()],
+          plugin_urls: [String.t()],
+          name: String.t() | nil,
+          safe_mode: boolean(),
           setting_sources: String.t() | nil,
           tmux: boolean(),
           prompt_suggestions: boolean(),
@@ -101,6 +104,7 @@ defmodule ClaudeWrapper.Query do
     :debug_filter,
     :debug_file,
     :betas,
+    :name,
     :setting_sources,
     allowed_tools: [],
     disallowed_tools: [],
@@ -109,6 +113,8 @@ defmodule ClaudeWrapper.Query do
     tools: [],
     files: [],
     plugin_dirs: [],
+    plugin_urls: [],
+    safe_mode: false,
     continue_session: false,
     no_session_persistence: false,
     dangerously_skip_permissions: false,
@@ -304,6 +310,18 @@ defmodule ClaudeWrapper.Query do
   @spec plugin_dir(t(), String.t()) :: t()
   def plugin_dir(%__MODULE__{} = q, dir), do: %{q | plugin_dirs: q.plugin_dirs ++ [dir]}
 
+  @doc "Fetch a plugin `.zip` from a URL (`--plugin-url`). Repeatable."
+  @spec plugin_url(t(), String.t()) :: t()
+  def plugin_url(%__MODULE__{} = q, url), do: %{q | plugin_urls: q.plugin_urls ++ [url]}
+
+  @doc "Set a display name for the session (`--name`)."
+  @spec name(t(), String.t()) :: t()
+  def name(%__MODULE__{} = q, name), do: %{q | name: name}
+
+  @doc "Start with all customizations disabled (`--safe-mode`)."
+  @spec safe_mode(t()) :: t()
+  def safe_mode(%__MODULE__{} = q), do: %{q | safe_mode: true}
+
   @doc "Set settings source list."
   @spec setting_sources(t(), String.t()) :: t()
   def setting_sources(%__MODULE__{} = q, sources), do: %{q | setting_sources: sources}
@@ -389,6 +407,7 @@ defmodule ClaudeWrapper.Query do
   defp apply_opt({:debug_filter, v}, q), do: debug_filter(q, v)
   defp apply_opt({:debug_file, v}, q), do: debug_file(q, v)
   defp apply_opt({:betas, v}, q), do: betas(q, v)
+  defp apply_opt({:name, v}, q), do: name(q, v)
   defp apply_opt({:setting_sources, v}, q), do: setting_sources(q, v)
 
   # Boolean flags: only apply on true.
@@ -421,6 +440,8 @@ defmodule ClaudeWrapper.Query do
   defp apply_opt({:disable_slash_commands, _}, q), do: q
   defp apply_opt({:include_hook_events, true}, q), do: include_hook_events(q)
   defp apply_opt({:include_hook_events, _}, q), do: q
+  defp apply_opt({:safe_mode, true}, q), do: safe_mode(q)
+  defp apply_opt({:safe_mode, _}, q), do: q
 
   defp apply_opt({:exclude_dynamic_system_prompt_sections, true}, q),
     do: exclude_dynamic_system_prompt_sections(q)
@@ -447,6 +468,9 @@ defmodule ClaudeWrapper.Query do
 
   defp apply_opt({:plugin_dirs, dirs}, q) when is_list(dirs),
     do: Enum.reduce(dirs, q, &plugin_dir(&2, &1))
+
+  defp apply_opt({:plugin_urls, urls}, q) when is_list(urls),
+    do: Enum.reduce(urls, q, &plugin_url(&2, &1))
 
   defp apply_opt({:mcp_config, paths}, q) when is_list(paths),
     do: Enum.reduce(paths, q, &mcp_config(&2, &1))
@@ -640,6 +664,9 @@ defmodule ClaudeWrapper.Query do
     |> add_opt("--debug-file", q.debug_file)
     |> add_opt("--betas", q.betas)
     |> add_list("--plugin-dir", q.plugin_dirs)
+    |> add_list("--plugin-url", q.plugin_urls)
+    |> add_opt("--name", q.name)
+    |> add_bool("--safe-mode", q.safe_mode)
     |> add_opt("--setting-sources", q.setting_sources)
     |> add_bool("--tmux", q.tmux)
     |> add_bool("--prompt-suggestions", q.prompt_suggestions)

--- a/test/claude_wrapper/query_test.exs
+++ b/test/claude_wrapper/query_test.exs
@@ -28,6 +28,7 @@ defmodule ClaudeWrapper.QueryTest do
           debug_filter: "api,hooks",
           debug_file: "/tmp/dbg.log",
           betas: "feature-x",
+          name: "my session",
           setting_sources: "user,project"
         )
 
@@ -50,6 +51,7 @@ defmodule ClaudeWrapper.QueryTest do
       assert q.debug_filter == "api,hooks"
       assert q.debug_file == "/tmp/dbg.log"
       assert q.betas == "feature-x"
+      assert q.name == "my session"
       assert q.setting_sources == "user,project"
     end
   end
@@ -68,7 +70,8 @@ defmodule ClaudeWrapper.QueryTest do
           fork_session: true,
           strict_mcp_config: true,
           include_partial_messages: true,
-          tmux: true
+          tmux: true,
+          safe_mode: true
         )
 
       assert q.dangerously_skip_permissions
@@ -80,6 +83,7 @@ defmodule ClaudeWrapper.QueryTest do
       assert q.strict_mcp_config
       assert q.include_partial_messages
       assert q.tmux
+      assert q.safe_mode
     end
 
     test "false (or any non-true) leaves the flag unchanged" do
@@ -121,12 +125,14 @@ defmodule ClaudeWrapper.QueryTest do
         |> Query.apply_opts(
           tools: ["Read", "Edit"],
           files: ["doc.txt", "img.png"],
-          plugin_dirs: ["/p1", "/p2"]
+          plugin_dirs: ["/p1", "/p2"],
+          plugin_urls: ["https://x/a.zip", "https://x/b.zip"]
         )
 
       assert q.tools == ["Read", "Edit"]
       assert q.files == ["doc.txt", "img.png"]
       assert q.plugin_dirs == ["/p1", "/p2"]
+      assert q.plugin_urls == ["https://x/a.zip", "https://x/b.zip"]
     end
 
     test "add_dir accepts a list or a single binary" do

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -128,6 +128,31 @@ defmodule ClaudeWrapperTest do
       assert Enum.at(args, idx + 1) == "api,hooks"
     end
 
+    test "build_args emits --name with the value" do
+      args = Query.new("p") |> Query.name("my session") |> Query.build_args()
+
+      idx = Enum.find_index(args, &(&1 == "--name"))
+      assert idx != nil
+      assert Enum.at(args, idx + 1) == "my session"
+    end
+
+    test "build_args emits --safe-mode only when set" do
+      assert "--safe-mode" in (Query.new("p") |> Query.safe_mode() |> Query.build_args())
+      refute "--safe-mode" in (Query.new("p") |> Query.build_args())
+    end
+
+    test "build_args emits repeated --plugin-url for each url" do
+      args =
+        Query.new("p")
+        |> Query.plugin_url("https://example.com/a.zip")
+        |> Query.plugin_url("https://example.com/b.zip")
+        |> Query.build_args()
+
+      assert Enum.count(args, &(&1 == "--plugin-url")) == 2
+      assert "https://example.com/a.zip" in args
+      assert "https://example.com/b.zip" in args
+    end
+
     test "to_command_string" do
       config = Config.new()
 


### PR DESCRIPTION
Closes #157.

## Summary

Adds three `Query` flags that exist in the `claude` CLI and the Rust `claude-wrapper` crate (0.12.1) but were missing here.

| Flag | Setter | Shape |
|------|--------|-------|
| `--name` | `name/2` | scalar |
| `--plugin-url` | `plugin_url/2` | repeatable list (mirrors `plugin_dir`) |
| `--safe-mode` | `safe_mode/1` | bare boolean (mirrors `bare`) |

Each gets a struct field, `@type` entry, setter, `apply_opt/2` clause (`plugin_urls` accepts a list; `safe_mode` applies on `true`), and `build_args` emission.

## Tests

- `apply_opts/2`: `name` (scalar), `plugin_urls` (list), `safe_mode` (boolean).
- `build_args/1`: `--name` with value, `--safe-mode` present/absent, repeated `--plugin-url` per URL.

## Checks

- `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` (clean), `mix test` (559 passed).