### PR TITLE
feat: instrument DuplexSession with telemetry (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ shape with `:start`, `:stop`, and `:exception` suffixes:
 | `[:claude_wrapper, :exec, _]` | `Query.execute/2` (one-shot query) |
 | `[:claude_wrapper, :stream, _]` | `Query.stream/2` (NDJSON streaming) |
 | `[:claude_wrapper, :session, :turn, _]` | `Session.send/3` (single turn) |
+| `[:claude_wrapper, :duplex, :session, _]` | `DuplexSession` process lifetime (open/terminate) |
+| `[:claude_wrapper, :duplex, :turn, _]` | `DuplexSession.send/3` (single long-lived-session turn) |
 
 Stop metadata adds `:cost_usd`, `:exit_code`, and the usual
 `:duration`. Subscribe with:
@@ -522,7 +524,7 @@ is present. A `DuplexSession` can also select the adapter per session with
 | `ClaudeWrapper.StreamEvent` | NDJSON streaming event (`partial_message/1`) |
 | `ClaudeWrapper.McpConfig` | `.mcp.json` builder |
 | `ClaudeWrapper.Retry` | Exponential backoff retry |
-| `ClaudeWrapper.Telemetry` | `:telemetry` spans for exec/stream/session |
+| `ClaudeWrapper.Telemetry` | `:telemetry` spans for exec/stream/session/duplex |
 | `ClaudeWrapper.Budget` | Client-side USD budget tracker |
 | `ClaudeWrapper.ToolPattern` | Typed, validated tool-spec builder |
 | `ClaudeWrapper.CliVersion` | Parse/compare the CLI version |

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -123,7 +123,7 @@ defmodule ClaudeWrapper.DuplexSession do
   use GenServer
   require Logger
 
-  alias ClaudeWrapper.{Config, Error, Query, Result}
+  alias ClaudeWrapper.{Config, Error, Query, Result, Telemetry}
   alias ClaudeWrapper.DuplexSession.Adapter
 
   @type tool_input :: map()
@@ -196,7 +196,9 @@ defmodule ClaudeWrapper.DuplexSession do
           exit_status: exit_status(),
           exit_waiters: %{reference() => pid()},
           owner_ref: reference() | nil,
-          deferred_permissions: MapSet.t(String.t())
+          deferred_permissions: MapSet.t(String.t()),
+          turn_span: {integer(), map()} | nil,
+          session_monotonic: integer() | nil
         }
 
   defstruct [
@@ -206,6 +208,8 @@ defmodule ClaudeWrapper.DuplexSession do
     :session_id,
     :on_permission,
     :owner_ref,
+    :turn_span,
+    :session_monotonic,
     buffer: <<>>,
     pending_turn: nil,
     pending_control: %{},
@@ -515,13 +519,16 @@ defmodule ClaudeWrapper.DuplexSession do
 
     case adapter.open(open_opts) do
       {:ok, handle} ->
+        session_monotonic = Telemetry.duplex_session_start(%{command: :duplex_session})
+
         {:ok,
          %__MODULE__{
            port: handle,
            adapter: adapter,
            config: config,
            on_permission: on_permission,
-           owner_ref: owner_ref
+           owner_ref: owner_ref,
+           session_monotonic: session_monotonic
          }}
 
       {:error, reason} ->
@@ -547,7 +554,8 @@ defmodule ClaudeWrapper.DuplexSession do
     }
 
     state.adapter.command(port, [Jason.encode!(msg), ?\n])
-    {:noreply, %{state | pending_turn: {from, []}}}
+    span = Telemetry.duplex_turn_start(%{command: :duplex_turn, session_id: state.session_id})
+    {:noreply, %{state | pending_turn: {from, []}, turn_span: span}}
   end
 
   def handle_call({:send, _prompt}, _from, %{pending_turn: nil, port: nil} = state) do
@@ -655,8 +663,14 @@ defmodule ClaudeWrapper.DuplexSession do
   @impl true
   def terminate(reason, %{port: port} = state) do
     if not is_nil(port), do: state.adapter.close(port)
-    fail_pending(state, :terminated)
+    state = fail_pending(state, :terminated)
     notify_exit_waiters(state, final_exit_status(state, reason))
