### PR TITLE
feat: wrap the ultrareview command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ ClaudeWrapper.Commands.AutoMode      # auto-mode config / defaults / critique
 ClaudeWrapper.Commands.Install       # claude install
 ClaudeWrapper.Commands.Update        # claude update
 ClaudeWrapper.Commands.Project       # project purge
+ClaudeWrapper.Commands.Ultrareview   # ultrareview (cloud multi-agent code review)
 ClaudeWrapper.Commands.Version       # claude --version
 ```
 

--- a/lib/claude_wrapper/commands/ultrareview.ex
+++ b/lib/claude_wrapper/commands/ultrareview.ex
@@ -1,0 +1,70 @@
+defmodule ClaudeWrapper.Commands.Ultrareview do
+  @moduledoc """
+  `claude ultrareview` -- cloud-hosted multi-agent code review.
+
+  Runs a cloud-hosted multi-agent code review and returns the findings.
+  With no target, reviews the current branch; pass a PR number/URL or a
+  base branch name to review that instead.
+
+  The review runs in the cloud and can take many minutes. The CLI's own
+  `--timeout` (default 30 minutes) bounds how long it waits for the review
+  to finish; size any surrounding timeout to at least that value.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # Review the current branch
+      {:ok, findings} = ClaudeWrapper.Commands.Ultrareview.execute(config)
+
+      # Review PR 123, raw JSON payload, wait up to 45 minutes
+      {:ok, json} =
+        ClaudeWrapper.Commands.Ultrareview.execute(config,
+          target: "123",
+          json: true,
+          timeout: 45
+        )
+  """
+
+  alias ClaudeWrapper.{Config, Error}
+
+  @doc """
+  Run `claude ultrareview` and return the output.
+
+  ## Options
+
+    * `:target` - Review a PR number/URL or a base branch name instead of
+      the current branch (positional argument).
+    * `:json` - Print the raw `bugs.json` payload instead of formatted
+      findings (`--json`, boolean).
+    * `:timeout` - Maximum minutes to wait for the review to finish
+      (`--timeout`). The CLI default is 30.
+  """
+  @spec execute(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def execute(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ args(opts)
+
+    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, Error.command_failed(code, output)}
+    end
+  end
+
+  @doc false
+  @spec args(keyword()) :: [String.t()]
+  def args(opts) do
+    flags =
+      bool_flag(opts[:json], "--json") ++
+        value_flag(opts[:timeout], "--timeout")
+
+    positional = if opts[:target], do: [to_string(opts[:target])], else: []
+
+    ["ultrareview"] ++ flags ++ positional
+  end
+
+  defp bool_flag(true, flag), do: [flag]
+  defp bool_flag(_falsy, _flag), do: []
+
+  defp value_flag(nil, _flag), do: []
+  defp value_flag(value, flag), do: [flag, to_string(value)]
+end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -1099,6 +1099,41 @@ defmodule ClaudeWrapperTest do
     end
   end
 
+  describe "Commands.Ultrareview" do
+    alias ClaudeWrapper.Commands.Ultrareview
+
+    test "module is loaded and has expected functions" do
+      Code.ensure_loaded!(Ultrareview)
+      funcs = Ultrareview.__info__(:functions)
+
+      assert {:execute, 1} in funcs
+      assert {:execute, 2} in funcs
+      assert {:args, 1} in funcs
+    end
+
+    test "args defaults to the bare subcommand" do
+      assert Ultrareview.args([]) == ["ultrareview"]
+    end
+
+    test "args emits --json, --timeout, then the target" do
+      assert Ultrareview.args(target: "123", json: true, timeout: 45) ==
+               ["ultrareview", "--json", "--timeout", "45", "123"]
+    end
+
+    test "args emits the target as a positional only" do
+      assert Ultrareview.args(target: "main") == ["ultrareview", "main"]
+    end
+
+    test "args emits --json only" do
+      assert Ultrareview.args(json: true) == ["ultrareview", "--json"]
+    end
+
+    test "args omits unset flags" do
+      refute "--json" in Ultrareview.args(timeout: 10)
+      refute "--timeout" in Ultrareview.args(json: true)
+    end
+  end
+
   describe "Commands.Auth" do
     alias ClaudeWrapper.Commands.Auth
 


### PR DESCRIPTION
Closes #159.

## Summary

Adds `ClaudeWrapper.Commands.Ultrareview`, mirroring the Rust `claude-wrapper` crate's `UltrareviewCommand`. Wraps `claude ultrareview [target]`, a cloud-hosted multi-agent code review.

Options:

- `:target` -> positional (PR number/URL or base branch; defaults to current branch)
- `:json` -> `--json` (raw `bugs.json` payload)
- `:timeout` -> `--timeout <minutes>` (CLI default 30)

Arg order matches the CLI and Rust: `ultrareview [--json] [--timeout N] [target]`. Follows the existing command idiom (direct `System.cmd`, `execute/2` plus an `@doc false` `args/1` builder). The moduledoc notes the review can take many minutes and that surrounding timeouts should be sized to at least the `--timeout` value.

## Tests

Functions-loaded assertions plus `args/1` coverage: default, `--json`/`--timeout`/target ordering, target-only, json-only, and unset-flag omission.

## Docs

Added the `Commands.Ultrareview` line to the CLAUDE.md command surface.

## Checks

- `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` (clean), `mix test` (575 passed).