### PR TITLE
fix: runner/config correctness — timeout, stream truncation, duplex lifecycle, :defer (#204/#209/#210/#211)

### DIFF
--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -108,14 +108,32 @@ defmodule ClaudeWrapper do
   def raw(args, opts \\ []) when is_list(args) do
     config = Config.new(opts)
     all_args = Config.base_args(config) ++ args
-    cmd_opts = Config.cmd_opts(config)
 
-    case System.cmd(config.binary, all_args, cmd_opts) do
-      {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, Error.command_failed(code, output)}
+    # Route through the configured Runner (not System.cmd directly) so raw/2
+    # honors `config.timeout` AND the leak-free Forcola runner's process-group
+    # kill -- the one API explicitly framed as "run an arbitrary CLI command"
+    # should not be the one that silently bypasses both.
+    case ClaudeWrapper.Runner.impl().run(
+           config.binary,
+           all_args,
+           Config.cmd_opts(config),
+           config.timeout
+         ) do
+      {:ok, {output, 0}} ->
+        {:ok, String.trim(output)}
+
+      {:ok, {output, code}} ->
+        {:error, Error.command_failed(code, output)}
+
+      {:error, :timeout} ->
+        {:error, Error.timeout(config.timeout)}
+
+      {:error, {:binary_not_found, _reason}} ->
+        {:error, Error.new(:binary_not_found, reason: config.binary)}
+
+      {:error, reason} ->
+        {:error, Error.io(reason)}
     end
-  rescue
-    e in ErlangError -> {:error, Error.io(e)}
   end
 
   @doc """
@@ -160,8 +178,13 @@ defmodule ClaudeWrapper do
   @doc """
   Execute a query and return a lazy stream of `%StreamEvent{}` structs.
 
-  The subprocess starts when the stream is consumed. Accepts the same
-  options as `query/2`.
+  The subprocess starts when the stream is consumed. Accepts the same options as
+  `query/2`, except `:timeout`: streaming is bounded only by a per-frame idle
+  deadline, not a whole-run timeout. A truncated run (idle timeout, non-zero
+  exit, spawn failure) ends with a terminal
+  `%StreamEvent{type: "error", data: %{"error" => "stream_truncated"}}` rather
+  than a silent stop; see `ClaudeWrapper.Query.stream/2` for details and the
+  Forcola-runner note.
   """
   @spec stream(String.t(), keyword()) :: Enumerable.t()
   def stream(prompt, opts \\ []) do

--- a/lib/claude_wrapper/commands/agents.ex
+++ b/lib/claude_wrapper/commands/agents.ex
@@ -41,7 +41,7 @@ defmodule ClaudeWrapper.Commands.Agents do
   def list(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ list_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, parse_agents(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -54,7 +54,7 @@ defmodule ClaudeWrapper.Commands.Agents do
   def execute(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ list_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/auth.ex
+++ b/lib/claude_wrapper/commands/auth.ex
@@ -25,7 +25,7 @@ defmodule ClaudeWrapper.Commands.Auth do
   def status(%Config{} = config) do
     args = Config.base_args(config) ++ ["auth", "status", "--json"]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} ->
         case Jason.decode(output) do
           {:ok, data} ->
@@ -107,7 +107,7 @@ defmodule ClaudeWrapper.Commands.Auth do
   def login(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ login_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -139,7 +139,7 @@ defmodule ClaudeWrapper.Commands.Auth do
   def logout(%Config{} = config) do
     args = Config.base_args(config) ++ ["auth", "logout"]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/auto_mode.ex
+++ b/lib/claude_wrapper/commands/auto_mode.ex
@@ -36,7 +36,7 @@ defmodule ClaudeWrapper.Commands.AutoMode do
   def config(%Config{} = config) do
     args = Config.base_args(config) ++ config_args()
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -58,7 +58,7 @@ defmodule ClaudeWrapper.Commands.AutoMode do
   def defaults(%Config{} = config) do
     args = Config.base_args(config) ++ defaults_args()
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -82,7 +82,7 @@ defmodule ClaudeWrapper.Commands.AutoMode do
   def critique(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ critique_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/doctor.ex
+++ b/lib/claude_wrapper/commands/doctor.ex
@@ -12,7 +12,7 @@ defmodule ClaudeWrapper.Commands.Doctor do
   def execute(%Config{} = config) do
     args = Config.base_args(config) ++ ["doctor"]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/install.ex
+++ b/lib/claude_wrapper/commands/install.ex
@@ -37,7 +37,7 @@ defmodule ClaudeWrapper.Commands.Install do
   def install(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ install_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/marketplace.ex
+++ b/lib/claude_wrapper/commands/marketplace.ex
@@ -37,7 +37,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
   def list(%Config{} = config) do
     args = Config.base_args(config) ++ ["plugin", "marketplace", "list", "--json"]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} ->
         case Jason.decode(output) do
           {:ok, data} -> {:ok, data}
@@ -61,7 +61,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
   def add(%Config{} = config, source, opts \\ []) do
     args = Config.base_args(config) ++ add_args(source, opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -81,7 +81,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
   def remove(%Config{} = config, name) do
     args = Config.base_args(config) ++ ["plugin", "marketplace", "remove", name]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -96,7 +96,7 @@ defmodule ClaudeWrapper.Commands.Marketplace do
   def update(%Config{} = config, name \\ nil) do
     args = Config.base_args(config) ++ update_args(name)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/mcp.ex
+++ b/lib/claude_wrapper/commands/mcp.ex
@@ -60,7 +60,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def list(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ ["mcp", "list"] ++ scope_args(opts[:scope])
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -80,7 +80,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def get(%Config{} = config, name, opts \\ []) do
     args = Config.base_args(config) ++ ["mcp", "get", name] ++ scope_args(opts[:scope])
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -117,7 +117,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def add(%Config{} = config, name, command_or_url, command_args \\ [], opts \\ []) do
     args = Config.base_args(config) ++ add_args(name, command_or_url, command_args, opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -166,7 +166,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def add_json(%Config{} = config, name, json, opts \\ []) do
     args = Config.base_args(config) ++ add_json_args(name, json, opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -199,7 +199,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def add_from_desktop(%Config{} = config, name \\ nil, opts \\ []) do
     args = Config.base_args(config) ++ add_from_desktop_args(name, opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -226,7 +226,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
     args = Config.base_args(config) ++ ["mcp", "remove", name]
     args = args ++ scope_args(opts[:scope])
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -248,7 +248,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def serve(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ serve_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -278,7 +278,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def login(%Config{} = config, name, opts \\ []) do
     args = Config.base_args(config) ++ login_args(name, opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -299,7 +299,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def logout(%Config{} = config, name) do
     args = Config.base_args(config) ++ logout_args(name)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -316,7 +316,7 @@ defmodule ClaudeWrapper.Commands.Mcp do
   def reset_project_choices(%Config{} = config) do
     args = Config.base_args(config) ++ ["mcp", "reset-project-choices"]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/plugin.ex
+++ b/lib/claude_wrapper/commands/plugin.ex
@@ -50,7 +50,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
     args = Config.base_args(config) ++ ["plugin", "list", "--json"]
     args = if opts[:available], do: args ++ ["--available"], else: args
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} ->
         case Jason.decode(output) do
           {:ok, data} -> {:ok, data}
@@ -76,7 +76,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
     args = Config.base_args(config) ++ ["plugin", "install", plugin]
     args = args ++ scope_args(opts[:scope])
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -98,7 +98,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
   def uninstall(%Config{} = config, plugin, opts \\ []) do
     args = Config.base_args(config) ++ uninstall_args(plugin, opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -128,7 +128,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
     args = Config.base_args(config) ++ ["plugin", "enable", plugin]
     args = args ++ scope_args(opts[:scope])
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -149,7 +149,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
     args = args ++ scope_args(opts[:scope])
     args = if opts[:all], do: args ++ ["--all"], else: args
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -167,7 +167,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
     args = Config.base_args(config) ++ ["plugin", "update", plugin]
     args = args ++ scope_args(opts[:scope])
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -180,7 +180,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
   def validate(%Config{} = config, path) do
     args = Config.base_args(config) ++ ["plugin", "validate", path]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -207,7 +207,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
   def tag(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ tag_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -237,7 +237,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
   def details(%Config{} = config, plugin) do
     args = Config.base_args(config) ++ ["plugin", "details", plugin]
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
@@ -259,7 +259,7 @@ defmodule ClaudeWrapper.Commands.Plugin do
   def prune(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ prune_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/project.ex
+++ b/lib/claude_wrapper/commands/project.ex
@@ -54,7 +54,7 @@ defmodule ClaudeWrapper.Commands.Project do
   def purge(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ purge_args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/ultrareview.ex
+++ b/lib/claude_wrapper/commands/ultrareview.ex
@@ -44,7 +44,7 @@ defmodule ClaudeWrapper.Commands.Ultrareview do
   def execute(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ args(opts)
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/update.ex
+++ b/lib/claude_wrapper/commands/update.ex
@@ -26,7 +26,7 @@ defmodule ClaudeWrapper.Commands.Update do
   def update(%Config{} = config) do
     args = Config.base_args(config) ++ update_args()
 
-    case System.cmd(config.binary, args, Config.cmd_opts(config)) do
+    case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end

--- a/lib/claude_wrapper/commands/version.ex
+++ b/lib/claude_wrapper/commands/version.ex
@@ -15,7 +15,7 @@ defmodule ClaudeWrapper.Commands.Version do
   """
   @spec execute(Config.t()) :: {:ok, version_info()} | {:error, term()}
   def execute(%Config{} = config) do
-    case System.cmd(config.binary, ["--version"], Config.cmd_opts(config)) do
+    case Config.exec(config, ["--version"]) do
       {output, 0} ->
         raw = String.trim(output)
         {:ok, %{version: raw, raw: raw}}

--- a/lib/claude_wrapper/config.ex
+++ b/lib/claude_wrapper/config.ex
@@ -40,7 +40,10 @@ defmodule ClaudeWrapper.Config do
       with `mix claude_wrapper.install`.
     * `:working_dir` - Working directory for the subprocess
     * `:env` - List of `{key, value}` environment variable tuples
-    * `:timeout` - Command timeout in milliseconds
+    * `:timeout` - Command timeout in milliseconds (default `nil`: unbounded).
+      Applies to `query/2`, `Command.run/3`, `raw/2`, and the CLI subcommand
+      wrappers (via `exec/2`). Streaming (`ClaudeWrapper.stream/2`) is bounded
+      only by its per-frame idle deadline, not this whole-run value.
     * `:verbose` - Enable verbose output
     * `:debug` - Enable debug output
   """
@@ -101,5 +104,30 @@ defmodule ClaudeWrapper.Config do
     opts = if config.working_dir, do: [{:cd, config.working_dir} | opts], else: opts
     opts = if config.env != [], do: [{:env, config.env} | opts], else: opts
     opts
+  end
+
+  @doc """
+  Run a claude subcommand, bounded by `config.timeout`.
+
+  `System.cmd/3` has no timeout, so the CLI subcommand wrappers used it directly
+  and a wedged subcommand blocked the calling process forever, silently
+  discarding the configured `:timeout`. This runs the command in a `Task` and
+  bounds it with `Task.yield/2` + `Task.shutdown/1` (mirroring the one-shot
+  `Runner.Port` path), returning `System.cmd/3`'s `{output, exit_code}` on
+  completion. On timeout it kills the task and synthesizes `{message, 124}` (124
+  is the conventional timeout exit code), so a caller's existing `{_, code}`
+  clause surfaces it as a `command_failed` instead of hanging. A `nil` timeout
+  (the default) is unbounded, exactly as before. A spawn failure (missing
+  binary) still crashes the caller via the task link, as the direct call did.
+  """
+  @spec exec(t(), [String.t()]) :: {String.t(), non_neg_integer()}
+  def exec(%__MODULE__{} = config, args) do
+    opts = cmd_opts(config)
+    task = Task.async(fn -> System.cmd(config.binary, args, opts) end)
+
+    case Task.yield(task, config.timeout || :infinity) || Task.shutdown(task) do
+      {:ok, {output, code}} -> {output, code}
+      nil -> {"claude command timed out after #{config.timeout}ms", 124}
+    end
   end
 end

--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -90,8 +90,13 @@ defmodule ClaudeWrapper.DuplexIEx do
       |> Keyword.put(:config, config)
       |> Keyword.put(:extra_args, extra_args)
 
-    case DuplexSession.start_link(duplex_opts) do
+    # `owner: self()` is the IEx evaluator: the session monitors it and stops
+    # (reaping the claude subprocess) if the REPL is abandoned or the evaluator
+    # crashes. We then unlink so a session crash does not, in turn, take down the
+    # evaluator (which would discard the user's REPL bindings).
+    case DuplexSession.start_link(Keyword.put(duplex_opts, :owner, self())) do
       {:ok, pid} ->
+        Process.unlink(pid)
         printer = spawn_printer(pid)
         Process.put(@session_key, pid)
         Process.put(@printer_key, printer)

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -148,6 +148,12 @@ defmodule ClaudeWrapper.DuplexSession do
       UI: handler broadcasts the request to a LiveView, which
       surfaces approve/deny and answers asynchronously).
 
+  A **2-arity** handler that returns `:defer` cannot be answered (nothing can
+  learn the `request_id`), so it is logged and treated as a **deny** rather than
+  wedging the turn -- use the 3-arity form to defer. If a turn ever does hang
+  (a genuinely unresponsive CLI), `interrupt/1` is the reset path: it aborts the
+  in-flight turn so the session accepts `send/3` again.
+
   Arity is detected at call time so existing 2-arity callbacks keep
   working unchanged.
   """
@@ -188,7 +194,9 @@ defmodule ClaudeWrapper.DuplexSession do
           subscribers: %{pid() => reference()},
           on_permission: permission_handler(),
           exit_status: exit_status(),
-          exit_waiters: %{reference() => pid()}
+          exit_waiters: %{reference() => pid()},
+          owner_ref: reference() | nil,
+          deferred_permissions: MapSet.t(String.t())
         }
 
   defstruct [
@@ -197,12 +205,14 @@ defmodule ClaudeWrapper.DuplexSession do
     :config,
     :session_id,
     :on_permission,
+    :owner_ref,
     buffer: <<>>,
     pending_turn: nil,
     pending_control: %{},
     subscribers: %{},
     exit_status: :running,
-    exit_waiters: %{}
+    exit_waiters: %{},
+    deferred_permissions: MapSet.new()
   ]
 
   # --- Public API ------------------------------------------------------