+
+    Telemetry.duplex_session_stop(state.session_monotonic, %{
+      command: :duplex_session,
+      session_id: state.session_id
+    })
+
     :ok
   end
 
@@ -800,9 +814,17 @@ defmodule ClaudeWrapper.DuplexSession do
     result = Result.from_json(msg)
     broadcast(state, {:result, result})
     GenServer.reply(from, {:ok, result})
+
+    Telemetry.duplex_turn_stop(state.turn_span, %{
+      command: :duplex_turn,
+      session_id: result.session_id || state.session_id,
+      cost_usd: result.cost_usd,
+      exit_code: 0
+    })
+
     # The turn is over; any still-tracked deferred permission ids are moot, so a
     # late respond_to_permission/3 for this turn becomes a documented no-op.
-    %{state | pending_turn: nil, deferred_permissions: MapSet.new()}
+    %{state | pending_turn: nil, turn_span: nil, deferred_permissions: MapSet.new()}
   end
 
   defp dispatch(%{"type" => "result"} = msg, state) do
@@ -880,7 +902,8 @@ defmodule ClaudeWrapper.DuplexSession do
 
   defp fail_pending_turn(%{pending_turn: {from, _}} = state, reason) do
     GenServer.reply(from, {:error, fail_reason_to_error(reason)})
-    %{state | pending_turn: nil}
+    Telemetry.duplex_turn_exception(state.turn_span, reason)
+    %{state | pending_turn: nil, turn_span: nil}
   end
 
   defp fail_pending_control(%{pending_control: pending} = state, _reason)

--- a/lib/claude_wrapper/telemetry.ex
+++ b/lib/claude_wrapper/telemetry.ex
@@ -21,6 +21,17 @@ defmodule ClaudeWrapper.Telemetry do
       emitted around `ClaudeWrapper.Session.send/3` (a single turn
       of a multi-turn session).
 
+    * `[:claude_wrapper, :duplex, :session, :start | :stop]` --
+      emitted around a `ClaudeWrapper.DuplexSession` process lifetime
+      (`:start` on a successful open, `:stop` on terminate).
+
+    * `[:claude_wrapper, :duplex, :turn, :start | :stop | :exception]` --
+      emitted around a single `ClaudeWrapper.DuplexSession.send/3` turn.
+      A turn spans several GenServer messages, so these are a manual
+      start/stop pair (like the stream lifecycle): `:start` on send,
+      `:stop` on the terminal `result`, `:exception` if the turn fails
+      before a result (e.g. the subprocess exits mid-turn).
+
   ## Measurements
 
   Automatically populated by `:telemetry.span/3`:
@@ -132,6 +143,78 @@ defmodule ClaudeWrapper.Telemetry do
       stop_metadata = Map.merge(start_metadata, session_turn_stop_metadata(result))
       {result, stop_metadata}
     end)
