### PR TITLE
fix!: prune/repair CLI-contract drift — mcp, agents, bundled install, auth classifier (#205-208)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,9 +99,9 @@ ClaudeWrapper.Worktrees  # git worktree introspection
 ```
 ClaudeWrapper.Command                # Behaviour for CLI commands
 ClaudeWrapper.Commands.Auth          # auth login (email/mode/sso) / logout / status / setup-token
-ClaudeWrapper.Commands.Agents        # list configured agents
+ClaudeWrapper.Commands.Agents        # list active background agent sessions (agents --json)
 ClaudeWrapper.Commands.Doctor        # claude doctor
-ClaudeWrapper.Commands.Mcp           # mcp add / add-json / add-from-desktop / serve / login / logout / list / get / remove
+ClaudeWrapper.Commands.Mcp           # mcp add / add-json / add-from-desktop / serve / list / get / remove
 ClaudeWrapper.Commands.Plugin        # plugin install/uninstall/enable/disable/update/validate/tag/details/prune
 ClaudeWrapper.Commands.Marketplace   # marketplace add/remove/list/update
 ClaudeWrapper.Commands.AutoMode      # auto-mode config / defaults / critique

--- a/README.md
+++ b/README.md
@@ -547,8 +547,8 @@ is present. A `DuplexSession` can also select the adapter per session with
 | Module | Description |
 |---|---|
 | `ClaudeWrapper.Commands.Auth` | Auth management (login modes, status, setup-token) |
-| `ClaudeWrapper.Commands.Agents` | List configured agents |
-| `ClaudeWrapper.Commands.Mcp` | MCP server management (add/list/get/remove/serve/login/logout) |
+| `ClaudeWrapper.Commands.Agents` | List active background agent sessions (`agents --json`) |
+| `ClaudeWrapper.Commands.Mcp` | MCP server management (add/add-json/add-from-desktop/list/get/remove/serve) |
 | `ClaudeWrapper.Commands.Plugin` | Plugin install/enable/disable/update/tag/details/prune |
 | `ClaudeWrapper.Commands.Marketplace` | Marketplace add/remove/list/update |
 | `ClaudeWrapper.Commands.AutoMode` | auto-mode config/defaults/critique |

--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -222,12 +222,14 @@ defmodule ClaudeWrapper do
   end
 
   @doc """
-  List configured agents.
+  List active background agent sessions (`claude agents --json`).
 
-  Returns a list of agent maps with `:name` and `:model` keys.
+  Returns the decoded JSON array of active sessions (each a raw, string-keyed
+  map). See `ClaudeWrapper.Commands.Agents`.
 
   ## Options
 
+    * `:all` - include completed sessions (`--all`)
     * `:setting_sources` - comma-separated setting sources (e.g. `"user,project"`)
 
   """

--- a/lib/claude_wrapper/auth.ex
+++ b/lib/claude_wrapper/auth.ex
@@ -293,21 +293,44 @@ defmodule ClaudeWrapper.Auth do
     mentions_provider? and mentions_auth_signal?
   end
 
+  # NOTE (#208): needles are unanchored `String.contains?`, and the classifier
+  # runs on a stderr_to_stdout blob, so bare tokens caught non-auth failures --
+  # `"quota"` matched EDQUOT "disk quota exceeded", `"expired"` matched "SSL
+  # certificate expired", bare `"401"`/`"403"`/`"429"` matched any output. Per the
+  # module's "prefer to miss over misclassify" contract, the highest-risk needles
+  # now require adjacent context; the broader word tokens (rate limit,
+  # unauthorized, invalid api key, ...) stay as-is.
   defp rate_limit?(combined) do
-    contains_any?(combined, ["rate limit", "too many requests", "429", "quota"])
+    contains_any?(combined, [
+      "rate limit",
+      "too many requests",
+      "http 429",
+      "status 429",
+      "usage limit",
+      "usage quota"
+    ])
   end
 
   defp expired?(combined) do
-    contains_any?(combined, ["expired", "session has expired", "token expired"])
+    contains_any?(combined, [
+      "session has expired",
+      "session expired",
+      "token expired",
+      "token has expired",
+      "credentials expired",
+      "api key expired"
+    ])
   end
 
   defp invalid_credentials?(combined) do
     contains_any?(combined, [
       "invalid api key",
       "invalid token",
-      "401",
+      "http 401",
+      "status 401",
       "unauthorized",
-      "403",
+      "http 403",
+      "status 403",
       "forbidden"
     ])
   end

--- a/lib/claude_wrapper/bundled.ex
+++ b/lib/claude_wrapper/bundled.ex
@@ -1,7 +1,10 @@
 defmodule ClaudeWrapper.Bundled do
-  # The claude CLI version this release pins the bundled binary to. Bump
-  # in lockstep with upstream CLI releases we have validated against.
-  @pinned_version "2.0.0"
+  # The MINIMUM claude CLI version the bundled binary must satisfy -- a floor,
+  # not an exact pin. The upstream installer always fetches the current stable
+  # CLI (it takes no version argument), so an exact-match assertion failed on
+  # every healthy machine once the installer moved past this value; a floor
+  # accepts the installed CLI as long as it is at least this validated version.
+  @minimum_version "2.0.0"
 
   @moduledoc """
   Opt-in bundled-binary resolution for the `claude` CLI.
@@ -26,26 +29,26 @@ defmodule ClaudeWrapper.Bundled do
 
       mix claude_wrapper.install      # or: ClaudeWrapper.Bundled.ensure!()
 
-  `ensure/0` installs only when the binary is missing or its version does
-  not match `pinned_version/0`.
+  `ensure/0` installs only when the binary is missing or its version is
+  below `minimum_version/0`.
 
-  ## Version pin
+  ## Minimum version
 
-  The pinned version is `#{@pinned_version}`.
-  `install/0` verifies the freshly-installed binary reports that version;
-  it does not attempt to coerce an arbitrary version out of the upstream
-  installer.
+  The bundled binary must be at least `#{@minimum_version}`.
+  `install/0` fetches the current stable CLI and verifies it reports a
+  version `>=` this floor; it does not coerce an exact version out of the
+  upstream installer (which takes no version argument).
   """
 
   alias ClaudeWrapper.{CliVersion, Error}
 
-  # Anthropic's official installer (POSIX shell). Piped to `sh` with a
-  # temp HOME so it does not touch the user's real install.
+  # Anthropic's official installer (POSIX shell). Downloaded to a temp file
+  # and run with a temp HOME so it does not touch the user's real install.
   @install_script_url "https://claude.ai/install.sh"
 
-  @doc "The pinned CLI version the bundled binary is expected to be."
-  @spec pinned_version() :: String.t()
-  def pinned_version, do: @pinned_version
+  @doc "The minimum CLI version the bundled binary must satisfy (a floor)."
+  @spec minimum_version() :: String.t()
+  def minimum_version, do: @minimum_version
 
   @doc """
   Absolute path to the bundled binary, `priv/bin/claude`.
@@ -83,7 +86,7 @@ defmodule ClaudeWrapper.Bundled do
   end
 
   @doc """
-  Ensure a bundled binary matching `pinned_version/0` is installed.
+  Ensure a bundled binary satisfying `minimum_version/0` is installed.
 
   Installs when the binary is missing or reports a different version;
   otherwise a no-op. Returns `{:ok, path}` or `{:error, %Error{}}`.
@@ -139,7 +142,15 @@ defmodule ClaudeWrapper.Bundled do
 
   defp up_to_date? do
     case {installed?(), installed_version()} do
-      {true, %CliVersion{} = v} -> CliVersion.to_string(v) == @pinned_version
+      {true, %CliVersion{} = v} -> meets_minimum?(v)
+      _ -> false
+    end
+  end
+
+  # The installed CLI satisfies the floor (installed >= @minimum_version).
+  defp meets_minimum?(%CliVersion{} = installed) do
+    case CliVersion.parse(@minimum_version) do
+      {:ok, minimum} -> CliVersion.check_version(installed, minimum) == :ok
       _ -> false
     end
   end
@@ -156,12 +167,21 @@ defmodule ClaudeWrapper.Bundled do
 
   defp run_installer(tmp_home) do
     env = [{"HOME", tmp_home}]
-    cmd = "curl -fsSL #{@install_script_url} | sh"
+    script = Path.join(tmp_home, "install.sh")
 
-    case System.cmd("sh", ["-c", cmd], env: env, stderr_to_stdout: true) do
-      {_out, 0} ->
-        locate_installed(tmp_home)
-
+    # Download to a file FIRST, then run it -- do not `curl ... | sh`. A POSIX
+    # pipeline exits with `sh`'s status, so a curl-side failure (404 under -f,
+    # DNS/TLS error, mid-stream reset, curl missing) would exit 0 with sh having
+    # run on empty/partial stdin: fail-open, with curl's stderr discarded.
+    # Checking curl's own exit code makes a download failure a real error.
+    with {_out, 0} <-
+           System.cmd("curl", ["-fsSL", "-o", script, @install_script_url],
+             env: env,
+             stderr_to_stdout: true
+           ),
+         {_out, 0} <- System.cmd("sh", [script], env: env, stderr_to_stdout: true) do
+      locate_installed(tmp_home)
+    else
       {out, code} ->
         {:error,
          Error.new(:command_failed,
@@ -234,12 +254,12 @@ defmodule ClaudeWrapper.Bundled do
   defp check_pinned(version_output, _dest) do
     case CliVersion.parse(version_output) do
       {:ok, v} ->
-        if CliVersion.to_string(v) == @pinned_version do
+        if meets_minimum?(v) do
           :ok
         else
           {:error,
            Error.new(:version_mismatch,
-             reason: {:expected, @pinned_version, :got, CliVersion.to_string(v)}
+             reason: {:minimum, @minimum_version, :got, CliVersion.to_string(v)}
            )}
         end
 

--- a/lib/claude_wrapper/commands/agents.ex
+++ b/lib/claude_wrapper/commands/agents.ex
@@ -1,54 +1,60 @@
 defmodule ClaudeWrapper.Commands.Agents do
   @moduledoc """
-  `claude agents` command -- lists configured agents.
+  `claude agents` command -- lists active background agent sessions.
+
+  Bare `claude agents` is an interactive, TTY-oriented view; the scripting
+  surface is `claude agents --json`, which "Print[s] active sessions as a JSON
+  array and exit[s] ... does not require a TTY". This module uses `--json` and
+  decodes that array, so it returns **active sessions** (not configured agents).
+  Each element is the CLI's raw session map (string keys).
 
   ## Usage
 
       config = ClaudeWrapper.Config.new()
 
-      # Parsed list of agent names and models
-      {:ok, agents} = ClaudeWrapper.Commands.Agents.list(config)
+      # Active background sessions (decoded JSON array)
+      {:ok, sessions} = ClaudeWrapper.Commands.Agents.list(config)
 
-      # Raw CLI output
-      {:ok, output} = ClaudeWrapper.Commands.Agents.execute(config)
+      # Include completed sessions too
+      {:ok, sessions} = ClaudeWrapper.Commands.Agents.list(config, all: true)
 
-      # Restrict which setting sources are loaded
-      {:ok, agents} = ClaudeWrapper.Commands.Agents.list(config, setting_sources: "user,project")
+      # Raw --json output string
+      {:ok, json} = ClaudeWrapper.Commands.Agents.execute(config)
   """
 
   alias ClaudeWrapper.{Config, Error}
 
-  @type agent :: %{
-          name: String.t(),
-          model: String.t()
-        }
+  @typedoc "A background-agent session as reported by `claude agents --json` (raw, string-keyed)."
+  @type session :: map()
 
   @doc """
-  Run `claude agents` and return the parsed agent list.
+  Run `claude agents --json` and return the decoded array of active sessions.
 
   ## Options
 
+    * `:all` - include completed sessions, not just active ones (`--all`)
     * `:setting_sources` - comma-separated setting sources to load
       (e.g. `"user,project"`)
-
-  ## Examples
-
-      {:ok, agents} = ClaudeWrapper.Commands.Agents.list(config)
-      # => {:ok, [%{name: "Explore", model: "haiku"}, ...]}
-
   """
-  @spec list(Config.t(), keyword()) :: {:ok, [agent()]} | {:error, term()}
+  @spec list(Config.t(), keyword()) :: {:ok, [session()]} | {:error, term()}
   def list(%Config{} = config, opts \\ []) do
     args = Config.base_args(config) ++ list_args(opts)
 
     case Config.exec(config, args) do
-      {output, 0} -> {:ok, parse_agents(output)}
-      {output, code} -> {:error, Error.command_failed(code, output)}
+      {output, 0} ->
+        case Jason.decode(output) do
+          {:ok, sessions} when is_list(sessions) -> {:ok, sessions}
+          {:ok, _other} -> {:error, Error.json(:not_an_array, output)}
+          {:error, reason} -> {:error, Error.json(reason, output)}
+        end
+
+      {output, code} ->
+        {:error, Error.command_failed(code, output)}
     end
   end
 
   @doc """
-  Run `claude agents` and return the raw output string.
+  Run `claude agents --json` and return the raw output string.
   """
   @spec execute(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def execute(%Config{} = config, opts \\ []) do
@@ -63,23 +69,12 @@ defmodule ClaudeWrapper.Commands.Agents do
   @doc false
   @spec list_args(keyword()) :: [String.t()]
   def list_args(opts) do
+    args = ["agents", "--json"]
+    args = if opts[:all], do: args ++ ["--all"], else: args
+
     case Keyword.get(opts, :setting_sources) do
-      nil -> ["agents"]
-      sources -> ["agents", "--setting-sources", sources]
+      nil -> args
+      sources -> args ++ ["--setting-sources", sources]
     end
-  end
-
-  defp parse_agents(output) do
-    output
-    |> String.split("\n")
-    |> Enum.reduce([], fn line, acc ->
-      line = String.trim(line)
-
-      case Regex.run(~r/^(.+?)\s+·\s+(.+)$/, line) do
-        [_, name, model] -> [%{name: String.trim(name), model: String.trim(model)} | acc]
-        _ -> acc
-      end
-    end)
-    |> Enum.reverse()
   end
 end

--- a/lib/claude_wrapper/commands/mcp.ex
+++ b/lib/claude_wrapper/commands/mcp.ex
@@ -50,15 +50,12 @@ defmodule ClaudeWrapper.Commands.Mcp do
   List configured MCP servers.
 
   `claude mcp list` emits human-readable text (it has no JSON mode), so
-  this returns the raw, trimmed output rather than structured data.
-
-  ## Options
-
-    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`).
+  this returns the raw, trimmed output rather than structured data. The
+  subcommand takes no `--scope` (it lists every scope).
   """
-  @spec list(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
-  def list(%Config{} = config, opts \\ []) do
-    args = Config.base_args(config) ++ ["mcp", "list"] ++ scope_args(opts[:scope])
+  @spec list(Config.t()) :: {:ok, String.t()} | {:error, term()}
+  def list(%Config{} = config) do
+    args = Config.base_args(config) ++ ["mcp", "list"]
 
     case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
@@ -70,15 +67,12 @@ defmodule ClaudeWrapper.Commands.Mcp do
   Get details for a specific MCP server.
 
   `claude mcp get` emits human-readable text (it has no JSON mode), so
-  this returns the raw, trimmed output rather than structured data.
-
-  ## Options
-
-    * `:scope` - Configuration scope (`:local`, `:user`, or `:project`).
+  this returns the raw, trimmed output rather than structured data. The
+  subcommand takes only the server name (no `--scope`).
   """
-  @spec get(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
-  def get(%Config{} = config, name, opts \\ []) do
-    args = Config.base_args(config) ++ ["mcp", "get", name] ++ scope_args(opts[:scope])
+  @spec get(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def get(%Config{} = config, name) do
+    args = Config.base_args(config) ++ ["mcp", "get", name]
 
     case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
@@ -185,19 +179,17 @@ defmodule ClaudeWrapper.Commands.Mcp do
   @doc """
   Import MCP servers from Claude Desktop (Mac and WSL only).
 
-  The installed CLI (`claude mcp add-from-claude-desktop`) takes no name
-  argument; `name` is accepted for forward compatibility and appended as a
-  positional only when non-nil.
+  `claude mcp add-from-claude-desktop` takes no name argument -- it imports
+  all Desktop servers -- so this accepts only options.
 
   ## Options
 
     * `:scope` - Configuration scope (`:local`, `:user`, or `:project`). Emits
       `--scope`.
   """
-  @spec add_from_desktop(Config.t(), String.t() | nil, keyword()) ::
-          {:ok, String.t()} | {:error, term()}
-  def add_from_desktop(%Config{} = config, name \\ nil, opts \\ []) do
-    args = Config.base_args(config) ++ add_from_desktop_args(name, opts)
+  @spec add_from_desktop(Config.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def add_from_desktop(%Config{} = config, opts \\ []) do
+    args = Config.base_args(config) ++ add_from_desktop_args(opts)
 
     case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
@@ -206,11 +198,9 @@ defmodule ClaudeWrapper.Commands.Mcp do
   end
 
   @doc false
-  @spec add_from_desktop_args(String.t() | nil, keyword()) :: [String.t()]
-  def add_from_desktop_args(name, opts) do
-    positional = if name, do: [name], else: []
-
-    ["mcp", "add-from-claude-desktop"] ++ scope_args(opts[:scope]) ++ positional
+  @spec add_from_desktop_args(keyword()) :: [String.t()]
+  def add_from_desktop_args(opts) do
+    ["mcp", "add-from-claude-desktop"] ++ scope_args(opts[:scope])
   end
 
   @doc """
@@ -264,50 +254,11 @@ defmodule ClaudeWrapper.Commands.Mcp do
     ["mcp", "serve"] ++ flags
   end
 
-  @doc """
-  Authenticate with an MCP server (HTTP, SSE, or claude.ai connector).
-
-  Wraps `claude mcp login <name>`.
-
-  ## Options
-
-    * `:no_browser` - Print the authorization URL instead of opening a browser
-      (`--no-browser`, boolean), for SSH/headless sessions.
-  """
-  @spec login(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
-  def login(%Config{} = config, name, opts \\ []) do
-    args = Config.base_args(config) ++ login_args(name, opts)
-
-    case Config.exec(config, args) do
-      {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, Error.command_failed(code, output)}
-    end
-  end
-
-  @doc false
-  @spec login_args(String.t(), keyword()) :: [String.t()]
-  def login_args(name, opts) do
-    ["mcp", "login"] ++ bool_flag(opts[:no_browser], "--no-browser") ++ [name]
-  end
-
-  @doc """
-  Clear stored OAuth credentials for an MCP server.
-
-  Wraps `claude mcp logout <name>`.
-  """
-  @spec logout(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
-  def logout(%Config{} = config, name) do
-    args = Config.base_args(config) ++ logout_args(name)
-
-    case Config.exec(config, args) do
-      {output, 0} -> {:ok, String.trim(output)}
-      {output, code} -> {:error, Error.command_failed(code, output)}
-    end
-  end
-
-  @doc false
-  @spec logout_args(String.t()) :: [String.t()]
-  def logout_args(name), do: ["mcp", "logout", name]
+  # `claude mcp login` / `logout` were removed from the CLI (2.1.x enumerates
+  # only add/add-from-claude-desktop/add-json/get/list/remove/reset-project-
+  # choices/serve); MCP OAuth now happens interactively via `/mcp`. The wrappers
+  # were guaranteed `:command_failed` against the current CLI, so they are dropped
+  # rather than kept as dead, misleading surface.
 
   @doc """
   Reset project choices for MCP servers.

--- a/lib/mix/tasks/claude_wrapper.install.ex
+++ b/lib/mix/tasks/claude_wrapper.install.ex
@@ -2,8 +2,8 @@ defmodule Mix.Tasks.ClaudeWrapper.Install do
   @shortdoc "Install the pinned bundled claude binary into priv/bin"
 
   @moduledoc """
-  Install the opt-in bundled `claude` CLI, pinned to
-  `ClaudeWrapper.Bundled.pinned_version/0`, into the package's `priv/bin/`.
+  Install the opt-in bundled `claude` CLI (current stable, verified `>=`
+  `ClaudeWrapper.Bundled.minimum_version/0`) into the package's `priv/bin/`.
 
       mix claude_wrapper.install
 
@@ -20,7 +20,9 @@ defmodule Mix.Tasks.ClaudeWrapper.Install do
 
     case ClaudeWrapper.Bundled.ensure() do
       {:ok, path} ->
-        Mix.shell().info("claude #{ClaudeWrapper.Bundled.pinned_version()} installed at #{path}")
+        Mix.shell().info(
+          "claude installed at #{path} (>= #{ClaudeWrapper.Bundled.minimum_version()})"
+        )
 
       {:error, error} ->
         Mix.raise("bundled install failed: #{Exception.message(error)}")

--- a/test/claude_wrapper/auth_test.exs
+++ b/test/claude_wrapper/auth_test.exs
@@ -191,7 +191,17 @@ defmodule ClaudeWrapper.AuthTest do
     test "rate limit takes precedence over invalid credentials wording" do
       assert Auth.classify_failure(1, "", "Rate limit exceeded. Please wait.") == :rate_limit
       assert Auth.classify_failure(1, "", "HTTP 429 Too Many Requests") == :rate_limit
-      assert Auth.classify_failure(1, "", "quota exceeded for this account") == :rate_limit
+      assert Auth.classify_failure(1, "", "usage quota exceeded for this account") == :rate_limit
+    end
+
+    test "bare disk-quota / SSL-expired / stray HTTP codes no longer misclassify as auth (#208)" do
+      # EDQUOT "disk quota" must not read as a rate limit (only "usage quota" does).
+      refute Auth.classify_failure(1, "", "write failed: disk quota exceeded") == :rate_limit
+      # "SSL certificate expired" must not read as an expired credential.
+      refute Auth.classify_failure(1, "", "SSL certificate has expired") == :expired
+      # A bare 401/403 in arbitrary output must not read as invalid credentials.
+      refute Auth.classify_failure(1, "", "downstream returned 403 for /assets/401.png") ==
+               :invalid_credentials
     end
 
     test "provider error when bedrock/vertex appears alongside an auth signal" do

--- a/test/claude_wrapper/bundled_test.exs
+++ b/test/claude_wrapper/bundled_test.exs
@@ -3,17 +3,17 @@ defmodule ClaudeWrapper.BundledTest do
 
   alias ClaudeWrapper.{Bundled, Config}
 
-  describe "path/0 and pinned_version/0 (pure)" do
+  describe "path/0 and minimum_version/0 (pure)" do
     test "path is an absolute priv/bin/claude under the app" do
       path = Bundled.path()
       assert Path.type(path) == :absolute
       assert String.ends_with?(path, Path.join(["priv", "bin", "claude"]))
     end
 
-    test "pinned_version is a concrete version string" do
+    test "minimum_version is a concrete version string" do
       # The CLI reports the version as the first token of --version output.
       assert {:ok, _} =
-               ClaudeWrapper.CliVersion.parse("#{Bundled.pinned_version()} (Claude Code)")
+               ClaudeWrapper.CliVersion.parse("#{Bundled.minimum_version()} (Claude Code)")
     end
 
     test "installed? is a boolean and installed_version is nil when absent" do
@@ -54,7 +54,7 @@ defmodule ClaudeWrapper.BundledTest do
       assert File.exists?(path)
 
       assert ClaudeWrapper.CliVersion.to_string(Bundled.installed_version()) ==
-               Bundled.pinned_version()
+               Bundled.minimum_version()
     end
   end
 end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -918,37 +918,24 @@ defmodule ClaudeWrapperTest do
       Code.ensure_loaded!(Mcp)
       funcs = Mcp.__info__(:functions)
 
-      assert {:list, 2} in funcs
-      assert {:get, 3} in funcs
+      assert {:list, 1} in funcs
+      assert {:get, 2} in funcs
       assert {:add, 5} in funcs
       assert {:add_json, 4} in funcs
-      assert {:add_from_desktop, 3} in funcs
+      assert {:add_from_desktop, 2} in funcs
       assert {:remove, 3} in funcs
       assert {:serve, 2} in funcs
-      assert {:login, 3} in funcs
-      assert {:logout, 2} in funcs
       assert {:reset_project_choices, 1} in funcs
+
+      # login/logout are gone: the current CLI has no `mcp login`/`logout`.
+      refute {:login, 3} in funcs
+      refute {:logout, 2} in funcs
 
       # @doc false builders are public for arg-composition testing.
       assert {:add_args, 4} in funcs
       assert {:add_json_args, 3} in funcs
-      assert {:add_from_desktop_args, 2} in funcs
+      assert {:add_from_desktop_args, 1} in funcs
       assert {:serve_args, 1} in funcs
-      assert {:login_args, 2} in funcs
-      assert {:logout_args, 1} in funcs
-    end
-
-    test "login_args defaults to subcommand plus name" do
-      assert Mcp.login_args("sentry", []) == ["mcp", "login", "sentry"]
-    end
-
-    test "login_args emits --no-browser before the name" do
-      assert Mcp.login_args("sentry", no_browser: true) ==
-               ["mcp", "login", "--no-browser", "sentry"]
-    end
-
-    test "logout_args is subcommand plus name" do
-      assert Mcp.logout_args("sentry") == ["mcp", "logout", "sentry"]
     end
 
     test "add_args defaults to subcommand plus positionals" do
@@ -1106,20 +1093,12 @@ defmodule ClaudeWrapperTest do
     end
 
     test "add_from_desktop_args defaults to just the subcommand" do
-      assert Mcp.add_from_desktop_args(nil, []) == ["mcp", "add-from-claude-desktop"]
+      assert Mcp.add_from_desktop_args([]) == ["mcp", "add-from-claude-desktop"]
     end
 
-    test "add_from_desktop_args emits --scope" do
-      assert Mcp.add_from_desktop_args(nil, scope: :user) ==
+    test "add_from_desktop_args emits --scope (and takes no name -- the CLI has none)" do
+      assert Mcp.add_from_desktop_args(scope: :user) ==
                ["mcp", "add-from-claude-desktop", "--scope", "user"]
-    end
-
-    test "add_from_desktop_args appends a name positional when given" do
-      assert Mcp.add_from_desktop_args("srv", []) ==
-               ["mcp", "add-from-claude-desktop", "srv"]
-
-      assert Mcp.add_from_desktop_args("srv", scope: :project) ==
-               ["mcp", "add-from-claude-desktop", "--scope", "project", "srv"]
     end
 
     test "serve_args defaults to just the subcommand" do
@@ -1262,52 +1241,21 @@ defmodule ClaudeWrapperTest do
       assert {:list_args, 1} in Agents.__info__(:functions)
     end
 
-    test "list_args defaults to just the subcommand" do
-      assert Agents.list_args([]) == ["agents"]
+    test "list_args always requests --json (the TTY-safe scripting surface)" do
+      assert Agents.list_args([]) == ["agents", "--json"]
+    end
+
+    test "list_args emits --all when requested" do
+      assert Agents.list_args(all: true) == ["agents", "--json", "--all"]
     end
 
     test "list_args emits --setting-sources with the value" do
       assert Agents.list_args(setting_sources: "user,project") ==
-               ["agents", "--setting-sources", "user,project"]
+               ["agents", "--json", "--setting-sources", "user,project"]
     end
 
     test "list_args omits --setting-sources when unset" do
       refute "--setting-sources" in Agents.list_args([])
-    end
-
-    test "parse_agents extracts agent names and models" do
-      output = """
-      5 active agents
-
-      Built-in agents:
-        claude-code-guide · haiku
-        Explore · haiku
-        general-purpose · inherit
-        Plan · inherit
-        statusline-setup · sonnet
-      """
-
-      # Call list via execute and parse manually to test parsing
-      # (list calls System.cmd which we can't mock easily here)
-      agents =
-        output
-        |> String.split("\n")
-        |> Enum.reduce([], fn line, acc ->
-          line = String.trim(line)
-
-          case Regex.run(~r/^(.+?)\s+·\s+(.+)$/, line) do
-            [_, name, model] -> [%{name: String.trim(name), model: String.trim(model)} | acc]
-            _ -> acc
-          end
-        end)
-        |> Enum.reverse()
-
-      assert length(agents) == 5
-      assert %{name: "claude-code-guide", model: "haiku"} in agents
-      assert %{name: "Explore", model: "haiku"} in agents
-      assert %{name: "general-purpose", model: "inherit"} in agents
-      assert %{name: "Plan", model: "inherit"} in agents
-      assert %{name: "statusline-setup", model: "sonnet"} in agents
     end
   end
 

--- a/test/mix/tasks/claude_wrapper_tasks_test.exs
+++ b/test/mix/tasks/claude_wrapper_tasks_test.exs
@@ -91,7 +91,7 @@ defmodule Mix.Tasks.ClaudeWrapperTasksTest do
           Install.run([])
         end)
 
-      assert output =~ Bundled.pinned_version()
+      assert output =~ Bundled.minimum_version()
       assert Bundled.installed?()
     end
   end


### PR DESCRIPTION
Second wrapper chunk: the CLI-contract-drift bugs — wrappers/parsers that no longer match claude's current CLI. Verified against the installed **2.1.170** (`--help` / `--json`).

> [!NOTE]
> Contains breaking changes (all to surfaces that were already broken against the current CLI). `fix!` + `BREAKING CHANGE:` footer so release-please flags it.

| # | Fix |
|---|---|
| **#205** | `mcp`: drop `--scope` from `list`/`get` (rejected); **remove `login`/`logout`** (gone from the CLI — MCP OAuth is interactive via `/mcp`); drop the `name` positional from `add_from_desktop` (takes only `-s/--scope`). All were guaranteed `:command_failed` — dead surface pruned. |
| **#206** | `agents`: bare `claude agents` is the interactive TTY view; the `name · model` regex table is gone. Switch to **`agents --json`** + `Jason.decode`. Now reports active background **sessions** (raw maps), not configured agents; docs updated. |
| **#207** | bundled install: **(a)** exact-match to a stale `@pinned_version "2.0.0"` failed on every healthy machine (installer fetches current stable) → reframed as a **minimum floor** (`minimum_version/0`). **(b)** `curl \| sh` is fail-open (pipeline exits with `sh`'s status) → download to a temp file, check curl's exit, then run. |
| **#208** | auth classifier: unanchored needles misclassified non-auth failures (`disk quota`→`:rate_limit`, `SSL certificate expired`→`:expired`, bare `401/403/429`→`:invalid_credentials`). Highest-risk needles now require adjacent context (http/status codes, usage-scoped quota, token/session-anchored expiry); broader tokens unchanged — honoring the module's "prefer to miss" contract. |

## Verification
Probed the real CLI: `mcp --help` (no login/logout), `mcp list/get --help` (no `--scope`), `mcp add-from-claude-desktop --help` (scope-only), `agents --help` (`--json` scripting surface). New tests cover the pruned arities, `agents --json` args (+`--all`), and the #208 false-positive cases (disk-quota/SSL-expired/stray-code no longer misclassify).

## Gate
`format`, `compile --warnings-as-errors`, `credo --strict`, `docs --warnings-as-errors`, `dialyzer` (0), `test` **651 passed / 40 excluded**.

Closes #205, closes #206, closes #207, closes #208