@@ -493,6 +503,16 @@ defmodule ClaudeWrapper.DuplexSession do
     adapter_opts = Keyword.get(opts, :adapter_opts, [])
     open_opts = [config: config, args: args, owner: self()] ++ adapter_opts
 
+    # An optional lifecycle owner (e.g. the IEx evaluator driving DuplexIEx):
+    # monitor it and stop when it dies, so an abandoned session reaps its claude
+    # subprocess instead of orphaning it. Distinct from the adapter's `owner`
+    # above (the GenServer, which receives the port's stdio messages).
+    owner_ref =
+      case Keyword.get(opts, :owner) do
+        owner when is_pid(owner) -> Process.monitor(owner)
+        _ -> nil
+      end
+
     case adapter.open(open_opts) do
       {:ok, handle} ->
         {:ok,
@@ -500,7 +520,8 @@ defmodule ClaudeWrapper.DuplexSession do
            port: handle,
            adapter: adapter,
            config: config,
-           on_permission: on_permission
+           on_permission: on_permission,
+           owner_ref: owner_ref
          }}
 
       {:error, reason} ->
@@ -561,9 +582,22 @@ defmodule ClaudeWrapper.DuplexSession do
     {:reply, :ok, drop_subscriber(state, pid)}
   end
 
+  def handle_call({:respond_to_permission, _request_id, :defer}, _from, state) do
+    {:reply, {:error, Error.new(:cannot_defer_again)}, state}
+  end
+
   def handle_call({:respond_to_permission, request_id, decision}, _from, state) do