+  end
+
+  @doc """
+  Emit `[:claude_wrapper, :duplex, :session, :start]` and return the start
+  monotonic time, to pass to `duplex_session_stop/2`.
+  """
+  @spec duplex_session_start(metadata()) :: integer()
+  def duplex_session_start(metadata) do
+    monotonic = System.monotonic_time()
+
+    :telemetry.execute(
+      [:claude_wrapper, :duplex, :session, :start],
+      %{monotonic_time: monotonic, system_time: System.system_time()},
+      metadata
+    )
+
+    monotonic
+  end
+
+  @doc "Emit `[:claude_wrapper, :duplex, :session, :stop]` for a started session."
+  @spec duplex_session_stop(integer() | nil, metadata()) :: :ok
+  def duplex_session_stop(nil, _metadata), do: :ok
+
+  def duplex_session_stop(monotonic, metadata) do
+    :telemetry.execute(
+      [:claude_wrapper, :duplex, :session, :stop],
+      %{monotonic_time: System.monotonic_time(), duration: System.monotonic_time() - monotonic},
+      metadata
+    )
+  end
+
+  @doc """
+  Emit `[:claude_wrapper, :duplex, :turn, :start]` and return a span context
+  (`{monotonic, metadata}`) to pass to `duplex_turn_stop/2` or
+  `duplex_turn_exception/2`. A turn spans several GenServer messages, so it uses
+  this manual pair rather than `:telemetry.span/3`.
+  """
+  @spec duplex_turn_start(metadata()) :: {integer(), metadata()}
+  def duplex_turn_start(metadata) do
+    monotonic = System.monotonic_time()
+
+    :telemetry.execute(
+      [:claude_wrapper, :duplex, :turn, :start],
+      %{monotonic_time: monotonic, system_time: System.system_time()},
+      metadata
+    )
+
+    {monotonic, metadata}
+  end
+
+  @doc "Emit `[:claude_wrapper, :duplex, :turn, :stop]` for a started turn span."
+  @spec duplex_turn_stop({integer(), metadata()} | nil, metadata()) :: :ok
+  def duplex_turn_stop(nil, _extra), do: :ok
+
+  def duplex_turn_stop({monotonic, metadata}, extra) do
+    :telemetry.execute(
+      [:claude_wrapper, :duplex, :turn, :stop],
+      %{monotonic_time: System.monotonic_time(), duration: System.monotonic_time() - monotonic},
+      Map.merge(metadata, extra)
+    )
+  end
+
+  @doc "Emit `[:claude_wrapper, :duplex, :turn, :exception]` for a turn that failed before a result."
+  @spec duplex_turn_exception({integer(), metadata()} | nil, term()) :: :ok
+  def duplex_turn_exception(nil, _reason), do: :ok
+
+  def duplex_turn_exception({monotonic, metadata}, reason) do
+    :telemetry.execute(
+      [:claude_wrapper, :duplex, :turn, :exception],
+      %{monotonic_time: System.monotonic_time(), duration: System.monotonic_time() - monotonic},
+      Map.merge(metadata, %{kind: :error, reason: reason, cost_usd: nil, exit_code: nil})
+    )
   end
 
   # --- Metadata builders ---

--- a/test/claude_wrapper/telemetry_test.exs
+++ b/test/claude_wrapper/telemetry_test.exs
@@ -1,7 +1,7 @@
 defmodule ClaudeWrapper.TelemetryTest do
   use ExUnit.Case, async: false
 
-  alias ClaudeWrapper.{Query, Result, StreamEvent, Telemetry}
+  alias ClaudeWrapper.{Config, DuplexSession, Query, Result, StreamEvent, Telemetry}
 
   @doc false
   def forward_event(event, measurements, metadata, test_pid) do
@@ -21,7 +21,12 @@ defmodule ClaudeWrapper.TelemetryTest do
       [:claude_wrapper, :stream, :exception],
       [:claude_wrapper, :session, :turn, :start],
       [:claude_wrapper, :session, :turn, :stop],
