### PR TITLE
fix: preserve http MCP servers on round-trip + fix mcp add argv order (#199, #202)

### DIFF
--- a/lib/claude_wrapper/commands/mcp.ex
+++ b/lib/claude_wrapper/commands/mcp.ex
@@ -142,7 +142,13 @@ defmodule ClaudeWrapper.Commands.Mcp do
         list -> ["--" | Enum.map(list, &to_string/1)]
       end
 
-    ["mcp", "add"] ++ flags ++ [name, command_or_url] ++ command_args ++ server_args
+    # Positionals FIRST, before the option flags: the CLI's `-e/--env` and
+    # `-H/--header` are variadic (`<env...>`), so when emitted before the
+    # positionals they greedily swallow `name`/`commandOrUrl` and the CLI aborts
+    # with "missing required argument" (#202). Fixed single-value/boolean flags
+    # are order-insensitive, so placing every flag after the positionals is safe;
+    # the `--` server_args separator still terminates option parsing last.
+    ["mcp", "add", name, command_or_url] ++ command_args ++ flags ++ server_args
   end
 
   @doc """

--- a/lib/claude_wrapper/mcp_config.ex
+++ b/lib/claude_wrapper/mcp_config.ex
@@ -35,7 +35,8 @@ defmodule ClaudeWrapper.McpConfig do
           command: String.t() | nil,
           args: [String.t()],
           env: %{String.t() => String.t()},
-          url: String.t() | nil
+          url: String.t() | nil,
+          headers: %{String.t() => String.t()}
         }
 
   @type t :: %__MODULE__{
@@ -75,13 +76,35 @@ defmodule ClaudeWrapper.McpConfig do
   ## Options
 
     * `:env` - Map of environment variables
+    * `:headers` - Map of HTTP headers (e.g. `%{"Authorization" => "Bearer ..."}`)
   """
   @spec add_sse(t(), String.t(), String.t(), keyword()) :: t()
   def add_sse(%__MODULE__{} = config, name, url, opts \\ []) do
     server = %{
       type: "sse",
       url: url,
-      env: opts[:env] || %{}
+      env: opts[:env] || %{},
+      headers: opts[:headers] || %{}
+    }
+
+    %{config | servers: Map.put(config.servers, name, server)}
+  end
+
+  @doc """
+  Add an HTTP-based MCP server (the CLI's primary remote transport).
+
+  ## Options
+
+    * `:env` - Map of environment variables
+    * `:headers` - Map of HTTP headers (e.g. `%{"Authorization" => "Bearer ..."}`)
+  """
+  @spec add_http(t(), String.t(), String.t(), keyword()) :: t()
+  def add_http(%__MODULE__{} = config, name, url, opts \\ []) do
+    server = %{
+      type: "http",
+      url: url,
+      env: opts[:env] || %{},
+      headers: opts[:headers] || %{}
     }
 
     %{config | servers: Map.put(config.servers, name, server)}
@@ -167,7 +190,8 @@ defmodule ClaudeWrapper.McpConfig do
           command: def_map["command"],
           args: def_map["args"] || [],
           env: def_map["env"] || %{},
-          url: def_map["url"]
+          url: def_map["url"],
+          headers: def_map["headers"] || %{}
         }
 
         {name, server}
@@ -189,11 +213,37 @@ defmodule ClaudeWrapper.McpConfig do
 
   defp encode_server(%{type: "sse"} = server) do
     %{"type" => "sse", "url" => server.url}
-    |> maybe_add_env(server.env)
+    |> maybe_add_env(server[:env] || %{})
+    |> maybe_add_headers(server[:headers] || %{})
   end
 
-  defp encode_server(%{type: type}), do: %{"type" => type}
+  defp encode_server(%{type: "http"} = server) do
+    %{"type" => "http", "url" => server.url}
+    |> maybe_add_env(server[:env] || %{})
+    |> maybe_add_headers(server[:headers] || %{})
+  end
+
+  # Preserve the connection fields the reader parsed for any other/future type,
+  # rather than dropping url/command/args/env/headers -- a read-modify-write must
+  # not silently discard a server's details (#199).
+  defp encode_server(%{type: type} = server) do
+    %{"type" => type}
+    |> maybe_put("command", server[:command])
+    |> maybe_put("url", server[:url])
+    |> maybe_add_args(server[:args] || [])
+    |> maybe_add_env(server[:env] || %{})
+    |> maybe_add_headers(server[:headers] || %{})
+  end
 
   defp maybe_add_env(map, env) when env == %{}, do: map
   defp maybe_add_env(map, env), do: Map.put(map, "env", env)
