### PR TITLE
fix: harden the one-shot query path — dash-prefixed prompts + missing binary (#197, #200)

### DIFF
--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -700,18 +700,25 @@ defmodule ClaudeWrapper.Query do
     |> drop_print_flag()
   end
 
-  # build_args/1 always emits `--print <prompt>` first (via add_flag),
-  # so the prompt is guaranteed to be the leading pair.
-  defp drop_print_flag(["--print", _prompt | rest]), do: rest
-  defp drop_print_flag(args), do: args
+  # build_args/1 emits a bare leading `--print` and the prompt last (after a
+  # `--` separator). A duplex session sends prompts per-turn over stdin, so strip
+  # both the leading flag and the trailing `-- <prompt>`.
+  defp drop_print_flag(["--print" | rest]), do: drop_trailing_prompt(rest)
+  defp drop_print_flag(args), do: drop_trailing_prompt(args)
+
+  defp drop_trailing_prompt(args) do
+    case Enum.reverse(args) do
+      [_prompt, "--" | rev_rest] -> Enum.reverse(rev_rest)
+      _ -> args
+    end
+  end
 
   @doc false
   @spec build_args(t()) :: [String.t()]
   def build_args(%__MODULE__{} = q) do
     q = resolve_hermetic(q)
 
-    []
-    |> add_flag("--print", q.prompt)
+    ["--print"]
     |> add_opt("--model", q.model)
     |> add_opt("--system-prompt", q.system_prompt)
     |> add_opt("--append-system-prompt", q.append_system_prompt)
@@ -761,6 +768,7 @@ defmodule ClaudeWrapper.Query do
       "--exclude-dynamic-system-prompt-sections",
       q.exclude_dynamic_system_prompt_sections
     )
+    |> append_prompt(q.prompt)
   end
 
   # Expand the hermetic preset into its three underlying flags. Done here,
@@ -782,7 +790,13 @@ defmodule ClaudeWrapper.Query do
   defp hermetic_setting_sources(:full), do: ""
   defp hermetic_setting_sources(:project), do: "user"
 
-  defp add_flag(args, flag, value), do: args ++ [flag, value]
+  # The prompt is a positional argument, emitted LAST after a `--`
+  # end-of-options separator so a prompt beginning with `-`/`--` (a diff line, a
+  # markdown bullet, a negative number, pasted patch text) is taken literally by
+  # the CLI's option parser instead of being parsed as a flag.
+  defp append_prompt(args, nil), do: args
+  defp append_prompt(args, prompt), do: args ++ ["--", prompt]
+
   defp add_opt(args, _flag, nil), do: args
   defp add_opt(args, flag, value), do: args ++ [flag, value]
   defp add_bool(args, _flag, false), do: args
@@ -848,14 +862,25 @@ defmodule ClaudeWrapper.Query do
 
   # Execute through the configured runner and normalize to this module's
   # {:ok, stdout} | {:error, %Error{}} contract. A non-zero exit becomes
-  # :command_failed (do_execute re-inspects it for a JSON rail-stop
-  # result); a timeout becomes :timeout; anything else is :io.
+  # :command_failed (do_execute re-inspects it for a JSON rail-stop result); a
+  # timeout becomes :timeout; a missing/unlaunchable binary becomes the typed
+  # :binary_not_found; anything else is :io.
   defp run_cmd(binary, args, opts, timeout) do
     case Runner.impl().run(binary, args, opts, timeout) do
-      {:ok, {stdout, 0}} -> {:ok, stdout}
-      {:ok, {stdout, code}} -> {:error, Error.command_failed(code, stdout)}
-      {:error, :timeout} -> {:error, Error.timeout(timeout)}
-      {:error, reason} -> {:error, Error.io(reason)}
+      {:ok, {stdout, 0}} ->
+        {:ok, stdout}
+
+      {:ok, {stdout, code}} ->
+        {:error, Error.command_failed(code, stdout)}
+
+      {:error, :timeout} ->
+        {:error, Error.timeout(timeout)}
+
+      {:error, {:binary_not_found, _reason}} ->
+        {:error, Error.new(:binary_not_found, reason: binary)}
+
+      {:error, reason} ->
+        {:error, Error.io(reason)}
     end
   end
 end

--- a/lib/claude_wrapper/runner/port.ex
+++ b/lib/claude_wrapper/runner/port.ex
@@ -24,19 +24,39 @@ defmodule ClaudeWrapper.Runner.Port do
     {stdout, code} = System.cmd(binary, args, opts)
     {:ok, {stdout, code}}
   rescue
-    e in ErlangError -> {:error, {:io, e}}
+    e in ErlangError -> {:error, launch_error(e)}
   end
 
   def run(binary, args, opts, timeout) do
-    task = Task.async(fn -> System.cmd(binary, args, opts) end)
+    # Rescue INSIDE the task: a missing/unlaunchable binary raises here, and
+    # `Task.async` links, so an un-rescued raise crashes the *caller* (the outer
+    # rescue below could not catch that linked exit -- the previous code did, so
+    # a missing binary on the timeout path crashed the job). Wrap the outcome so
+    # both success and failure come back through `Task.yield`.
+    task =
+      Task.async(fn ->
+        try do
+          {:ok, System.cmd(binary, args, opts)}
+        rescue
+          e in ErlangError -> {:error, launch_error(e)}
+        end
+      end)
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
-      {:ok, {stdout, code}} -> {:ok, {stdout, code}}
+      {:ok, {:ok, {stdout, code}}} -> {:ok, {stdout, code}}
+      {:ok, {:error, reason}} -> {:error, reason}
       nil -> {:error, :timeout}
     end
