### PR TITLE
fix: harden the streaming path — argv quoting, >1MB lines, 5s stall (#196, #198, #201)

### DIFF
--- a/lib/claude_wrapper/command.ex
+++ b/lib/claude_wrapper/command.ex
@@ -47,12 +47,23 @@ defmodule ClaudeWrapper.Command do
     ["-c", shell_cmd]
   end
 
+  # A conservative allowlist of shell-safe characters. Anything else -- and the
+  # empty string -- gets single-quoted below.
+  @safe_arg ~r/\A[A-Za-z0-9_@%+=:,.\/-]+\z/
+
   @doc false
+  # Single-quote every argument except strictly-safe tokens (kept bare for
+  # readable debug output). The old denylist missed metacharacters like
+  # `> < * ? [ ] { } ~` and left the empty string unquoted, so on the /bin/sh
+  # streaming path a space-free redirection token could truncate a file and an
+  # empty arg (e.g. hermetic's `--setting-sources ""`) vanished under
+  # word-splitting -- diverging from the execve-based one-shot path. An
+  # allowlist closes the whole class at once.
   def shell_escape(arg) do
-    if String.contains?(arg, ["'", " ", "\"", "\\", "(", ")", "$", "`", "!", "&", "|", ";", "\n"]) do
-      "'" <> String.replace(arg, "'", "'\\''") <> "'"
-    else
+    if Regex.match?(@safe_arg, arg) do
       arg
+    else
+      "'" <> String.replace(arg, "'", "'\\''") <> "'"
     end
   end
 end

--- a/lib/claude_wrapper/runner/port.ex
+++ b/lib/claude_wrapper/runner/port.ex
@@ -68,31 +68,43 @@ defmodule ClaudeWrapper.Runner.Port do
         env_opts(opts) ++ cd_opts(opts)
 
     Stream.resource(
-      fn -> Port.open({:spawn_executable, "/bin/sh"}, port_opts) end,
-      fn port -> next_line(port, idle_timeout) end,
-      fn port -> close(port) end
+      fn -> {Port.open({:spawn_executable, "/bin/sh"}, port_opts), [], :open} end,
+      fn {port, buffer, _status} -> next_line(port, buffer, idle_timeout) end,
+      fn {port, _buffer, status} -> close(port, status) end
     )
   end
 
-  defp next_line(port, idle_timeout) do
+  # Reassemble lines longer than the port's line buffer: the port delivers an
+  # over-long line as one or more `{:noeol, fragment}` followed by `{:eol, rest}`.
+  # Carry the fragments in an iolist buffer and flush the whole line on `:eol`,
+  # rather than dropping fragments (which silently lost any NDJSON event > 1 MB).
+  defp next_line(port, buffer, idle_timeout) do
     receive do
-      {^port, {:data, {:eol, line}}} -> {[line], port}
-      # A line longer than the buffer cap: skip its fragment, as before.
-      {^port, {:data, {:noeol, _partial}}} -> {[], port}
-      {^port, {:exit_status, _code}} -> {:halt, port}
+      {^port, {:data, {:eol, line}}} ->
+        {[IO.iodata_to_binary([buffer, line])], {port, [], :open}}
+
+      {^port, {:data, {:noeol, fragment}}} ->
+        {[], {port, [buffer, fragment], :open}}
+
+      {^port, {:exit_status, _code}} ->
+        {:halt, {port, buffer, :exited}}
     after
-      idle_timeout -> {:halt, port}
+      idle_timeout -> {:halt, {port, buffer, :open}}
     end
   end
 
-  defp close(port) do
-    send(port, {self(), :close})
+  # On normal completion the port has already terminated (we received
+  # `:exit_status`), so there is nothing to close -- and the old code then waited
+  # for a `:closed` reply that never arrives, stalling *every* stream for the
+  # full 5s receive timeout. Only a still-open port (idle timeout, or a consumer
+  # that stopped early) needs an explicit close.
+  defp close(_port, :exited), do: :ok
 
-    receive do
-      {^port, :closed} -> :ok
-    after
-      5_000 -> :ok
-    end
+  defp close(port, :open) do
+    Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> :ok
   end
 
   defp env_opts(opts) do

--- a/test/claude_wrapper/command_test.exs
+++ b/test/claude_wrapper/command_test.exs
@@ -1,0 +1,35 @@
+defmodule ClaudeWrapper.CommandTest do
+  use ExUnit.Case, async: true
+
+  alias ClaudeWrapper.Command
+
+  describe "shell_escape/1 (#196)" do
+    test "leaves strictly-safe tokens bare" do
+      for safe <- ["--model", "sonnet", "/path/to/file.json", "issue-42", "a,b:c=d.5"] do
+        assert Command.shell_escape(safe) == safe
+      end
+    end
+
+    test "single-quotes shell metacharacters the old denylist missed" do
+      assert Command.shell_escape("a>b") == "'a>b'"
+      assert Command.shell_escape("glob_*.txt") == "'glob_*.txt'"
+      assert Command.shell_escape("~/project") == "'~/project'"
+      assert Command.shell_escape("a b") == "'a b'"
+    end
+
+    test "single-quotes the empty string so it survives word-splitting" do
+      assert Command.shell_escape("") == "''"
+    end
+
+    test "escapes an embedded single quote" do
+      assert Command.shell_escape("it's") == ~S('it'\''s')
+    end
+  end
+
+  describe "shell_cmd_args/2 (#196)" do
+    test "an empty arg (e.g. hermetic's --setting-sources \"\") stays a distinct token" do
+      assert Command.shell_cmd_args("claude", ["--setting-sources", ""]) ==
+               ["-c", "claude --setting-sources '' < /dev/null"]
+    end
+  end
+end

--- a/test/claude_wrapper/runner_test.exs
+++ b/test/claude_wrapper/runner_test.exs
@@ -56,5 +56,28 @@ defmodule ClaudeWrapper.RunnerTest do
 
       assert lines == ["a", "b", "c"]
     end
+
+    test "reassembles a line longer than the port buffer instead of dropping it (#198)" do
+      big = String.duplicate("A", 1_100_000)
+
+      lines =
+        "sh"
+        |> Port.stream_lines(["-c", "head -c 1100000 /dev/zero | tr '\\0' A; echo"], [], nil)
+        |> Enum.to_list()
+
+      assert lines == [big]
+    end
+
+    test "a naturally-completing stream returns promptly, not after a 5s stall (#201)" do
+      {micros, lines} =
+        :timer.tc(fn ->
+          "printf" |> Port.stream_lines(["a\nb\n"], [], nil) |> Enum.to_list()
+        end)
+
+      assert lines == ["a", "b"]
+
+      assert micros < 2_000_000,
+             "stream took #{div(micros, 1000)}ms (the 5s close stall regressed)"
+    end
   end
 end


### PR DESCRIPTION
Second batch — the three `Query.stream/2` bugs, all cases where the streaming path diverges from the one-shot path.

| Issue | Fix |
|---|---|
| #196 | The `/bin/sh` argv escaper used a **denylist** that missed `> < * ? [ ] { } ~` etc. and left the empty string unquoted — so a space-free redirection token could truncate a file, and hermetic's `--setting-sources ""` **vanished under word-splitting, silently dropping the seal** on `stream/2`. Switched to an allowlist: single-quote everything but strictly-safe tokens. |
| #198 | An NDJSON line larger than the 1 MB port buffer was silently dropped (its `{:noeol, _}` fragments discarded). `next_line` now **reassembles** fragments and flushes the whole line on `:eol` — the fix DuplexSession already had. |
| #201 | Every naturally-completing stream **stalled a fixed 5s** — `close/1` waited for a `:closed` reply from a port that had already exited. Now it tracks the exit and skips the wait on normal completion. |

## Gate
`compile --warnings-as-errors`, `credo --strict`, `dialyzer` (0), **640 tests** — added escaper unit tests (metachars/empty-string/quotes), a >1MB reassembly test, and a no-stall timing assertion. Nice side effect of #201: the suite dropped from ~9s to ~3.6s (that was the accumulated stall). Also lays down the escaper/streaming coverage the audit's #21 asked for.

Non-flagged — auto-merging on green.

Closes #196, closes #198, closes #201