-    write_permission_response(state, request_id, decision)
-    {:reply, :ok, state}
+    if MapSet.member?(state.deferred_permissions, request_id) do
+      write_permission_response(state, request_id, decision)
+
+      {:reply, :ok,
+       %{state | deferred_permissions: MapSet.delete(state.deferred_permissions, request_id)}}
+    else
+      # A genuine no-op for a request_id the session has no record of: never
+      # deferred, or already answered / resolved by an interrupt. Previously this
+      # wrote a stray control_response unconditionally, contradicting the docs.
+      {:reply, :ok, state}
+    end
   end
 
   def handle_call(:interrupt, _from, %{port: nil} = state) do
@@ -600,6 +634,13 @@ defmodule ClaudeWrapper.DuplexSession do
     state = fail_pending(state, {:port_exit, reason})
     status = derive_exit_status({:port_exit, reason})
     {:stop, :normal, %{state | port: nil, exit_status: status}}
+  end
+
+  # The lifecycle owner (e.g. an abandoned IEx evaluator) died: stop so
+  # `terminate/2` closes the transport and reaps the claude subprocess, rather
+  # than leaving it running ownerless until BEAM exit.
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state) do
+    {:stop, :normal, state}
   end
 
   def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
@@ -698,11 +739,30 @@ defmodule ClaudeWrapper.DuplexSession do
       end
 
     case decision do