-      [:claude_wrapper, :session, :turn, :exception]
+      [:claude_wrapper, :session, :turn, :exception],
+      [:claude_wrapper, :duplex, :session, :start],
+      [:claude_wrapper, :duplex, :session, :stop],
+      [:claude_wrapper, :duplex, :turn, :start],
+      [:claude_wrapper, :duplex, :turn, :stop],
+      [:claude_wrapper, :duplex, :turn, :exception]
     ]
 
     :telemetry.attach_many(
@@ -211,6 +216,93 @@ defmodule ClaudeWrapper.TelemetryTest do
       assert_receive {:telemetry, [:claude_wrapper, :stream, :exception], _, meta}
       assert meta.kind == :error
       assert %RuntimeError{message: "boom"} = meta.reason
+    end
+  end
+
+  describe "duplex telemetry helpers (#215)" do
+    test "session start/stop emit with a duration and merged metadata" do
+      mono = Telemetry.duplex_session_start(%{command: :duplex_session})
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :session, :start], _, meta}
+      assert meta.command == :duplex_session
+
+      :ok = Telemetry.duplex_session_stop(mono, %{command: :duplex_session, session_id: "s1"})
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :session, :stop], meas, stop_meta}
+      assert is_integer(meas.duration)
+      assert stop_meta.session_id == "s1"
+    end
+
+    test "turn start/stop emit; stop metadata overrides start" do
+      span = Telemetry.duplex_turn_start(%{command: :duplex_turn, session_id: "s1"})
+
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :turn, :start], _,
+                      %{command: :duplex_turn}}
+
+      :ok = Telemetry.duplex_turn_stop(span, %{cost_usd: 0.05, exit_code: 0, session_id: "s2"})
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :turn, :stop], meas, meta}
+      assert is_integer(meas.duration)
+      assert meta.cost_usd == 0.05
+      # the stop payload wins over the start metadata's session_id
+      assert meta.session_id == "s2"
+    end
+
+    test "turn exception carries the reason and a nil cost" do
+      span = Telemetry.duplex_turn_start(%{command: :duplex_turn, session_id: "s1"})
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :turn, :start], _, _}
+
+      :ok = Telemetry.duplex_turn_exception(span, {:port_exit, 1})
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :turn, :exception], _, meta}
+      assert meta.reason == {:port_exit, 1}
+      assert meta.cost_usd == nil
+    end
+
+    test "stop/exception are no-ops with a nil span context" do
+      assert :ok = Telemetry.duplex_session_stop(nil, %{})
+      assert :ok = Telemetry.duplex_turn_stop(nil, %{})
+      assert :ok = Telemetry.duplex_turn_exception(nil, :whatever)
+      refute_receive {:telemetry, [:claude_wrapper, :duplex, _, _], _, _}
+    end
+  end
+
+  describe "DuplexSession emits the duplex events at its real boundaries (#215)" do
+    # Same cat-loopback fake claude as DuplexSessionTest: inject NDJSON via the
+    # port, which echoes it back for the session to dispatch.
+    defp start_fake_duplex do
+      config = Config.new(binary: System.find_executable("cat"))
+      {:ok, pid} = DuplexSession.start_link(config: config, args_override: [])
+      pid
+    end
+
+    defp inject(pid, term) do
+      state = :sys.get_state(pid)
+      Port.command(state.port, [Jason.encode!(term), ?\n])
+    end
+
+    test "session :start on open, :stop on stop" do
+      pid = start_fake_duplex()
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :session, :start], _, _}
+
+      DuplexSession.stop(pid)
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :session, :stop], _, _}
+    end
+
+    test "turn :start on send, :stop on the terminal result (with cost/session)" do
+      pid = start_fake_duplex()
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :session, :start], _, _}
+
+      # send/3 blocks until the result, so drive it from a separate process.
+      spawn(fn -> DuplexSession.send(pid, "hi") end)
+
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :turn, :start], _,
+                      %{command: :duplex_turn}},
+                     1_000
+
+      inject(pid, %{type: "result", subtype: "success", total_cost_usd: 0.05, session_id: "s-1"})
+      assert_receive {:telemetry, [:claude_wrapper, :duplex, :turn, :stop], meas, meta}, 1_000
+      assert is_integer(meas.duration)
+      assert meta.cost_usd == 0.05
+      assert meta.session_id == "s-1"
+
+      DuplexSession.stop(pid)
     end
   end
 end


### PR DESCRIPTION
`DuplexSession` — the headline long-lived-session feature — emitted **zero** `:telemetry`, while `exec`/`stream`/`session` were instrumented. A chat-UI/agent host (the exact audience the README points at DuplexSession) attaching handlers to track cost/latency saw nothing for its sessions.

## Events (manual start/stop pairs — a turn spans multiple GenServer messages, like the stream lifecycle)
| Event | When |
|---|---|
| `[:claude_wrapper, :duplex, :session, :start\|:stop]` | process lifetime — `:start` on successful open, `:stop` on terminate |
| `[:claude_wrapper, :duplex, :turn, :start\|:stop\|:exception]` | one `send/3` turn — `:start` on send, `:stop` on the terminal `result` (carrying `cost_usd` + `session_id`), `:exception` if the turn fails before a result (e.g. subprocess exits mid-turn) |

## How
- `ClaudeWrapper.Telemetry` gains `duplex_session_start/stop` + `duplex_turn_start/stop/exception` helpers (nil-context = no-op).
- `DuplexSession` calls them at the init / send / result / fail_pending_turn / terminate boundaries; the span context rides in state (`turn_span`, `session_monotonic`) — no new abstraction.
- Telemetry moduledoc + README telemetry table document the new events.

## Tests
Helper units (start/stop/exception, metadata merge, nil no-op) + an integration test driving a real session/turn through the `cat` loopback harness, asserting `:start`/`:stop` fire with `cost_usd`/`session_id`. `async: false` (telemetry handlers are global).

## Gate
`format`, `compile --warnings-as-errors`, `credo --strict`, `docs --warnings-as-errors`, `dialyzer` (0), `test` **657 passed / 40 excluded**.

Closes #215