### PR TITLE
test: extract and test Commands.Agents.list_args/1

### DIFF
--- a/lib/claude_wrapper/commands/agents.ex
+++ b/lib/claude_wrapper/commands/agents.ex
@@ -39,7 +39,7 @@ defmodule ClaudeWrapper.Commands.Agents do
   """
   @spec list(Config.t(), keyword()) :: {:ok, [agent()]} | {:error, term()}
   def list(%Config{} = config, opts \\ []) do
-    args = Config.base_args(config) ++ ["agents"] ++ build_args(opts)
+    args = Config.base_args(config) ++ list_args(opts)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, parse_agents(output)}
@@ -52,7 +52,7 @@ defmodule ClaudeWrapper.Commands.Agents do
   """
   @spec execute(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def execute(%Config{} = config, opts \\ []) do
-    args = Config.base_args(config) ++ ["agents"] ++ build_args(opts)
+    args = Config.base_args(config) ++ list_args(opts)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
@@ -60,10 +60,12 @@ defmodule ClaudeWrapper.Commands.Agents do
     end
   end
 
-  defp build_args(opts) do
+  @doc false
+  @spec list_args(keyword()) :: [String.t()]
+  def list_args(opts) do
     case Keyword.get(opts, :setting_sources) do
-      nil -> []
-      sources -> ["--setting-sources", sources]
+      nil -> ["agents"]
+      sources -> ["agents", "--setting-sources", sources]
     end
   end
 

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -1227,6 +1227,22 @@ defmodule ClaudeWrapperTest do
       assert {:list, 2} in Agents.__info__(:functions)
       assert {:execute, 1} in Agents.__info__(:functions)
       assert {:execute, 2} in Agents.__info__(:functions)
+
+      # @doc false builder is public for arg-composition testing.
+      assert {:list_args, 1} in Agents.__info__(:functions)
+    end
+
+    test "list_args defaults to just the subcommand" do
+      assert Agents.list_args([]) == ["agents"]
+    end
+
+    test "list_args emits --setting-sources with the value" do
+      assert Agents.list_args(setting_sources: "user,project") ==
+               ["agents", "--setting-sources", "user,project"]
+    end
+
+    test "list_args omits --setting-sources when unset" do
+      refute "--setting-sources" in Agents.list_args([])
     end
 
     test "parse_agents extracts agent names and models" do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -507,7 +507,7 @@ defmodule ClaudeWrapper.IntegrationTest do
   end
 
   describe "command smokes (live, non-mutating)" do
-    alias ClaudeWrapper.Commands.{Doctor, Mcp, Plugin, Version}
+    alias ClaudeWrapper.Commands.{Agents, Doctor, Mcp, Plugin, Version}
 
     test "mcp list", %{config: config} do
       assert {:ok, output} = Mcp.list(config)
@@ -516,6 +516,11 @@ defmodule ClaudeWrapper.IntegrationTest do
 
     test "plugin list", %{config: config} do
       assert {:ok, _plugins} = Plugin.list(config)
+    end
+
+    test "agents list", %{config: config} do
+      assert {:ok, agents} = Agents.list(config)
+      assert is_list(agents)
     end
 
     test "auth status" do


### PR DESCRIPTION
## Summary

Closes #170.

`Commands.Agents`'s arg-building was private (`build_args/1`) and had no
direct test coverage; `list/2` and `execute/2` shell out to the CLI and
were absent from the integration "command smokes" block.

- Extract a public `@doc false` `list_args/1`, matching the convention
  used by `Auth.login_args/1`, `Plugin.install_args/2`, etc.
- Unit-test the `--setting-sources` branch in `claude_wrapper_test.exs`.
- Add an `agents list` smoke test to the integration command-smokes
  block.

## Test plan

- [x] `mix format`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test`