### PR TITLE
docs: accuracy sweep (9 issues) + enforce docs --warnings-as-errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
         run: mix deps.get
 
       - name: Build docs
-        run: mix docs
+        run: mix docs --warnings-as-errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ mix compile --warnings-as-errors
 mix credo --strict
 mix test
 mix dialyzer
+mix docs --warnings-as-errors
 ```
 
 - `mix test` runs the unit suite (integration tests are excluded).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,4 +238,4 @@ real `claude` binary and against real `~/.claude` data (for the read-side
 modules), so they are environment-dependent and excluded by default.
 
 Pre-commit checklist: `mix format`, `mix compile --warnings-as-errors`,
-`mix credo --strict`, `mix test`, `mix dialyzer`.
+`mix credo --strict`, `mix test`, `mix dialyzer`, `mix docs --warnings-as-errors`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ host can use `claude` the same way an IDE backend would.
 ```elixir
 def deps do
   [
-    {:claude_wrapper, "~> 0.8"}
+    {:claude_wrapper, "~> 0.13"}
   ]
 end
 ```
@@ -284,7 +284,7 @@ implements its `Backend` behaviour. Use it alongside
 ```elixir
 def deps do
   [
-    {:claude_wrapper, "~> 0.8"},
+    {:claude_wrapper, "~> 0.13"},
     {:agent_workshop, "~> 0.1"}
   ]
 end

