### PR TITLE
feat(mcp): wrap mcp login and mcp logout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ ClaudeWrapper.Command                # Behaviour for CLI commands
 ClaudeWrapper.Commands.Auth          # auth login (email/mode/sso) / logout / status / setup-token
 ClaudeWrapper.Commands.Agents        # list configured agents
 ClaudeWrapper.Commands.Doctor        # claude doctor
-ClaudeWrapper.Commands.Mcp           # mcp add / add-json / add-from-desktop / serve / list / get / remove
+ClaudeWrapper.Commands.Mcp           # mcp add / add-json / add-from-desktop / serve / login / logout / list / get / remove
 ClaudeWrapper.Commands.Plugin        # plugin install/uninstall/enable/disable/update/validate/tag/details/prune
 ClaudeWrapper.Commands.Marketplace   # marketplace add/remove/list/update
 ClaudeWrapper.Commands.AutoMode      # auto-mode config / defaults / critique

--- a/lib/claude_wrapper/commands/mcp.ex
+++ b/lib/claude_wrapper/commands/mcp.ex
@@ -2,7 +2,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   @moduledoc """
   MCP (Model Context Protocol) server management commands.
 
-  Wraps `claude mcp add|add-json|add-from-claude-desktop|remove|list|get|serve|reset-project-choices`.
+  Wraps `claude mcp add|add-json|add-from-claude-desktop|remove|list|get|serve|login|logout|reset-project-choices`.
 
   ## Usage
 
@@ -257,6 +257,51 @@ defmodule ClaudeWrapper.Commands.Mcp do
 
     ["mcp", "serve"] ++ flags
   end
+
+  @doc """
+  Authenticate with an MCP server (HTTP, SSE, or claude.ai connector).
+
+  Wraps `claude mcp login <name>`.
+
+  ## Options
+
+    * `:no_browser` - Print the authorization URL instead of opening a browser
+      (`--no-browser`, boolean), for SSH/headless sessions.
+  """
+  @spec login(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def login(%Config{} = config, name, opts \\ []) do
+    args = Config.base_args(config) ++ login_args(name, opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, Error.command_failed(code, output)}
+    end
+  end
+
+  @doc false
+  @spec login_args(String.t(), keyword()) :: [String.t()]
+  def login_args(name, opts) do
+    ["mcp", "login"] ++ bool_flag(opts[:no_browser], "--no-browser") ++ [name]
+  end
+
+  @doc """
+  Clear stored OAuth credentials for an MCP server.
+
+  Wraps `claude mcp logout <name>`.
+  """
+  @spec logout(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def logout(%Config{} = config, name) do
+    args = Config.base_args(config) ++ logout_args(name)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, Error.command_failed(code, output)}
+    end
+  end
+
+  @doc false
+  @spec logout_args(String.t()) :: [String.t()]
+  def logout_args(name), do: ["mcp", "logout", name]
 
   @doc """
   Reset project choices for MCP servers.

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -885,6 +885,8 @@ defmodule ClaudeWrapperTest do
       assert {:add_from_desktop, 3} in funcs
       assert {:remove, 3} in funcs
       assert {:serve, 2} in funcs
+      assert {:login, 3} in funcs
+      assert {:logout, 2} in funcs
       assert {:reset_project_choices, 1} in funcs
 
       # @doc false builders are public for arg-composition testing.
@@ -892,6 +894,21 @@ defmodule ClaudeWrapperTest do
       assert {:add_json_args, 3} in funcs
       assert {:add_from_desktop_args, 2} in funcs
       assert {:serve_args, 1} in funcs
+      assert {:login_args, 2} in funcs
+      assert {:logout_args, 1} in funcs
+    end
+
+    test "login_args defaults to subcommand plus name" do
+      assert Mcp.login_args("sentry", []) == ["mcp", "login", "sentry"]
+    end
+
+    test "login_args emits --no-browser before the name" do
+      assert Mcp.login_args("sentry", no_browser: true) ==
+               ["mcp", "login", "--no-browser", "sentry"]
+    end
+
+    test "logout_args is subcommand plus name" do
+      assert Mcp.logout_args("sentry") == ["mcp", "logout", "sentry"]
     end
 
     test "add_args defaults to subcommand plus positionals" do


### PR DESCRIPTION
Closes #158.

## Summary

Adds the `mcp login` and `mcp logout` subcommands to `ClaudeWrapper.Commands.Mcp`, matching the Rust `claude-wrapper` crate (0.12.1) and the current CLI.

- `login/3` wraps `claude mcp login <name>`, with a `:no_browser` option emitting `--no-browser` (for SSH/headless sessions). The flag is placed before the name to match the CLI.
- `logout/2` wraps `claude mcp logout <name>` (clears stored OAuth credentials).

Both follow the existing subcommand pattern, with `@doc false` `login_args/2` and `logout_args/1` builders for arg-composition tests.

## Tests

- Functions-loaded assertions for `login/3`, `logout/2`, `login_args/2`, `logout_args/1`.
- `login_args` default (`mcp login <name>`), `--no-browser` ordering, and `logout_args`.

## Docs

Updated the `Commands.Mcp` line in CLAUDE.md.

## Checks

- `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` (clean), `mix test`.