### PR TITLE
feat(duplex): accept a %Query{} for typed spawn-time knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,28 @@ ClaudeWrapper.DuplexSession.interrupt(pid)
 ClaudeWrapper.DuplexSession.close(pid)
 ```
 
+### Configuring the session with a `Query`
+
+Pass a `%ClaudeWrapper.Query{}` to configure the session's spawn-time
+knobs (model, system prompt, permission mode, tool allow/deny lists,
+mcp config, effort, turn/budget caps, session continuity, ...) with the
+same setters and `apply_opts/2` as the one-shot path. The query's
+prompt and transport-format flags are ignored: the session owns its
+stream-json transport and takes prompts per turn via `send/3`.
+
+```elixir
+query =
+  ClaudeWrapper.Query.new("")
+  |> ClaudeWrapper.Query.model("sonnet")
+  |> ClaudeWrapper.Query.allowed_tool("Read")
+  |> ClaudeWrapper.Query.max_turns(20)
+
+{:ok, pid} = ClaudeWrapper.DuplexSession.start_link(config: config, query: query)
+```
+
+`:extra_args` still works as an escape hatch for flags not yet on
+`Query`, and is applied after the query's flags.
+
 ### Permission callback
 
 When the CLI wants to run a tool, it routes the prompt back through

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -123,7 +123,7 @@ defmodule ClaudeWrapper.DuplexSession do
   use GenServer
   require Logger
 
-  alias ClaudeWrapper.{Config, Error, Result}
+  alias ClaudeWrapper.{Config, Error, Query, Result}
   alias ClaudeWrapper.DuplexSession.Adapter
 
   @type tool_input :: map()
@@ -157,6 +157,7 @@ defmodule ClaudeWrapper.DuplexSession do
 
   @type option ::
           {:config, Config.t()}
+          | {:query, Query.t()}
           | {:extra_args, [String.t()]}
           | {:on_permission, permission_handler()}
           | {:name, GenServer.name()}
@@ -212,11 +213,31 @@ defmodule ClaudeWrapper.DuplexSession do
   ## Options
 
     * `:config` -- (required) `%ClaudeWrapper.Config{}` struct.
-    * `:extra_args` -- extra CLI flags to append (e.g.
-      `["--permission-mode", "plan", "--max-turns", "1"]`).
+    * `:query` -- a `%ClaudeWrapper.Query{}` whose spawn-time knobs
+      (model, system prompt, permission mode, tool allow/deny lists,
+      mcp config, effort, turn/budget caps, session continuity, ...)
+      configure the session. Built with the same `Query` setters and
+      `apply_opts/2` as the one-shot path; the query's prompt and
+      transport-format flags are ignored (the session owns its
+      stream-json transport and takes prompts per turn via `send/3`).
+      See `ClaudeWrapper.Query.spawn_args/1`.
+    * `:extra_args` -- extra CLI flags to append, applied after the
+      `:query` flags (e.g. `["--permission-mode", "plan"]`). The
+      escape hatch for flags not yet on `Query`.
     * `:name` -- register the GenServer under a name.
 
   All other keyword options are passed through to `GenServer.start_link/3`.
+
+  ## Examples
+
+      query =
+        ClaudeWrapper.Query.new("")
+        |> ClaudeWrapper.Query.model("sonnet")
+        |> ClaudeWrapper.Query.allowed_tool("Read")
+        |> ClaudeWrapper.Query.max_turns(20)
+
+      {:ok, pid} =
+        ClaudeWrapper.DuplexSession.start_link(config: config, query: query)
   """
   @spec start_link([option()]) :: GenServer.on_start()
   def start_link(opts) do
@@ -451,8 +472,17 @@ defmodule ClaudeWrapper.DuplexSession do
   def init(opts) do
     Process.flag(:trap_exit, true)
     config = Keyword.fetch!(opts, :config)
-    extra_args = Keyword.get(opts, :extra_args, [])
     on_permission = Keyword.get(opts, :on_permission, &__MODULE__.deny_all/2)
+
+    # A `%Query{}`'s spawn-time knobs come first; explicit `:extra_args`
+    # follow as the escape hatch (and win on any repeated flag).
+    query_args =
+      case Keyword.get(opts, :query) do
+        %Query{} = query -> Query.spawn_args(query)
+        nil -> []
+      end
+
+    extra_args = query_args ++ Keyword.get(opts, :extra_args, [])
 
     # Tests substitute a fake binary (e.g. `cat`) that does not understand
     # the duplex flag set; they pass `:args_override` to bypass defaults.

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -624,6 +624,33 @@ defmodule ClaudeWrapper.Query do
 
   # --- Arg building ---
 
+  @doc """
+  The spawn-time flag subset of a query, for a long-lived
+  `ClaudeWrapper.DuplexSession`.
+
+  Reuses `build_args/1` (the single source of flag emission, so the
+  duplex and one-shot paths cannot drift), then removes the flags a
+  duplex session owns itself: the transport formats
+  (`--output-format` / `--input-format` / `--include-partial-messages`,
+  which the session fixes to its stream-json protocol) and the leading
+  `--print <prompt>` pair (in duplex the prompt is a per-turn
+  stream-json message, not an argv). Everything else -- model, system
+  prompt, permission mode, tool allow/deny lists, mcp config, effort,
+  turn/budget caps, session continuity, and so on -- is spawn-safe and
+  passes through.
+  """
+  @spec spawn_args(t()) :: [String.t()]
+  def spawn_args(%__MODULE__{} = q) do
+    %{q | output_format: nil, input_format: nil, include_partial_messages: false}
+    |> build_args()
+    |> drop_print_flag()
+  end
+
+  # build_args/1 always emits `--print <prompt>` first (via add_flag),
+  # so the prompt is guaranteed to be the leading pair.
+  defp drop_print_flag(["--print", _prompt | rest]), do: rest
+  defp drop_print_flag(args), do: args
+
   @doc false
   @spec build_args(t()) :: [String.t()]
   def build_args(%__MODULE__{} = q) do

--- a/test/claude_wrapper/duplex_session_test.exs
+++ b/test/claude_wrapper/duplex_session_test.exs
@@ -1,7 +1,27 @@
+defmodule ClaudeWrapper.DuplexSessionTest.ArgsCaptureAdapter do
+  @moduledoc false
+  # Captures the spawn args DuplexSession assembles, without launching a
+  # process. Sends them to the configured `:test_pid`.
+  @behaviour ClaudeWrapper.DuplexSession.Adapter
+
+  @impl true
+  def open(opts) do
+    send(Keyword.fetch!(opts, :test_pid), {:captured_args, Keyword.fetch!(opts, :args)})
+    {:ok, make_ref()}
+  end
+
+  @impl true
+  def command(_handle, _iodata), do: :ok
+
+  @impl true
+  def close(_handle), do: :ok
+end
+
 defmodule ClaudeWrapper.DuplexSessionTest do
   use ExUnit.Case, async: true
 
-  alias ClaudeWrapper.{Config, DuplexSession}
+  alias ClaudeWrapper.{Config, DuplexSession, Query}
+  alias ClaudeWrapper.DuplexSessionTest.ArgsCaptureAdapter
 
   # Helper: spawn a DuplexSession against `cat` so we can inject NDJSON
   # bytes via Port.command/2 and observe how the GenServer demuxes them.
@@ -734,5 +754,71 @@ defmodule ClaudeWrapper.DuplexSessionTest do
         Process.sleep(10)
         do_wait_until(fun, deadline)
     end
+  end
+
+  describe "start_link/1 with a :query" do
+    test "folds the query's spawn knobs into the args and keeps the transport flags" do
+      query =
+        Query.new("ignored prompt")
+        |> Query.model("sonnet")
+        |> Query.max_turns(3)
+        |> Query.allowed_tool("Read")
+
+      args = capture_args(query: query)
+
+      # Query knobs are present.
+      assert ["--model", "sonnet"] |> contiguous?(args)
+      assert ["--max-turns", "3"] |> contiguous?(args)
+      assert ["--allowed-tools", "Read"] |> contiguous?(args)
+
+      # The prompt is not spawned as an argv (it is a per-turn message).
+      refute "ignored prompt" in args
+
+      # The fixed duplex transport flags are still owned by the session.
+      assert ["--input-format", "stream-json"] |> contiguous?(args)
+      assert ["--output-format", "stream-json"] |> contiguous?(args)
+      assert "--include-partial-messages" in args
+    end
+
+    test "extra_args are appended after the query args" do
+      args =
+        capture_args(
+          query: Query.new("") |> Query.model("sonnet"),
+          extra_args: ["--permission-mode", "plan"]
+        )
+
+      model_idx = Enum.find_index(args, &(&1 == "sonnet"))
+      perm_idx = Enum.find_index(args, &(&1 == "plan"))
+
+      assert model_idx < perm_idx
+    end
+
+    test "without a :query the args are unchanged from the plain transport set" do
+      args = capture_args([])
+
+      assert ["--input-format", "stream-json"] |> contiguous?(args)
+      refute "--model" in args
+    end
+  end
+
+  defp capture_args(opts) do
+    config = Config.new(binary: System.find_executable("cat"))
+
+    {:ok, _pid} =
+      DuplexSession.start_link(
+        [config: config, adapter: ArgsCaptureAdapter, adapter_opts: [test_pid: self()]] ++ opts
+      )
+
+    assert_receive {:captured_args, args}
+    args
+  end
+
+  # True when `sub` appears as a contiguous run inside `list`.
+  defp contiguous?(sub, list) do
+    len = length(sub)
+
+    list
+    |> Enum.chunk_every(len, 1, :discard)
+    |> Enum.any?(&(&1 == sub))
   end
 end

--- a/test/claude_wrapper/query_test.exs
+++ b/test/claude_wrapper/query_test.exs
@@ -3,6 +3,16 @@ defmodule ClaudeWrapper.QueryTest do
 
   alias ClaudeWrapper.Query
 
+  # True when `sub` appears as a contiguous run inside `list` (a flag
+  # immediately followed by its value(s)).
+  defp subsequence?(sub, list) do
+    len = length(sub)
+
+    list
+    |> Enum.chunk_every(len, 1, :discard)
+    |> Enum.any?(&(&1 == sub))
+  end
+
   describe "apply_opts/2 -- scalar opts" do
     test "applies all scalar string/value opts" do
       q =
@@ -181,6 +191,72 @@ defmodule ClaudeWrapper.QueryTest do
         |> Query.apply_opts(model: "haiku", model: "sonnet")
 
       assert q.model == "sonnet"
+    end
+  end
+
+  describe "spawn_args/1" do
+    test "drops the prompt and the transport-format flags" do
+      args =
+        "hello there"
+        |> Query.new()
+        |> Query.apply_opts(
+          output_format: :stream_json,
+          input_format: :stream_json,
+          include_partial_messages: true
+        )
+        |> Query.spawn_args()
+
+      refute "hello there" in args
+      refute "--print" in args
+      refute "--output-format" in args
+      refute "--input-format" in args
+      refute "--include-partial-messages" in args
+    end
+
+    test "passes spawn-time knobs through" do
+      args =
+        ""
+        |> Query.new()
+        |> Query.apply_opts(
+          model: "sonnet",
+          system_prompt: "be terse",
+          permission_mode: :plan,
+          allowed_tools: ["Read", "Bash"],
+          disallowed_tools: ["WebFetch"],
+          mcp_config: ["/mcp.json"],
+          add_dir: ["/extra"],
+          effort: :high,
+          max_turns: 20,
+          max_budget_usd: 5.0,
+          json_schema: ~s({"type":"object"}),
+          session_id: "sess-1",
+          resume: "prior",
+          fallback_model: "haiku",
+          strict_mcp_config: true,
+          no_session_persistence: true
+        )
+        |> Query.spawn_args()
+
+      assert ["--model", "sonnet"] |> subsequence?(args)
+      assert ["--system-prompt", "be terse"] |> subsequence?(args)
+      assert ["--permission-mode", "plan"] |> subsequence?(args)
+      assert ["--allowed-tools", "Read", "Bash"] |> subsequence?(args)
+      assert ["--disallowed-tools", "WebFetch"] |> subsequence?(args)
+      assert ["--mcp-config", "/mcp.json"] |> subsequence?(args)
+      assert ["--add-dir", "/extra"] |> subsequence?(args)
+      assert ["--effort", "high"] |> subsequence?(args)
+      assert ["--max-turns", "20"] |> subsequence?(args)
+      assert ["--max-budget-usd", "5.0"] |> subsequence?(args)
+      assert ["--json-schema", ~s({"type":"object"})] |> subsequence?(args)
+      assert ["--session-id", "sess-1"] |> subsequence?(args)
+      assert ["--resume", "prior"] |> subsequence?(args)
+      assert ["--fallback-model", "haiku"] |> subsequence?(args)
+      assert "--strict-mcp-config" in args
+      assert "--no-session-persistence" in args
+    end
+
+    test "an empty query yields no flags" do
+      assert Query.spawn_args(Query.new("")) == []
     end
   end
 


### PR DESCRIPTION
Closes #187. Rust parity for `claude-wrapper` v0.13.0 #674 (`bring DuplexOptions to parity with the QueryCommand knob set`).

## Approach

Rust extracted a `SharedSpawnArgs` so the oneshot and duplex paths emit identical flags and cannot drift. Elixir already has one flag-emission source of truth: `Query.build_args/1`. Rather than duplicate it, `DuplexSession` will accept a `%Query{}` and reuse `build_args/1` to derive the spawn-time flags. Any knob added to `Query` in the future flows into duplex automatically.

`start_link/1` gains a `{:query, %Query{}}` option. The query's spawn-safe flags are prepended to the existing `:extra_args` (which stays as the escape hatch) and fed through the duplex transport arg builder.

### Spawn-safe extraction

New `@doc false Query.spawn_args/1` returns the spawn-time flag subset by:

- nulling the transport fields the duplex path fixes itself (`output_format`, `input_format`, `include_partial_messages`) so they are not re-emitted, then
- dropping the always-leading `--print <prompt>` pair (the prompt is per-turn in duplex, sent as a stream-json `user` message, not argv).

Everything else `build_args/1` emits (model, system_prompt/append, permission_mode, allowed/disallowed_tools, mcp_config, add_dir, effort, max_turns, max_budget_usd, json_schema, session_id, resume, continue, fallback_model, settings, strict_mcp_config, no_session_persistence, etc.) is spawn-safe and passes through. This is a superset of Rust's #674 list, which is the agreed scope (all spawn-safe Query knobs, not just Rust's enumerated set).

The fixed duplex transport flags (`--input-format stream-json`, `--output-format stream-json`, `--include-partial-messages`, `--verbose`, `--print`, `--permission-prompt-tool stdio`) remain owned by `DuplexSession.build_args/1` and are never overridden.

## Steps

- [ ] Add `Query.spawn_args/1` (`@doc false`) reusing `build_args/1`
- [ ] `DuplexSession`: add `{:query, Query.t()}` to the `option` type; in `init/1`, prepend `Query.spawn_args(query)` to `:extra_args`
- [ ] Docs: `start_link/1` moduledoc + README duplex section showing a `%Query{}` start
- [ ] Unit tests: exhaustive `Query.spawn_args/1` (transport fields stripped, prompt dropped, knobs preserved)
- [ ] Wiring test: a capturing adapter asserts the args `DuplexSession` hands the transport for a representative `%Query{}`

## Verification

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test`, `mix dialyzer`.

## Rust reference

- v0.13.0 #674, commit `00e6e6a`; `src/command/spawn_args.rs`, `src/duplex.rs`