### PR TITLE
docs(commands): add Usage section to Agents moduledoc

### DIFF
--- a/lib/claude_wrapper/commands/agents.ex
+++ b/lib/claude_wrapper/commands/agents.ex
@@ -1,6 +1,19 @@
 defmodule ClaudeWrapper.Commands.Agents do
   @moduledoc """
   `claude agents` command -- lists configured agents.
+
+  ## Usage
+
+      config = ClaudeWrapper.Config.new()
+
+      # Parsed list of agent names and models
+      {:ok, agents} = ClaudeWrapper.Commands.Agents.list(config)
+
+      # Raw CLI output
+      {:ok, output} = ClaudeWrapper.Commands.Agents.execute(config)
+
+      # Restrict which setting sources are loaded
+      {:ok, agents} = ClaudeWrapper.Commands.Agents.list(config, setting_sources: "user,project")
   """
 
   alias ClaudeWrapper.{Config, Error}


### PR DESCRIPTION
## Summary

`ClaudeWrapper.Commands.Agents` was the one `Commands.*` module without a `## Usage` section in its moduledoc, unlike Auth, Mcp, Plugin, Marketplace, Install, Update, Project, Ultrareview, and Doctor. This adds a `## Usage` block with `list/2` and `execute/2` examples, including the `:setting_sources` option, matching the shape of `commands/project.ex` and `commands/ultrareview.ex`.

Closes #168

## Test plan

- [x] `mix format`
- [x] `mix test` (575 tests passing)