### PR TITLE
feat(error): detect --max-budget-usd cap and enrich rail-stop errors with cost/turn figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,23 @@ case ClaudeWrapper.query("...", max_turns: 1) do
 end
 ```
 
+The CLI's own rail-stop caps are surfaced as typed, recoverable errors
+distinct from a genuine failure. `:max_turns_exceeded` (`--max-turns`)
+and `:max_budget_exceeded` (`--max-budget-usd`, separate from the
+client-side `:budget_exceeded` of `ClaudeWrapper.Budget`) each carry a
+`:reason` map of `%{cap:, cost_usd:, num_turns:, session_id:}` so a
+capped run can be resumed:
+
+```elixir
+case ClaudeWrapper.query("...", max_budget_usd: 5.0) do
+  {:ok, result} ->
+    result
+
+  {:error, %ClaudeWrapper.Error{kind: :max_budget_exceeded, reason: %{session_id: sid}}} ->
+    {:resume, sid}
+end
+```
+
 ## Modules
 
 **Long-lived sessions (the headline feature)**

--- a/lib/claude_wrapper/error.ex
+++ b/lib/claude_wrapper/error.ex
@@ -28,7 +28,17 @@ defmodule ClaudeWrapper.Error do
     * `:json` -- the CLI output could not be decoded as JSON
       (`:reason`, optional `:stdout`)
     * `:max_turns_exceeded` -- the CLI stopped at its `--max-turns`
-      limit
+      limit. `:reason` is a `%{cap:, cost_usd:, num_turns:,
+      session_id:}` map (any field may be `nil`); `:cap` is the
+      configured turn limit and `:session_id` can resume the run
+    * `:max_budget_exceeded` -- the CLI stopped at its
+      `--max-budget-usd` spend cap (subtype `error_max_budget_usd`).
+      Distinct from `:budget_exceeded`, which is the client-side
+      `ClaudeWrapper.Budget` tracker. `:reason` is a `%{cap:,
+      cost_usd:, num_turns:, session_id:}` map (any field may be
+      `nil`); `:cap` is the reported cap, not the actual spend, since
+      claude checks the budget post-hoc and a run can overspend before
+      tripping
     * `:version_mismatch` -- the CLI is older than a required minimum
       (`:reason` is `%{found:, minimum:}`)
     * `:invalid_version` -- a version string could not be parsed
@@ -72,6 +82,7 @@ defmodule ClaudeWrapper.Error do
           | :timeout
           | :json
           | :max_turns_exceeded
+          | :max_budget_exceeded
           | :version_mismatch
           | :invalid_version
           | :budget_exceeded
@@ -165,8 +176,18 @@ defmodule ClaudeWrapper.Error do
   defp default_message(%{kind: :json}),
     do: "could not decode claude JSON output"
 
+  defp default_message(%{kind: :max_turns_exceeded, reason: %{cap: cap}}) when not is_nil(cap),
+    do: "claude hit the --max-turns cap of #{cap}"
+
   defp default_message(%{kind: :max_turns_exceeded}),
     do: "claude reached its maximum number of turns"
+
+  defp default_message(%{kind: :max_budget_exceeded, reason: %{cap: cap}}) when not is_nil(cap),
+    do:
+      "claude hit the --max-budget-usd cap of $#{:erlang.float_to_binary(cap * 1.0, decimals: 2)}"
+
+  defp default_message(%{kind: :max_budget_exceeded}),
+    do: "claude reached its maximum budget"
 
   defp default_message(%{kind: :version_mismatch, reason: %{found: found, minimum: min}}),
     do: "claude #{found} is older than the required minimum #{min}"

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -515,18 +515,32 @@ defmodule ClaudeWrapper.Query do
   end
 
   # A non-zero CLI exit that still emits valid JSON is not always a hard
-  # failure: max-turns is the one case the CLI reports this way and we
-  # surface it as a typed error; any other valid-JSON result keeps its
-  # `is_error` flag and returns `{:ok, %Result{}}`. When the output is not
-  # decodable JSON the exit is a genuine command failure -- classified as
-  # an auth error first when it looks auth-shaped, otherwise plain.
-  defp handle_nonzero_exit(code, stdout) do
+  # failure: the CLI reports its rail-stop caps (--max-turns and
+  # --max-budget-usd) this way, and we surface each as its own typed
+  # error carrying the run's cost/turn figures; any other valid-JSON
+  # result keeps its `is_error` flag and returns `{:ok, %Result{}}`.
+  # When the output is not decodable JSON the exit is a genuine command
+  # failure -- classified as an auth error first when it looks
+  # auth-shaped, otherwise plain.
+  @doc false
+  @spec handle_nonzero_exit(integer(), String.t()) ::
+          {:ok, Result.t()} | {:error, Error.t()}
+  def handle_nonzero_exit(code, stdout) do
     case parse_json_output(stdout) do
       {:ok, result} ->
-        if max_turns_result?(result) do
-          {:error, Error.new(:max_turns_exceeded, exit_code: code, stdout: stdout)}
-        else
-          {:ok, result}
+        case rail_stop_kind(result) do
+          nil ->
+            {:ok, result}
+
+          {kind, cap} ->
+            reason = %{
+              cap: cap,
+              cost_usd: result.cost_usd,
+              num_turns: result.num_turns,
+              session_id: result.session_id
+            }
+
+            {:error, Error.new(kind, reason: reason, exit_code: code, stdout: stdout)}
         end
 
       {:error, _} ->
@@ -534,8 +548,37 @@ defmodule ClaudeWrapper.Query do
     end
   end
 
-  defp max_turns_result?(%Result{extra: extra}) do
-    Map.get(extra, "subtype") == "error_max_turns"
+  # Classify a terminal `result` event by its rail-stop subtype,
+  # returning `{error_kind, parsed_cap}` or `nil`. The cap is pulled
+  # from the human message ("Reached maximum number of turns (N)" /
+  # "Reached maximum budget ($X)"); it may be `nil` if absent.
+  defp rail_stop_kind(%Result{extra: extra, result: message}) do
+    case Map.get(extra, "subtype") do
+      "error_max_turns" -> {:max_turns_exceeded, parse_cap(message, :int)}
+      "error_max_budget_usd" -> {:max_budget_exceeded, parse_cap(message, :float)}
+      _ -> nil
+    end
+  end
+
+  defp parse_cap(message, type) when is_binary(message) do
+    case Regex.run(~r/\(\$?([0-9]+(?:\.[0-9]+)?)\)/, message) do
+      [_, captured] -> cast_cap(captured, type)
+      nil -> nil
+    end
+  end
+
+  defp cast_cap(captured, :int) do
+    case Integer.parse(captured) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp cast_cap(captured, :float) do
+    case Float.parse(captured) do
+      {n, _} -> n
+      :error -> nil
+    end
   end
 
   # A non-zero exit with no parseable JSON: run the auth classifier over

--- a/test/claude_wrapper/error_test.exs
+++ b/test/claude_wrapper/error_test.exs
@@ -91,6 +91,16 @@ defmodule ClaudeWrapper.ErrorTest do
 
     test "derives a default for :max_turns_exceeded" do
       assert Error.message(Error.new(:max_turns_exceeded)) =~ "maximum number of turns"
+
+      assert Error.message(Error.new(:max_turns_exceeded, reason: %{cap: 3})) =~
+               "--max-turns cap of 3"
+    end
+
+    test "derives a default for :max_budget_exceeded" do
+      assert Error.message(Error.new(:max_budget_exceeded)) =~ "maximum budget"
+
+      assert Error.message(Error.new(:max_budget_exceeded, reason: %{cap: 5.0})) =~
+               "--max-budget-usd cap of $5.00"
     end
 
     test "derives a default for :not_found with and without a reason" do

--- a/test/claude_wrapper/query_test.exs
+++ b/test/claude_wrapper/query_test.exs
@@ -1,6 +1,7 @@
 defmodule ClaudeWrapper.QueryTest do
   use ExUnit.Case, async: true
 
+  alias ClaudeWrapper.Error
   alias ClaudeWrapper.Query
 
   describe "apply_opts/2 -- scalar opts" do
@@ -219,6 +220,109 @@ defmodule ClaudeWrapper.QueryTest do
       assert q.agents_json == "{}"
       assert q.fork_session
       assert q.strict_mcp_config
+    end
+  end
+
+  describe "handle_nonzero_exit/2 -- rail-stop caps" do
+    test "surfaces :max_turns_exceeded with parsed cap and run figures" do
+      stdout =
+        Jason.encode!(%{
+          "type" => "result",
+          "subtype" => "error_max_turns",
+          "is_error" => true,
+          "result" => "Reached maximum number of turns (3)",
+          "session_id" => "sess-abc",
+          "num_turns" => 3,
+          "total_cost_usd" => 0.0512,
+          "duration_ms" => 1234
+        })
+
+      assert {:error, %Error{kind: :max_turns_exceeded} = error} =
+               Query.handle_nonzero_exit(1, stdout)
+
+      assert error.exit_code == 1
+      assert error.stdout == stdout
+
+      assert error.reason == %{
+               cap: 3,
+               cost_usd: 0.0512,
+               num_turns: 3,
+               session_id: "sess-abc"
+             }
+    end
+
+    test "surfaces :max_budget_exceeded with parsed cap and run figures" do
+      stdout =
+        Jason.encode!(%{
+          "type" => "result",
+          "subtype" => "error_max_budget_usd",
+          "is_error" => true,
+          "result" => "Reached maximum budget ($5.00)",
+          "session_id" => "sess-def",
+          "num_turns" => 7,
+          "total_cost_usd" => 5.12,
+          "duration_ms" => 9999
+        })
+
+      assert {:error, %Error{kind: :max_budget_exceeded} = error} =
+               Query.handle_nonzero_exit(1, stdout)
+
+      assert error.reason == %{
+               cap: 5.0,
+               cost_usd: 5.12,
+               num_turns: 7,
+               session_id: "sess-def"
+             }
+    end
+
+    test "tolerates a missing cap in the result message" do
+      stdout =
+        Jason.encode!(%{
+          "type" => "result",
+          "subtype" => "error_max_turns",
+          "is_error" => true,
+          "result" => "stopped",
+          "num_turns" => 2
+        })
+
+      assert {:error, %Error{kind: :max_turns_exceeded, reason: reason}} =
+               Query.handle_nonzero_exit(1, stdout)
+
+      assert reason.cap == nil
+      assert reason.cost_usd == nil
+      assert reason.num_turns == 2
+      assert reason.session_id == nil
+    end
+
+    test ":max_budget_exceeded is distinct from the client-side :budget_exceeded" do
+      stdout =
+        Jason.encode!(%{
+          "type" => "result",
+          "subtype" => "error_max_budget_usd",
+          "result" => "Reached maximum budget ($1)"
+        })
+
+      assert {:error, %Error{kind: :max_budget_exceeded, reason: %{cap: 1.0}}} =
+               Query.handle_nonzero_exit(1, stdout)
+    end
+
+    test "a non-rail-stop error result keeps its is_error flag and returns :ok" do
+      stdout =
+        Jason.encode!(%{
+          "type" => "result",
+          "subtype" => "success",
+          "is_error" => true,
+          "result" => "some other failure",
+          "num_turns" => 1
+        })
+
+      assert {:ok, %ClaudeWrapper.Result{is_error: true}} =
+               Query.handle_nonzero_exit(1, stdout)
+    end
+
+    test "non-JSON output falls back to a command failure" do
+      assert {:error, %Error{kind: kind}} = Query.handle_nonzero_exit(1, "boom: not json")
+      assert kind in [:command_failed, :auth]
     end
   end
 end


### PR DESCRIPTION
Closes #186. Rust parity for `claude-wrapper` v0.12.3 #666 and v0.13.0 #669.

## Plan

Two coupled changes at the same detection site ([query.ex `handle_nonzero_exit/2`](lib/claude_wrapper/query.ex)) and in `ClaudeWrapper.Error`.

### 1. Typed `:max_budget_exceeded` (Rust #666)

claude trips `--max-budget-usd` with a terminal `result` event whose `subtype == "error_max_budget_usd"` (exit 1, JSON on stdout). Today it folds into `:command_failed`. Add detection mirroring the existing `error_max_turns` path, and a new `:max_budget_exceeded` error kind. Distinct from the existing client-side `:budget_exceeded` (`ClaudeWrapper.Budget` tracker) -- both kept.

### 2. Enrich rail-stop errors with figures (Rust #669)

`:max_turns_exceeded` is currently built with only `exit_code` + `stdout`. Both rail-stop errors will carry a structured `:reason` map pulled from the already-parsed `%Result{}`:

- `cap` -- configured cap, parsed from the `result` message (`Reached maximum number of turns (N)` / `Reached maximum budget ($X)`)
- `cost_usd` -- `Result.cost_usd` (actual spend)
- `num_turns` -- `Result.num_turns`
- `session_id` -- `Result.session_id` (usable to resume the capped run)

The `%Result{}` already parses `cost_usd` / `num_turns` / `session_id`, so figures come from the struct, not a stdout re-parse. Cap comes from the `result` text.

## Steps

- [ ] Add `:max_budget_exceeded` to `Error.kind` type + `default_message/1` clause
- [ ] `handle_nonzero_exit/2`: detect `error_max_budget_usd` alongside `error_max_turns`; build enriched `:reason` for both
- [ ] Helper to parse the cap number from the result message (turns: int, budget: float)
- [ ] Unit tests over fixture stdout for both subtypes (kind + all `:reason` fields)
- [ ] Update README / moduledoc error-kind list

## Verification

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test`, `mix dialyzer`.