### PR TITLE
fix(ci): gate Hex publish behind the quality suite + add hex.audit (#203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
+      - name: Audit deps for retirements/advisories
+        run: mix hex.audit
+
       - name: Compile (warnings as errors)
         run: mix compile --warnings-as-errors
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+# Queue release runs; never cancel a publish mid-flight.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -29,7 +34,11 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     steps:
+      # Check out the released tag, not the triggering sha (release-please tags
+      # the release-PR merge commit, which may not be the commit that fired this).
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - uses: erlef/setup-beam@v1
         with:
@@ -38,6 +47,30 @@ jobs:
 
       - name: Install dependencies
         run: mix deps.get
+
+      # Gate the publish on CI's quality suite. release.yml and ci.yml are
+      # separate workflows, so a `needs:` cannot link them and main has no
+      # required-status-check protection -- without this, a red main (failing
+      # tests, a credo/format/warning regression) publishes to Hex regardless
+      # (`mix hex.publish` compiles without --warnings-as-errors and runs no
+      # tests). #203.
+      - name: Audit deps for retirements/advisories
+        run: mix hex.audit
+
+      - name: Compile (warnings as errors)
+        run: mix compile --warnings-as-errors
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Credo
+        run: mix credo --strict
+
+      - name: Run tests
+        run: mix test
+
+      - name: Build docs
+        run: mix docs
 
       - name: Publish
         env:


### PR DESCRIPTION
Last p1 from the audit — the release/CI hardening (mirrors what we did on oban_claude in #66/#103).

## What changed
- **`release.yml`**: the publish job ran only `deps.get` + `hex.publish --yes` — no gate, and it's a separate workflow from `ci.yml` so a `needs:` can't link them, with no required-status-check on main. A **red main would publish to Hex regardless** (`hex.publish` compiles without `--warnings-as-errors` and runs no tests/credo/format). Added the gate before publish: `hex.audit`, `compile --warnings-as-errors`, `format --check-formatted`, `credo --strict`, `test`, `docs`. Also **checkout the released tag** (not the triggering sha) and a **concurrency group**.
- **`ci.yml`**: added `mix hex.audit` to the test job (the tree is currently advisory-clean, so it passes — this is the guard for future advisories, your earlier point).

Skipped `dialyzer` in the *publish* gate (it needs a from-scratch PLT build there; it runs on every PR in `ci.yml`). Say the word if you'd rather I add it too.

## ⚠️ Flagged (same as oban_claude #101)
- Touches **Hex publishing**; CI can't exercise the release workflow (it only runs on a real release). YAML validated; logic mirrors the oban_claude change you merged. Please eyeball before merge.
- Manual repo setting (not in this PR): add the CI `test` job as a **required status check** on `main` — the real branch-protection fix; this in-workflow gate is belt-and-suspenders.

Paused for your OK.

Closes #203