-      :defer -> :ok
-      _ -> write_permission_response(state, id, default_allow_input(decision, input))
-    end
+      :defer ->
+        if handler_arity(state.on_permission) == 3 do
+          # 3-arity handler deferred: track the id so respond_to_permission/3 can
+          # answer it later, and so an unknown/duplicate id is a genuine no-op.
+          %{state | deferred_permissions: MapSet.put(state.deferred_permissions, id)}
+        else
+          # A 2-arity handler never receives the request_id, so no process can
+          # answer -- the turn would wedge permanently with `alive?/1` still true.
+          # Deny so the turn resolves, and tell the host to use the 3-arity form.
+          Logger.warning(
+            "DuplexSession: a 2-arity on_permission returned :defer for " <>
+              "#{inspect(tool_name)}, but a 2-arity handler cannot receive the " <>
+              "request_id needed to answer it later -- the turn would wedge. " <>
+              "Denying. Use a 3-arity (tool_name, input, request_id) handler to defer."
+          )
 
-    state
+          write_permission_response(state, id, {:deny, "2-arity on_permission cannot defer"})
+          state
+        end
+
+      _ ->
+        write_permission_response(state, id, default_allow_input(decision, input))
+        state
+    end
   end
 
   # Reply to an outbound control_request we sent (e.g. interrupt).