+
+  defp maybe_add_headers(map, headers) when headers == %{}, do: map
+  defp maybe_add_headers(map, headers), do: Map.put(map, "headers", headers)
+
+  defp maybe_add_args(map, []), do: map
+  defp maybe_add_args(map, args), do: Map.put(map, "args", args)
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -700,6 +700,35 @@ defmodule ClaudeWrapperTest do
       assert McpConfig.get_server(roundtripped, "remote").url == "https://example.com"
     end
 
+    test "preserves an http server (url + headers) through to_json/from_map (#199)" do
+      config =
+        McpConfig.new()
+        |> McpConfig.add_http("sentry", "https://mcp.sentry.dev/mcp",
+          headers: %{"Authorization" => "Bearer abc"}
+        )
+
+      json = McpConfig.to_json(config)
+      {:ok, data} = Jason.decode(json)
+
+      assert data["mcpServers"]["sentry"]["type"] == "http"
+      assert data["mcpServers"]["sentry"]["url"] == "https://mcp.sentry.dev/mcp"
+      assert data["mcpServers"]["sentry"]["headers"] == %{"Authorization" => "Bearer abc"}
+
+      rt = McpConfig.from_map(data)
+      assert McpConfig.get_server(rt, "sentry").url == "https://mcp.sentry.dev/mcp"
+      assert McpConfig.get_server(rt, "sentry").headers == %{"Authorization" => "Bearer abc"}
+    end
+
+    test "a read-modify-write does not drop an http server's url (#199)" do
+      # Simulates reading a project .mcp.json with an http server and writing it
+      # back; previously the url was silently rewritten away to {"type":"http"}.
+      data = %{"mcpServers" => %{"x" => %{"type" => "http", "url" => "https://x.example"}}}
+      json = data |> McpConfig.from_map() |> McpConfig.to_json()
+      {:ok, out} = Jason.decode(json)
+
+      assert out["mcpServers"]["x"]["url"] == "https://x.example"
+    end
+
     test "write! and read roundtrip" do
       path = Path.join(System.tmp_dir!(), "test_mcp_#{:rand.uniform(100_000)}.json")
 
@@ -931,26 +960,27 @@ defmodule ClaudeWrapperTest do
                ["mcp", "add", "srv", "my-command", "--some-flag", "arg1"]
     end
 
-    test "add_args emits --transport before the positionals" do
+    test "add_args emits the positionals before the flags (#202)" do
       assert Mcp.add_args("sentry", "https://mcp.sentry.dev/mcp", [], transport: :http) ==
-               ["mcp", "add", "--transport", "http", "sentry", "https://mcp.sentry.dev/mcp"]
+               ["mcp", "add", "sentry", "https://mcp.sentry.dev/mcp", "--transport", "http"]
 
       assert Mcp.add_args("s", "u", [], transport: :sse) ==
-               ["mcp", "add", "--transport", "sse", "s", "u"]
+               ["mcp", "add", "s", "u", "--transport", "sse"]
 
       assert Mcp.add_args("s", "u", [], transport: :stdio) ==
-               ["mcp", "add", "--transport", "stdio", "s", "u"]
+               ["mcp", "add", "s", "u", "--transport", "stdio"]
     end
 
-    test "add_args emits env as repeated -e KEY=value (map and keyword)" do
+    test "add_args emits env as repeated -e KEY=value, after the positionals (#202)" do
+      # name/commandOrUrl must precede the variadic -e or the CLI swallows them.
       assert Mcp.add_args("s", "npx", [], env: %{"API_KEY" => "xxx"}) ==
-               ["mcp", "add", "-e", "API_KEY=xxx", "s", "npx"]
+               ["mcp", "add", "s", "npx", "-e", "API_KEY=xxx"]
 
       assert Mcp.add_args("s", "npx", [], env: [API_KEY: "xxx"]) ==