--- a/lib/claude_wrapper.ex
+++ b/lib/claude_wrapper.ex
@@ -166,6 +166,14 @@ defmodule ClaudeWrapper do
       surface: `true` or `:full` (drops user + project + local ambient),
       `:project` (keeps the user's global config). Does not change auth.
       See `ClaudeWrapper.Query.hermetic/2`.
+
+  The list above is the common subset. Any other option accepted by
+  `ClaudeWrapper.Query.apply_opts/2` also works here (for example `:effort`,
+  `:agent`, `:agents_json`, `:fallback_model`, `:output_format`,
+  `:allowed_tools`, `:disallowed_tools`, `:add_dir`, `:files`, `:mcp_config`,
+  `:plugin_dirs`, `:worktree`, `:fork_session`, `:setting_sources`,
+  `:json_schema`, `:betas`) -- see `ClaudeWrapper.Query.apply_opts/2` for the
+  authoritative full list.
   """
   @spec query(String.t(), keyword()) :: {:ok, Result.t()} | {:error, term()}
   def query(prompt, opts \\ []) do

--- a/lib/claude_wrapper/budget.ex
+++ b/lib/claude_wrapper/budget.ex
@@ -18,7 +18,7 @@ defmodule ClaudeWrapper.Budget do
 
   It is self-contained: `ClaudeWrapper.Session` and
   `ClaudeWrapper.SessionServer` are not aware of it. Drive it yourself
-  from a multi-turn loop -- record each turn's `total_cost_usd`, then
+  from a multi-turn loop -- record each turn's `cost_usd`, then
   `check/1` before the next turn.
 
   ## Threshold semantics
@@ -46,7 +46,7 @@ defmodule ClaudeWrapper.Budget do
         )
 
       # In a multi-turn loop, after each turn:
-      :ok = ClaudeWrapper.Budget.record(budget, result.total_cost_usd)
+      :ok = ClaudeWrapper.Budget.record(budget, result.cost_usd)
 
       case ClaudeWrapper.Budget.check(budget) do
         :ok -> :keep_going
@@ -143,11 +143,15 @@ defmodule ClaudeWrapper.Budget do
 
   Fires `:on_warning` the first time the running total reaches
   `:warn_at_usd`, and `:on_exceeded` the first time it reaches
-  `:max_usd`. Non-positive and non-finite costs are ignored.
+  `:max_usd`. Non-positive and non-finite costs are ignored, and a `nil`
+  cost is a no-op (so recording a `%ClaudeWrapper.Result{}`'s `cost_usd`
+  directly is safe -- it is `nil` on an interrupted/cancelled turn).
 
   Returns `:ok`.
   """
-  @spec record(server(), number()) :: :ok
+  @spec record(server(), number() | nil) :: :ok
+  def record(_server, nil), do: :ok
+
   def record(server, cost) when is_number(cost) do
     GenServer.call(server, {:record, cost})
   end

--- a/lib/claude_wrapper/commands/agents.ex
+++ b/lib/claude_wrapper/commands/agents.ex
@@ -6,6 +6,8 @@ defmodule ClaudeWrapper.Commands.Agents do
   surface is `claude agents --json`, which "Print[s] active sessions as a JSON
   array and exit[s] ... does not require a TTY". This module uses `--json` and
   decodes that array, so it returns **active sessions** (not configured agents).
+  This is distinct from `ClaudeWrapper.Agents`, which reads and writes the
+  agent-definition files under `~/.claude` directly.
   Each element is the CLI's raw session map (string keys).
 
   ## Usage

--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -44,10 +44,15 @@ defmodule ClaudeWrapper.DuplexIEx do
 
   - Working dir defaults to `File.cwd!()` so the session sees your
     current project
-  - Permission mode defaults to `"bypassPermissions"` so tool calls
-    just work in the REPL without a permission callback. **This is
-    not safe** for prompts you do not control. For trustworthy use,
-    pass `permission_mode: "default"` and an `on_permission` callback
+  - With no `:on_permission` callback, the session is started with
+    `--dangerously-skip-permissions` so tool calls just work in the
+    REPL. **This is not safe** for prompts you do not control. For
+    trustworthy use, pass an `:on_permission` callback: its presence
+    automatically selects `--permission-mode default` so every tool
+    request is routed to your callback instead of being bypassed
+    (see `ensure_permission_mode/2`). There is no `permission_mode:`
+    option -- the callback is the only knob; to force a specific CLI
+    mode yourself, pass it via `extra_args: ["--permission-mode", ...]`
   - All `ClaudeWrapper.Config` options (`:binary`, `:env`, `:timeout`,
     etc.) are accepted and forwarded to `ClaudeWrapper.Config.new/1`
   - All `ClaudeWrapper.DuplexSession` options (`:on_permission`,

--- a/lib/claude_wrapper/duplex_session.ex
+++ b/lib/claude_wrapper/duplex_session.ex
@@ -332,8 +332,19 @@ defmodule ClaudeWrapper.DuplexSession do
   end
 
   @doc """
-  Stop the session. Closes the port, waits for the child to exit, and
-  shuts down the GenServer.
+  Stop the session: shut down the GenServer, which calls the adapter's
+  `close/1` on the port during `terminate/2`.
+
+  With the default `ClaudeWrapper.DuplexSession.Adapter.Port`, close severs
+  the stdio pipes without sending any signal to the OS process and without
+  reaping it, so the `claude` child (and any stdio MCP servers it spawned)
+  is orphaned rather than terminated (see #185). This function does *not*
+  wait for the child to exit; `timeout` is only the `GenServer.stop/3`
+  terminate deadline.
+
+  For SIGTERM-then-SIGKILL group termination that actually reaps the child,
+  configure `ClaudeWrapper.DuplexSession.Adapter.Forcola`
+  (`config :claude_wrapper, duplex_adapter: ClaudeWrapper.DuplexSession.Adapter.Forcola`).
 
   See also `close/1` for a short-form alias.
   """
@@ -345,8 +356,11 @@ defmodule ClaudeWrapper.DuplexSession do
   @doc """
   Graceful close: shorthand for `stop(server, :normal, 10_000)`.
 
-  Closes the port (which sends SIGTERM to the child), waits up to
-  10 seconds for it to exit, and shuts down the GenServer.
+  The `10_000` is the `GenServer.stop/3` terminate deadline, not a
+  child-exit wait. See `stop/3` for the adapter caveat: the default
+  `Adapter.Port` severs the pipes without signalling or reaping the
+  child (orphaned per #185); use `Adapter.Forcola` for real
+  SIGTERM-then-SIGKILL group termination.
   """
   @spec close(GenServer.server()) :: :ok
   def close(server), do: stop(server, :normal, 10_000)

--- a/lib/claude_wrapper/error.ex
+++ b/lib/claude_wrapper/error.ex
@@ -73,6 +73,12 @@ defmodule ClaudeWrapper.Error do
       (`:reason` is the specific problem)
     * `:auth` -- an authentication failure, classified into `:reason`
       (see `t:ClaudeWrapper.Auth.auth_error_kind/0`)
+    * `:invalid_render` -- a `ClaudeWrapper.Structured` module's `render/1`
+      returned a value that was neither a `%ClaudeWrapper.Prompt{}` nor a
+      string (`:reason` is the offending return value)
+    * `:no_structured_output` -- a `ClaudeWrapper.Structured` run produced a
+      result with no structured output, i.e. no `--json-schema` took effect
+      (`:reason` is the `%ClaudeWrapper.Result{}`)
   """
 
   @type kind ::

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -293,7 +293,7 @@ defmodule ClaudeWrapper.Query do
   @spec worktree(t(), String.t()) :: t()
   def worktree(%__MODULE__{} = q, name) when is_binary(name), do: %{q | worktree: name}
 
-  @doc "Enable brief mode."
+  @doc "Enable the SendUserMessage tool for agent-to-user communication (`--brief`)."
   @spec brief(t()) :: t()
   def brief(%__MODULE__{} = q), do: %{q | brief: true}
 

--- a/mix.exs
+++ b/mix.exs
@@ -91,7 +91,7 @@ defmodule ClaudeWrapper.MixProject do
           ClaudeWrapper.DuplexSession.Adapter.Forcola,
           ClaudeWrapper.DuplexSession.Adapter.Test
         ],
-        "Read-side introspection of ~/.claude": [
+        "~/.claude introspection & agent authoring": [
           ClaudeWrapper.History,
           ClaudeWrapper.Settings,
           ClaudeWrapper.Agents,

--- a/test/claude_wrapper/budget_test.exs
+++ b/test/claude_wrapper/budget_test.exs
@@ -25,6 +25,12 @@ defmodule ClaudeWrapper.BudgetTest do
       assert Budget.total(b) == 0.0
     end
 
+    test "a nil cost is a no-op (recording result.cost_usd directly is safe)" do
+      b = start_budget()
+      assert :ok = Budget.record(b, nil)
+      assert Budget.total(b) == 0.0
+    end
+
     test "accepts integer costs" do
       b = start_budget()
       assert :ok = Budget.record(b, 1)


### PR DESCRIPTION
Wrapper cleanup, batch 1 of 3 (docs). Specs produced by a triage workflow over the remaining backlog.

| # | Fix |
|---|---|
| #212 | DuplexIEx moduledoc documented a phantom `permission_mode:` option that steered callers onto `--dangerously-skip-permissions`; rewritten to the real contract (callback presence flips to `--permission-mode default`). |
| #213 | Budget example called `result.total_cost_usd` (KeyError — field is `cost_usd`); fixed both mentions **+** `record/2` treats `nil` as a no-op so recording `result.cost_usd` directly is safe (+ test). |
| #214 | `stop/3`/`close/1` docstrings falsely claimed SIGTERM + child-exit wait; corrected (default `Adapter.Port` orphans per #185; use `Adapter.Forcola`). |
| #226 | Add `:invalid_render` / `:no_structured_output` to the Error `## Kinds` list. |
| #227 | `brief/1` docstring was circular/wrong (`--brief` enables the SendUserMessage tool). |
| #228 | `query/2` doc listed ~10 of ~40 options; pointer to the authoritative `Query.apply_opts/2` set. |
| #229 | README dep pins `~> 0.8` → `~> 0.13`. |
| #230 | Rename the misleading "Read-side introspection" docs group; cross-link `Commands.Agents` ↔ `Agents`. |
| #231 | CI docs job ran bare `mix docs` (no-op gate); now `--warnings-as-errors` + added to the CLAUDE.md/AGENTS.md checklists. |

Only code changes: the `Budget.record/2` nil-tolerance guard (#213). Everything else is docs/CI. The newly-hardened `mix docs --warnings-as-errors` gate passes at HEAD (verified).

## Gate
`format`, `compile --warnings-as-errors`, `credo --strict`, `docs --warnings-as-errors`, `dialyzer` (0), `test` **658 passed / 40 excluded**.

Closes #212, closes #213, closes #214, closes #226, closes #227, closes #228, closes #229, closes #230, closes #231