@@ -740,7 +800,9 @@ defmodule ClaudeWrapper.DuplexSession do
     result = Result.from_json(msg)
     broadcast(state, {:result, result})
     GenServer.reply(from, {:ok, result})
-    %{state | pending_turn: nil}
+    # The turn is over; any still-tracked deferred permission ids are moot, so a
+    # late respond_to_permission/3 for this turn becomes a documented no-op.
+    %{state | pending_turn: nil, deferred_permissions: MapSet.new()}
   end
 
   defp dispatch(%{"type" => "result"} = msg, state) do
@@ -776,6 +838,11 @@ defmodule ClaudeWrapper.DuplexSession do
       {:arity, 3} -> handler.(tool_name, input, request_id)
       {:arity, 2} -> handler.(tool_name, input)
     end
+  end
+
+  defp handler_arity(handler) do
+    {:arity, arity} = :erlang.fun_info(handler, :arity)
+    arity
   end
 
   defp accumulate(%{pending_turn: {from, events}} = state, msg) do

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -645,6 +645,15 @@ defmodule ClaudeWrapper.Query do
   Uses a Port with `:line` mode to read NDJSON output line-by-line.
   The port is opened when the stream is consumed and closed when
   the stream terminates.
+
+  A clean run ends with a terminal `%StreamEvent{type: "result"}`. If the stream
+  halts without one -- an idle timeout (`Config.timeout` is *not* a whole-run
+  bound here; only the per-frame idle deadline applies), a non-zero exit, or a
+  spawn failure -- the stream ends with a terminal
+  `%StreamEvent{type: "error", data: %{"error" => "stream_truncated"}}` so the
+  truncation is observable. Note the default runner orphans a stalled
+  subprocess; use the `ClaudeWrapper.Runner.Forcola` runner for leak-free
+  termination.
   """
   @spec stream(t(), Config.t()) :: Enumerable.t()
   def stream(%__MODULE__{} = query, %Config{} = config) do
@@ -661,12 +670,42 @@ defmodule ClaudeWrapper.Query do
 
     config.binary
     |> Runner.impl().stream_lines(args, stream_opts(config), nil)
-    |> Stream.flat_map(fn line ->
-      case StreamEvent.parse(line) do
-        {:ok, event} -> [event]
-        {:error, _} -> []
-      end
-    end)
+    |> Stream.transform(
+      fn -> false end,
+      fn line, saw_result? ->
+        case StreamEvent.parse(line) do
+          {:ok, %StreamEvent{type: "result"} = event} -> {[event], true}
+          {:ok, event} -> {[event], saw_result?}
+          {:error, _} -> {[], saw_result?}
+        end
+      end,
+      # A clean stream-json run ends with a terminal `result` event. If the
+      # stream halts without one -- an idle timeout, a non-zero/failed exit, or a
+      # spawn failure -- the default runner ends the Stream silently, so a caller
+      # cannot tell a truncated run from a clean one. Append an explicit terminal
+      # `error` event so the truncation is observable (the Forcola runner already
+      # raises on non-clean termination; this aligns the default path).
+      fn
+        true -> {[], true}
+        false -> {[truncation_event()], false}
+      end,
+      fn _acc -> :ok end
+    )
+  end
+
+  defp truncation_event do
+    %StreamEvent{
+      type: "error",
+      data: %{
+        "error" => "stream_truncated",
+        "message" =>
+          "the stream ended without a terminal `result` event (idle timeout, " <>
+            "non-zero exit, or spawn failure); the run may be incomplete. The " <>
+            "default runner also orphans a stalled subprocess -- use the Forcola " <>
+            "runner for leak-free termination."
+      },
+      raw: nil
+    }
   end
 
   defp stream_opts(%Config{working_dir: dir, env: env}) do

--- a/test/claude_wrapper/duplex_session_test.exs
+++ b/test/claude_wrapper/duplex_session_test.exs
@@ -326,33 +326,83 @@ defmodule ClaudeWrapper.DuplexSessionTest do
       end
     end
 
-    test "defer callback does not crash; respond_to_permission/3 finishes the cycle" do
+    test "a 3-arity :defer tracks the request_id; respond_to_permission/3 answers and clears it" do
       pid = start_with_fake_claude()
+      parent = self()
 
       :sys.replace_state(pid, fn state ->
-        %{state | on_permission: fn _tool, _input -> :defer end}
+        %{state | on_permission: fn _tool, _input, _id -> send(parent, :asked) && :defer end}
       end)
 
       try do
         inject(pid, %{
           type: "control_request",
           request_id: "deferred-1",
-          request: %{
-            subtype: "can_use_tool",
-            tool_name: "Bash",
-            input: %{}
-          }
+          request: %{subtype: "can_use_tool", tool_name: "Bash", input: %{}}
         })
 
-        # If defer crashed the GenServer, this call would error.
-        assert :ok = DuplexSession.respond_to_permission(pid, "deferred-1", :allow)
+        assert_receive :asked, 1_000
+        assert MapSet.member?(:sys.get_state(pid).deferred_permissions, "deferred-1")
 
-        # Calling respond_to_permission with :defer is rejected.
+        # Answering a tracked id succeeds and clears it.
+        assert :ok = DuplexSession.respond_to_permission(pid, "deferred-1", :allow)
+        refute MapSet.member?(:sys.get_state(pid).deferred_permissions, "deferred-1")
+
+        # Answering with :defer is rejected.
         assert {:error, %ClaudeWrapper.Error{kind: :cannot_defer_again}} =
                  DuplexSession.respond_to_permission(pid, "deferred-1", :defer)
       after
         DuplexSession.stop(pid)
       end
+    end
+
+    test "a 2-arity on_permission returning :defer is denied, not tracked (no wedged turn)" do
+      pid = start_with_fake_claude()
+      parent = self()
+
+      :sys.replace_state(pid, fn state ->
+        %{state | on_permission: fn _tool, _input -> send(parent, :asked) && :defer end}
+      end)
+
+      try do
+        inject(pid, %{
+          type: "control_request",
+          request_id: "two-arity-defer",
+          request: %{subtype: "can_use_tool", tool_name: "Bash", input: %{}}
+        })
+
+        assert_receive :asked, 1_000
+        # A 2-arity handler cannot be answered later, so :defer is downgraded to
+        # a deny and the id is NOT tracked -- the turn resolves rather than wedging.
+        refute MapSet.member?(:sys.get_state(pid).deferred_permissions, "two-arity-defer")
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "respond_to_permission/3 is a no-op for an unknown request_id" do
+      pid = start_with_fake_claude()
+
+      try do
+        assert :ok = DuplexSession.respond_to_permission(pid, "never-deferred", :allow)
+        assert MapSet.size(:sys.get_state(pid).deferred_permissions) == 0
+      after
+        DuplexSession.stop(pid)
+      end
+    end
+
+    test "the session stops (reaping its subprocess) when its :owner dies (#210)" do
+      config = Config.new(binary: System.find_executable("cat"))
+      owner = spawn(fn -> Process.sleep(:infinity) end)
+
+      {:ok, pid} =
+        DuplexSession.start_link(config: config, args_override: [], owner: owner)
+
+      ref = Process.monitor(pid)
+      Process.exit(owner, :kill)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+      refute Process.alive?(pid)
     end
 
     test "3-arity callback receives request_id" do

--- a/test/claude_wrapper/runner_config_test.exs
+++ b/test/claude_wrapper/runner_config_test.exs
@@ -1,0 +1,113 @@
+defmodule ClaudeWrapper.RunnerConfigTest do
+  # Covers the runner/config-correctness fixes: config.timeout enforcement on the
+  # subcommand path (Config.exec/2, #204), raw/2 routing through the configured
+  # Runner (#204), and Query.stream/2's terminal truncation event (#209).
+  #
+  # async: false -- the raw/2 and stream tests swap the global `:runner`.
+  use ExUnit.Case, async: false
+
+  alias ClaudeWrapper.{Config, Error, Query}
+
+  defmodule TimeoutRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:error, :timeout}
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout), do: []
+  end
+
+  defmodule OkRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"out\n", 0}}
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout), do: []
+  end
+
+  defmodule ResultRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"", 0}}
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout) do
+      [
+        ~s({"type":"system","subtype":"init","session_id":"s1"}),
+        ~s({"type":"assistant","message":{}}),
+        ~s({"type":"result","result":"done"})
+      ]
+    end
+  end
+
+  defmodule TruncatedRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"", 0}}
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout) do
+      # no terminal "result" event -> a stalled/truncated run
+      [
+        ~s({"type":"system","subtype":"init","session_id":"s1"}),
+        ~s({"type":"assistant","message":{}})
+      ]
+    end
+  end
+
+  setup do
+    prev = Application.get_env(:claude_wrapper, :runner)
+
+    on_exit(fn ->
+      if prev,
+        do: Application.put_env(:claude_wrapper, :runner, prev),
+        else: Application.delete_env(:claude_wrapper, :runner)
+    end)
+
+    :ok
+  end
+
+  describe "Config.exec/2 (subcommand timeout, #204)" do
+    test "returns {output, code} for a command that completes within the timeout" do
+      config = Config.new(binary: System.find_executable("printf"), timeout: 5_000)
+      assert {"hello", 0} = Config.exec(config, ["hello"])
+    end
+
+    test "bounds a slow command by config.timeout and synthesizes a timeout result" do
+      config = Config.new(binary: System.find_executable("sleep"), timeout: 50)
+      assert {message, 124} = Config.exec(config, ["2"])
+      assert message =~ "timed out"
+    end
+  end
+
+  describe "raw/2 (routes through the configured Runner, #204)" do
+    test "maps a runner timeout to a typed Error (no longer bypasses the runner)" do
+      Application.put_env(:claude_wrapper, :runner, TimeoutRunner)
+      assert {:error, %Error{kind: :timeout}} = ClaudeWrapper.raw(["config", "list"])
+    end
+
+    test "trims a successful runner result" do
+      Application.put_env(:claude_wrapper, :runner, OkRunner)
+      assert {:ok, "out"} = ClaudeWrapper.raw(["config", "list"])
+    end
+  end
+
+  describe "Query.stream/2 truncation signal (#209)" do
+    defp stream_events(runner) do
+      Application.put_env(:claude_wrapper, :runner, runner)
+      "hi" |> Query.new() |> Query.stream(Config.new()) |> Enum.to_list()
+    end
+
+    test "a clean run (ending with a result event) emits no truncation event" do
+      events = stream_events(ResultRunner)
+
+      assert Enum.any?(events, &(&1.type == "result"))
+      refute Enum.any?(events, &(&1.type == "error" and &1.data["error"] == "stream_truncated"))
+    end
+
+    test "a truncated run (no result event) ends with a terminal truncation error event" do
+      events = stream_events(TruncatedRunner)
+      last = List.last(events)
+
+      assert last.type == "error"
+      assert last.data["error"] == "stream_truncated"
+    end
+  end
+end


### PR DESCRIPTION
The first "crank through the wrapper backlog" chunk: the runner/config-correctness bugs (all medium priority, no p1s remain). These are the process/timeout behaviors the fleet path relies on.

| # | Fix |
|---|---|
| **#204** | `config.timeout` was silently discarded outside the two one-shot Runner paths. **`raw/2`** now routes through the configured Runner (not `System.cmd` directly) → honors `config.timeout` **and** the Forcola process-group kill. The **37 CLI subcommand** call sites now use a new **`Config.exec/2`** that bounds `System.cmd` in a `Task` (`yield`+`shutdown`, mirroring `Runner.Port`), synthesizing a `{msg, 124}` timeout result so a wedged subcommand can't block the BEAM forever. Streaming's whole-run bound documented as out of scope. |
| **#209** | `Query.stream/2` halted **silently** on idle-timeout / non-zero exit / spawn failure. A clean stream-json run ends with a `result` event; when it doesn't, the stream now ends with a terminal `%StreamEvent{type: "error", data: %{"error" => "stream_truncated"}}`. Uniform across runners (Forcola already raises), **additive** (clean runs unchanged). |
| **#210** | `DuplexIEx` orphaned the claude subprocess when the IEx evaluator died. `DuplexSession` now accepts an **`:owner`**, monitors it, and stops (terminate reaps the subprocess) on its death; `DuplexIEx` passes `owner: self()` and **unlinks** (so a session crash no longer respawns the evaluator). |
| **#211** | A 2-arity `on_permission` returning `:defer` **wedged the turn permanently**. Now logged + downgraded to a deny. Deferred request ids are tracked, so `respond_to_permission/3` is a genuine **no-op** for an unknown id (was writing a stray `control_response`), and answering with `:defer` is rejected. `interrupt/1` documented as the reset path. |

## Scope note
The `Config.exec/2` timeout synthesizes a `{msg, 124}` result (surfaced as `command_failed` with exit 124) rather than a distinct `:timeout` error kind — the thin, contract-preserving choice across 37 uniform call sites (all of which already have a `{_, code}` clause, verified). Fixes the real bug (indefinite block); the exit-code semantics can be refined later if wanted.

## Gate
`format`, `compile --warnings-as-errors`, `credo --strict`, `docs --warnings-as-errors`, `dialyzer` (0), `test` **654 passed / 40 excluded** (+9: covers each fix, incl. a `cat`-loopback owner-reap test and fake-runner stream/raw tests).

Closes #204, closes #209, closes #210, closes #211