### PR TITLE
test: deflake the turn-in-flight stream test (unblocks 0.13.1)

### DIFF
--- a/test/claude_wrapper/stream_test.exs
+++ b/test/claude_wrapper/stream_test.exs
@@ -161,7 +161,13 @@ defmodule ClaudeWrapper.StreamTest do
 
       events = pid |> CWStream.stream("second") |> Enum.to_list()
 
-      assert [{:error, %ClaudeWrapper.Error{kind: :turn_in_flight}}] = events
+      # The concurrent "occupy" turn is driven through `cat`, which echoes its
+      # user message; depending on scheduling that echo can land in this stream
+      # before the rejection (a fake-harness artifact -- real claude does not
+      # echo another turn's message into a new subscriber). What this test pins
+      # is that the send is rejected *terminally*: Enum.to_list returned (no
+      # hang) and turn_in_flight is the final event.
+      assert {:error, %ClaudeWrapper.Error{kind: :turn_in_flight}} = List.last(events)
     end
 
     # The occupying turn registers a pending_turn but no subscriber; wait


### PR DESCRIPTION
The 0.13.1 release CI hit a flaky failure in `stream_test.exs:154` — not a real bug.

**Mechanism:** the test's fake claude is `cat`, which echoes everything. The concurrent `"occupy"` turn's user message gets echoed back and — depending on scheduling — lands in the `"second"` stream before the `turn_in_flight` rejection, so `events` is `[user: "occupy", error: turn_in_flight]` instead of just `[error: turn_in_flight]`. That's a fake-harness artifact (real claude doesn't echo another turn's message into a new subscriber), and the rejection is still terminal with no hang. The faster stream teardown from #201 shifted timing enough to surface it under the full suite's concurrency (it passes 12/12 in isolation).

**Fix:** assert the test's actual intent — `turn_in_flight` is the *terminal* event and `Enum.to_list` returned (no hang) — tolerating a leading echoed user event, instead of exact-list equality.

Verified: full suite green ×2 under `--max-cases 4` contention; the target test passes in isolation.

`test:`-typed so it doesn't affect the 0.13.1 version. Merging this to main lets release-please refresh the release PR and turn its CI green.