### PR TITLE
docs: sync README module inventory and mix.exs groups_for_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,22 @@ end
 | `ClaudeWrapper.SessionServer` | Supervised wrapper for `Session` |
 | `ClaudeWrapper.IEx` | REPL helpers for one-shot/per-call mode |
 
+**Prompt building & structured output**
+
+| Module | Description |
+|---|---|
+| `ClaudeWrapper.Prompt` | Composable prompt builder with deferred file/git expansion |
+| `ClaudeWrapper.Stream` | Lazy `Stream` combinators over a `DuplexSession` turn |
+| `ClaudeWrapper.Structured` | Typed structured-output tasks |
+
+**DuplexSession transport adapter**
+
+| Module | Description |
+|---|---|
+| `ClaudeWrapper.DuplexSession.Adapter` | Transport seam for `DuplexSession` |
+| `ClaudeWrapper.DuplexSession.Adapter.Port` | Default adapter: real `claude` subprocess over a Port |
+| `ClaudeWrapper.DuplexSession.Adapter.Test` | Controllable in-process test double |
+
 **Shared infrastructure**
 
 | Module | Description |
@@ -435,6 +451,8 @@ end
 | `ClaudeWrapper.CliVersion` | Parse/compare the CLI version |
 | `ClaudeWrapper.DangerousClient` | Env-gated `--dangerously-skip-permissions` |
 | `ClaudeWrapper.Auth` | Env auth detection + failure classification |
+| `ClaudeWrapper.Test` | Drive a `DuplexSession` against an in-process double (network-free) |
+| `ClaudeWrapper.Bundled` | Opt-in bundled-binary resolution for the `claude` CLI |
 
 **Reading `~/.claude` state**
 
@@ -452,6 +470,7 @@ end
 | Module | Description |
 |---|---|
 | `ClaudeWrapper.Commands.Auth` | Auth management (login modes, status, setup-token) |
+| `ClaudeWrapper.Commands.Agents` | List configured agents |
 | `ClaudeWrapper.Commands.Mcp` | MCP server management (add/list/get/remove/serve/login/logout) |
 | `ClaudeWrapper.Commands.Plugin` | Plugin install/enable/disable/update/tag/details/prune |
 | `ClaudeWrapper.Commands.Marketplace` | Marketplace add/remove/list/update |

--- a/mix.exs
+++ b/mix.exs
@@ -44,26 +44,51 @@ defmodule ClaudeWrapper.MixProject do
       source_url: @source_url,
       extras: ["README.md", "CHANGELOG.md"],
       groups_for_modules: [
-        "Long-lived sessions": [
+        "Driving claude": [
           ClaudeWrapper.DuplexSession,
-          ClaudeWrapper.DuplexIEx
-        ],
-        "One-shot / per-call": [
+          ClaudeWrapper.DuplexIEx,
+          ClaudeWrapper.Conversation,
           ClaudeWrapper,
           ClaudeWrapper.Query,
           ClaudeWrapper.Session,
           ClaudeWrapper.SessionServer,
           ClaudeWrapper.IEx
         ],
-        "Shared infrastructure": [
+        "Prompt building & structured output": [
+          ClaudeWrapper.Prompt,
+          ClaudeWrapper.Stream,
+          ClaudeWrapper.Structured
+        ],
+        "Config, results, support": [
           ClaudeWrapper.Config,
           ClaudeWrapper.Result,
           ClaudeWrapper.StreamEvent,
+          ClaudeWrapper.Error,
           ClaudeWrapper.McpConfig,
           ClaudeWrapper.Retry,
-          ClaudeWrapper.Telemetry
+          ClaudeWrapper.Telemetry,
+          ClaudeWrapper.Budget,
+          ClaudeWrapper.ToolPattern,
+          ClaudeWrapper.CliVersion,
+          ClaudeWrapper.DangerousClient,
+          ClaudeWrapper.Auth,
+          ClaudeWrapper.Test,
+          ClaudeWrapper.Bundled
         ],
-        "CLI subcommand wrappers": [
+        "DuplexSession transport adapter": [
+          ClaudeWrapper.DuplexSession.Adapter,
+          ClaudeWrapper.DuplexSession.Adapter.Port,
+          ClaudeWrapper.DuplexSession.Adapter.Test
+        ],
+        "Read-side introspection of ~/.claude": [
+          ClaudeWrapper.History,
+          ClaudeWrapper.Settings,
+          ClaudeWrapper.Agents,
+          ClaudeWrapper.Skills,
+          ClaudeWrapper.Jobs,
+          ClaudeWrapper.Worktrees
+        ],
+        "Command surface": [
           ClaudeWrapper.Command,
           ClaudeWrapper.Commands.Auth,
           ClaudeWrapper.Commands.Agents,
@@ -71,6 +96,11 @@ defmodule ClaudeWrapper.MixProject do
           ClaudeWrapper.Commands.Mcp,
           ClaudeWrapper.Commands.Plugin,
           ClaudeWrapper.Commands.Marketplace,
+          ClaudeWrapper.Commands.AutoMode,
+          ClaudeWrapper.Commands.Install,
+          ClaudeWrapper.Commands.Update,
+          ClaudeWrapper.Commands.Project,
+          ClaudeWrapper.Commands.Ultrareview,
           ClaudeWrapper.Commands.Version
         ]
       ]


### PR DESCRIPTION
Closes #165

## Summary

The README `## Modules` tables and `mix.exs` `groups_for_modules` (which drives the ExDoc sidebar) both omitted a growing set of shipped, in-module-documented modules. Ungrouped modules fall into ExDoc's generic "Modules" catch-all, so this was a discoverability gap on hexdocs, not just the README.

## Changes

- `mix.exs`: regrouped `groups_for_modules` from 4 groups / 13 modules to 6 groups covering all 47 top-level public modules, matching CLAUDE.md's existing inventory grouping (`Driving claude`, `Prompt building & structured output`, `Config, results, support`, `DuplexSession transport adapter`, `Read-side introspection of ~/.claude`, `Command surface`).
- `README.md`: added two new subsections (`Prompt building & structured output`, `DuplexSession transport adapter`) and two missing rows (`ClaudeWrapper.Test`, `ClaudeWrapper.Bundled` in "Shared infrastructure"; `ClaudeWrapper.Commands.Agents` in "CLI subcommand wrappers").

Nested convenience structs (`Agents.Definition`, `History.SessionLog`, etc.) stay out of scope, consistent with prior README/mix.exs treatment.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix test` (584 passed)
- [x] `mix docs`, verified the generated sidebar has no stray top-level modules outside the 12 already-excluded nested structs