-               ["mcp", "add", "-e", "API_KEY=xxx", "s", "npx"]
+               ["mcp", "add", "s", "npx", "-e", "API_KEY=xxx"]
     end
 
-    test "add_args emits one --header per header (list)" do
+    test "add_args emits one --header per header, after the positionals (#202)" do
       args =
         Mcp.add_args("c", "https://app.corridor.dev/api/mcp", [],
           transport: :http,
@@ -960,14 +990,14 @@ defmodule ClaudeWrapperTest do
       assert args == [
                "mcp",
                "add",
+               "c",
+               "https://app.corridor.dev/api/mcp",
                "--transport",
                "http",
                "--header",
                "Authorization: Bearer abc",
                "--header",
-               "X-Custom: value",
-               "c",
-               "https://app.corridor.dev/api/mcp"
+               "X-Custom: value"
              ]
 
       assert Enum.count(args, &(&1 == "--header")) == 2
@@ -975,7 +1005,7 @@ defmodule ClaudeWrapperTest do
 
     test "add_args accepts headers as a map rendered Key: Value" do
       assert Mcp.add_args("s", "u", [], header: %{"X-Api-Key" => "abc123"}) ==
-               ["mcp", "add", "--header", "X-Api-Key: abc123", "s", "u"]
+               ["mcp", "add", "s", "u", "--header", "X-Api-Key: abc123"]
     end
 
     test "add_args emits server_args after a -- separator" do
@@ -992,7 +1022,7 @@ defmodule ClaudeWrapperTest do
 
     test "add_args emits --callback-port with a stringified value" do
       assert Mcp.add_args("s", "https://example.com/mcp", [], callback_port: 8080) ==
-               ["mcp", "add", "--callback-port", "8080", "s", "https://example.com/mcp"]
+               ["mcp", "add", "s", "https://example.com/mcp", "--callback-port", "8080"]
     end
 
     test "add_args emits --client-id and --client-secret together" do
@@ -1003,11 +1033,11 @@ defmodule ClaudeWrapperTest do
                [
                  "mcp",
                  "add",
+                 "s",
+                 "https://example.com/mcp",
                  "--client-id",
                  "my-app-id",
-                 "--client-secret",
-                 "s",
-                 "https://example.com/mcp"
+                 "--client-secret"
                ]
     end
 
@@ -1030,6 +1060,8 @@ defmodule ClaudeWrapperTest do
       assert args == [
                "mcp",
                "add",
+               "srv",
+               "https://example.com/mcp",
                "--transport",
                "http",
                "--scope",
@@ -1040,9 +1072,7 @@ defmodule ClaudeWrapperTest do
                "9000",
                "--client-id",
                "cid",
-               "--client-secret",
-               "srv",
-               "https://example.com/mcp"
+               "--client-secret"
              ]
     end
 


### PR DESCRIPTION
Third batch — the two MCP bugs.

| Issue | Fix |
|---|---|
| #199 | `encode_server/1` only handled `stdio`/`sse`, so a read-modify-write of a `.mcp.json` with an **http** server silently rewrote it to `{"type":"http"}` — dropping `url`/`env`. Added an http clause + a **field-preserving catch-all** for any other/future type. Also added `add_http/4` and `:headers` support (on `add_http`/`add_sse`) since authenticated remote servers need an `Authorization` header, and `from_map` now reads headers. |
| #202 | `add_args` emitted option flags **before** the positionals, so the CLI's variadic `-e/--env` and `-H/--header` swallowed `name`/`commandOrUrl` and the CLI aborted with "missing required argument" (both moduledoc examples produced broken argv). Positionals now come first, matching the CLI's own examples and `marketplace add`; the `--` `server_args` separator still terminates parsing last. |

## Scope note
Beyond the strict data-loss fix for #199, I included `add_http/4` + `:headers` (the finding endorsed them as thin and matching a real CLI capability). Say the word if you'd rather I drop the feature bits and keep only the round-trip preservation.

## Gate
`compile --warnings-as-errors`, `credo --strict`, `dialyzer` (0), **642 tests** — added http+headers round-trip, a read-modify-write preservation test, and corrected `add_args` ordering assertions.

Non-flagged — auto-merging on green.

Closes #199, closes #202