### PR TITLE
test: assert --debug-file emission in build_args/1

### DIFF
--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -128,6 +128,17 @@ defmodule ClaudeWrapperTest do
       assert Enum.at(args, idx + 1) == "api,hooks"
     end
 
+    test "build_args emits --debug-file with the path" do
+      args =
+        Query.new("p")
+        |> Query.debug_file("/tmp/debug.log")
+        |> Query.build_args()
+
+      idx = Enum.find_index(args, &(&1 == "--debug-file"))
+      assert idx != nil
+      assert Enum.at(args, idx + 1) == "/tmp/debug.log"
+    end
+
     test "build_args emits --name with the value" do
       args = Query.new("p") |> Query.name("my session") |> Query.build_args()
 


### PR DESCRIPTION
## Summary

`debug_file` -> `--debug-file` is set via `Query.debug_file/2` and tested at the field level in `query_test.exs`, but `build_args/1` never asserted the flag actually appears in the CLI argument list. This mirrors the existing `--debug` filter test in the same block.

## Changes

- Add a test in `test/claude_wrapper_test.exs` asserting `build_args/1` emits `--debug-file` followed by the path, alongside the existing `--debug`/`--debug-filter` regression test.

## Test plan

- [x] `mix format`
- [x] `mix test`

Closes #173