### PR TITLE
docs: document opt-in bundled-binary install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,29 @@ end
 Requires the `claude` CLI to be installed and on your `PATH` (or set
 `CLAUDE_CLI` to point at it).
 
+### Bundled binary (opt-in)
+
+`claude_wrapper` can also resolve, install, and version-pin a `claude`
+binary under its own `priv/bin/`, so an app can depend on
+`claude_wrapper` and get a known CLI version without a separate PATH
+install. This is opt-in; the PATH/`CLAUDE_CLI` default above is
+unchanged for everyone else.
+
+```elixir
+config = ClaudeWrapper.Config.new(binary: :bundled)
+```
+
+`Config.new/1` resolution is pure -- it does not touch the network.
+Install the pinned binary explicitly:
+
+```bash
+mix claude_wrapper.install    # install/update the pinned bundled binary
+mix claude_wrapper.uninstall  # remove it
+mix claude_wrapper.path       # print its path and install state
+```
+
+See `ClaudeWrapper.Bundled` for details.
+
 ## DuplexSession (long-lived chat-style sessions)
 
 Holds one `claude` subprocess open across many turns. Subscribers


### PR DESCRIPTION
## Summary

README's Installation section only documented PATH/`CLAUDE_CLI` discovery. The bundled-binary opt-in (`ClaudeWrapper.Config.new(binary: :bundled)`, `ClaudeWrapper.Bundled`, and the `mix claude_wrapper.install`/`.uninstall`/`.path` tasks) is a shipped capability, already documented in `CLAUDE.md` and the `ClaudeWrapper.Bundled` moduledoc, but absent from the README.

## Changes

- Add a "Bundled binary (opt-in)" subsection under Installation covering `Config.new(binary: :bundled)`, the explicit install step, and the three `mix claude_wrapper.*` tasks.
- Notes that the default PATH/`CLAUDE_CLI` resolution is unchanged.

Closes #166.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix test` (575 passed)