### PR TITLE
test: add live smokes for Commands.Doctor and Commands.Version

### DIFF
--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -507,7 +507,7 @@ defmodule ClaudeWrapper.IntegrationTest do
   end
 
   describe "command smokes (live, non-mutating)" do
-    alias ClaudeWrapper.Commands.{Mcp, Plugin}
+    alias ClaudeWrapper.Commands.{Doctor, Mcp, Plugin, Version}
 
     test "mcp list", %{config: config} do
       assert {:ok, output} = Mcp.list(config)
@@ -521,6 +521,14 @@ defmodule ClaudeWrapper.IntegrationTest do
     test "auth status" do
       assert {:ok, status} = ClaudeWrapper.auth_status()
       assert is_map(status)
+    end
+
+    test "doctor", %{config: config} do
+      assert {:ok, _output} = Doctor.execute(config)
+    end
+
+    test "version", %{config: config} do
+      assert {:ok, _version_info} = Version.execute(config)
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes #171.

`Commands.Doctor` and `Commands.Version` are execute-only with no branching, so no arg-builder is expected. But neither had a live smoke test in the "command smokes (live, non-mutating)" block, unlike `mcp list`, `plugin list`, and `auth status`.

- Added a one-line smoke test for `Doctor.execute/1` (`claude doctor`)
- Added a one-line smoke test for `Version.execute/1` (`claude --version`)

## Test plan

- [x] `mix format`
- [x] `mix test`
- [x] `mix test --only integration test/integration_test.exs` (new `doctor` and `version` tests pass; 2 pre-existing, unrelated failures in IEx multi-turn tests)