-  rescue
-    e in ErlangError -> {:error, {:io, e}}
   end
+
+  # A missing or non-executable binary fails the OS spawn with `:enoent` /
+  # `:eacces`; surface it as the typed `:binary_not_found` signal (run_cmd turns
+  # it into a `%Error{kind: :binary_not_found}`) rather than a generic `:io`,
+  # which the classifier would retry to exhaustion.
+  defp launch_error(%ErlangError{original: reason}) when reason in [:enoent, :eacces],
+    do: {:binary_not_found, reason}
+
+  defp launch_error(e), do: {:io, e}
 
   @impl true
   def stream_lines(binary, args, opts, timeout) do

--- a/test/claude_wrapper/query_test.exs
+++ b/test/claude_wrapper/query_test.exs
@@ -261,6 +261,21 @@ defmodule ClaudeWrapper.QueryTest do
     end
   end
 
+  describe "build_args/1 prompt handling (#197)" do
+    test "emits a bare --print and the prompt last, after a -- separator" do
+      args = Query.build_args(Query.new("do the thing"))
+
+      assert "--print" in args
+      assert Enum.take(args, -2) == ["--", "do the thing"]
+    end
+
+    test "a dash-prefixed prompt goes after -- so the CLI does not parse it as a flag" do
+      args = Query.build_args(Query.new("--version is what I want summarized"))
+
+      assert Enum.take(args, -2) == ["--", "--version is what I want summarized"]
+    end
+  end
+
   describe "hermetic preset (#193)" do
     test "hermetic: true defaults to the full seal" do
       q = "p" |> Query.new() |> Query.apply_opts(hermetic: true)

--- a/test/claude_wrapper/runner_test.exs
+++ b/test/claude_wrapper/runner_test.exs
@@ -32,8 +32,16 @@ defmodule ClaudeWrapper.RunnerTest do
       assert {:error, :timeout} = Port.run("sleep", ["10"], [], 200)
     end
 
-    test "a missing binary returns an io error" do
-      assert {:error, {:io, _}} = Port.run("definitely-not-a-real-binary-xyz", [], [], nil)
+    test "a missing binary returns a :binary_not_found signal (no-timeout path)" do
+      assert {:error, {:binary_not_found, :enoent}} =
+               Port.run("definitely-not-a-real-binary-xyz", [], [], nil)
+    end
+
+    test "a missing binary on the timeout path returns :binary_not_found (does not crash)" do
+      # Regression (#200): the raise happens inside the linked Task, so it must
+      # come back as a value rather than crashing this process.
+      assert {:error, {:binary_not_found, :enoent}} =
+               Port.run("definitely-not-a-real-binary-xyz", [], [], 1_000)
     end
   end
 

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -351,12 +351,12 @@ defmodule ClaudeWrapperTest do
   describe "named worktree (#84)" do
     test "worktree/1 emits the bare flag" do
       assert Query.new("p") |> Query.worktree() |> Query.build_args() ==
-               ["--print", "p", "--worktree"]
+               ["--print", "--worktree", "--", "p"]
     end
 
     test "worktree/2 emits --worktree <name>" do
       assert Query.new("p") |> Query.worktree("feature-x") |> Query.build_args() ==
-               ["--print", "p", "--worktree", "feature-x"]
+               ["--print", "--worktree", "feature-x", "--", "p"]
     end
 
     test "apply_opts accepts a name, true, or false" do


### PR DESCRIPTION
First batch from the audit — the two `query/2`-path correctness bugs that most affect consumers (oban_claude uses this path).

| Issue | Fix |
|---|---|
| #197 | A prompt starting with `-`/`--` was parsed as a flag and never reached the model (diff lines, bullets, negative numbers; worst case a prompt of `--dangerously-skip-permissions`). `build_args` now emits a bare leading `--print` and appends the prompt **last, after a `--` separator**, so the CLI treats it literally. `spawn_args`/`drop_print_flag` updated to strip both the leading flag and the trailing prompt (duplex unaffected). |
| #200 | A missing/unlaunchable binary was misreported as `:io` on the no-timeout path and **crashed the caller** on the timeout path (the raise was inside the linked `Task`, uncatchable by the outer rescue). `Runner.Port` now rescues inside the Task and maps `:enoent`/`:eacces` to the documented **`:binary_not_found`** kind — which previously had no producer, so the classifier retried it to exhaustion. |

Chose the `--` separator over feeding the prompt via stdin (the finding's alternative) — it's the minimal, thin-wrapper fix and keeps the argv fully inspectable.

## Gate
`compile --warnings-as-errors`, `credo --strict`, `dialyzer` (0), `mix docs`, **633 tests** (added: dash-prompt placement, `:binary_not_found` on both runner paths incl. the timeout no-crash regression).

## Downstream note
#200 makes `:binary_not_found` reachable, which oban_claude's classifier already cancels via `@config_faults`. Once oban_claude bumps to a wrapper release with this, its `:io`/`:enoent` clause (from its own #74) becomes belt-and-suspenders — a future cleanup, not a break.

Non-flagged (clear correctness fixes) — auto-merging on green.

Closes #197, closes #200