### PR TITLE
refactor(marketplace): extract add_args/2 and update_args/1 builders

### DIFF
--- a/lib/claude_wrapper/commands/marketplace.ex
+++ b/lib/claude_wrapper/commands/marketplace.ex
@@ -59,19 +59,19 @@ defmodule ClaudeWrapper.Commands.Marketplace do
   """
   @spec add(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def add(%Config{} = config, source, opts \\ []) do
-    args = Config.base_args(config) ++ ["plugin", "marketplace", "add", source]
-    args = args ++ scope_args(opts[:scope])
-
-    args =
-      case opts[:sparse] do
-        nil -> args
-        paths when is_list(paths) -> args ++ ["--sparse" | paths]
-      end
+    args = Config.base_args(config) ++ add_args(source, opts)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
+  end
+
+  @doc false
+  @spec add_args(String.t(), keyword()) :: [String.t()]
+  def add_args(source, opts) do
+    flags = scope_args(opts[:scope]) ++ sparse_args(opts[:sparse])
+    ["plugin", "marketplace", "add", source | flags]
   end
 
   @doc """
@@ -94,8 +94,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
   """
   @spec update(Config.t(), String.t() | nil) :: {:ok, String.t()} | {:error, term()}
   def update(%Config{} = config, name \\ nil) do
-    args = Config.base_args(config) ++ ["plugin", "marketplace", "update"]
-    args = if name, do: args ++ [name], else: args
+    args = Config.base_args(config) ++ update_args(name)
 
     case System.cmd(config.binary, args, Config.cmd_opts(config)) do
       {output, 0} -> {:ok, String.trim(output)}
@@ -103,8 +102,18 @@ defmodule ClaudeWrapper.Commands.Marketplace do
     end
   end
 
+  @doc false
+  @spec update_args(String.t() | nil) :: [String.t()]
+  def update_args(name) do
+    base = ["plugin", "marketplace", "update"]
+    if name, do: base ++ [name], else: base
+  end
+
   defp scope_args(nil), do: []
   defp scope_args(:user), do: ["--scope", "user"]
   defp scope_args(:project), do: ["--scope", "project"]
   defp scope_args(:local), do: ["--scope", "local"]
+
+  defp sparse_args(nil), do: []
+  defp sparse_args(paths) when is_list(paths), do: ["--sparse" | paths]
 end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -1290,6 +1290,45 @@ defmodule ClaudeWrapperTest do
       assert {:add, 3} in Marketplace.__info__(:functions)
       assert {:remove, 2} in Marketplace.__info__(:functions)
       assert {:update, 2} in Marketplace.__info__(:functions)
+      assert {:add_args, 2} in Marketplace.__info__(:functions)
+      assert {:update_args, 1} in Marketplace.__info__(:functions)
+    end
+
+    test "add_args defaults to source with no flags" do
+      assert Marketplace.add_args("url", []) == ["plugin", "marketplace", "add", "url"]
+    end
+
+    test "add_args composes scope" do
+      assert Marketplace.add_args("url", scope: :project) ==
+               ["plugin", "marketplace", "add", "url", "--scope", "project"]
+    end
+
+    test "add_args composes sparse as a flag followed by each path" do
+      assert Marketplace.add_args("url", sparse: [".claude-plugin", "plugins"]) ==
+               ["plugin", "marketplace", "add", "url", "--sparse", ".claude-plugin", "plugins"]
+    end
+
+    test "add_args composes scope and sparse together, scope first" do
+      assert Marketplace.add_args("url", scope: :local, sparse: ["plugins"]) ==
+               [
+                 "plugin",
+                 "marketplace",
+                 "add",
+                 "url",
+                 "--scope",
+                 "local",
+                 "--sparse",
+                 "plugins"
+               ]
+    end
+
+    test "update_args with no name updates all marketplaces" do
+      assert Marketplace.update_args(nil) == ["plugin", "marketplace", "update"]
+    end
+
+    test "update_args with a name updates just that marketplace" do
+      assert Marketplace.update_args("my-marketplace") ==
+               ["plugin", "marketplace", "update", "my-marketplace"]
     end
   end
 


### PR DESCRIPTION
## Summary

Extracts the inline argument composition in `Commands.Marketplace.add/3` and `update/2` into public, `@doc false` builder functions (`add_args/2`, `update_args/1`), matching the existing convention in `Commands.Plugin` (`uninstall_args/2`, `tag_args/1`, `prune_args/1`) and `Commands.Mcp`. This makes the argument-building logic directly unit-testable without shelling out to `System.cmd`.

No behavior change to the public `add/3`/`update/2` API.

Closes #169

## Changes

- `lib/claude_wrapper/commands/marketplace.ex`: add `add_args/2` and `update_args/1`, plus a private `sparse_args/1` helper; `add/3` and `update/2` now delegate to them.
- `test/claude_wrapper_test.exs`: extend the `Commands.Marketplace` describe block with direct tests for `add_args/2` and `update_args/1`, and assert the new functions are exported.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (590 passed, 32 excluded integration)