### PR TITLE
feat: expose missing CLI flags, retry rate limits, codepoint-safe truncation (#221-225)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -7,7 +7,7 @@
         extra: [
           # The Query struct intentionally maps every `claude` CLI flag, so it
           # grows as the CLI does. Headroom kept above the current field count.
-          {Credo.Check.Warning.StructFieldAmount, max_fields: 50}
+          {Credo.Check.Warning.StructFieldAmount, max_fields: 56}
         ]
       }
     }

--- a/lib/claude_wrapper/auth.ex
+++ b/lib/claude_wrapper/auth.ex
@@ -14,6 +14,7 @@ defmodule ClaudeWrapper.Auth.Summary do
   @enforce_keys [
     :strategy,
     :has_anthropic_api_key,
+    :has_auth_token,
     :has_oauth_token,
     :bedrock_enabled,
     :vertex_enabled
@@ -21,6 +22,7 @@ defmodule ClaudeWrapper.Auth.Summary do
   defstruct [
     :strategy,
     :has_anthropic_api_key,
+    :has_auth_token,
     :has_oauth_token,
     :bedrock_enabled,
     :vertex_enabled
@@ -29,6 +31,7 @@ defmodule ClaudeWrapper.Auth.Summary do
   @type t :: %__MODULE__{
           strategy: Auth.strategy(),
           has_anthropic_api_key: boolean(),
+          has_auth_token: boolean(),
           has_oauth_token: boolean(),
           bedrock_enabled: boolean(),
           vertex_enabled: boolean()
@@ -62,8 +65,14 @@ defmodule ClaudeWrapper.Auth do
     1. `CLAUDE_CODE_USE_BEDROCK` truthy -> `:bedrock`
     2. `CLAUDE_CODE_USE_VERTEX` truthy -> `:vertex`
     3. `ANTHROPIC_API_KEY` non-empty -> `:api_key`
-    4. `CLAUDE_CODE_OAUTH_TOKEN` non-empty -> `:oauth_token`
-    5. Otherwise -> `:subscription`
+    4. `ANTHROPIC_AUTH_TOKEN` non-empty -> `:auth_token`
+    5. `CLAUDE_CODE_OAUTH_TOKEN` non-empty -> `:oauth_token`
+    6. Otherwise -> `:subscription`
+
+  `ANTHROPIC_API_KEY` is ordered ahead of `ANTHROPIC_AUTH_TOKEN` because the
+  direct-API key is the more common path; both are env-pinned header
+  credentials, so their relative order only affects the reported label, not
+  liveness.
 
   Cloud-provider strategies (Bedrock, Vertex) take precedence because
   they redirect ALL traffic regardless of API key presence.
@@ -110,6 +119,10 @@ defmodule ClaudeWrapper.Auth do
     * `:vertex` -- `CLAUDE_CODE_USE_VERTEX` is truthy. Requests route to
       Google Vertex; GCP credentials are resolved separately.
     * `:api_key` -- `ANTHROPIC_API_KEY` is set. Direct API access.
+    * `:auth_token` -- `ANTHROPIC_AUTH_TOKEN` is set. A custom Bearer token
+      sent as `Authorization: Bearer` (typically alongside `ANTHROPIC_BASE_URL`
+      for a gateway / custom endpoint), distinct from `ANTHROPIC_API_KEY`,
+      which is sent as `x-api-key`.
     * `:oauth_token` -- `CLAUDE_CODE_OAUTH_TOKEN` is set (typically from
       `claude setup-token`).
     * `:subscription` -- no auth env var set. The CLI looks for stored
@@ -119,7 +132,7 @@ defmodule ClaudeWrapper.Auth do
 
   See the module docs for precedence rules.
   """
-  @type strategy :: :bedrock | :vertex | :api_key | :oauth_token | :subscription
+  @type strategy :: :bedrock | :vertex | :api_key | :auth_token | :oauth_token | :subscription
 
   @typedoc """
   Best-effort classification of an auth-related CLI failure.
@@ -167,6 +180,7 @@ defmodule ClaudeWrapper.Auth do
     bedrock_enabled = truthy?(Map.get(env, "CLAUDE_CODE_USE_BEDROCK"))
     vertex_enabled = truthy?(Map.get(env, "CLAUDE_CODE_USE_VERTEX"))
     has_anthropic_api_key = set?(Map.get(env, "ANTHROPIC_API_KEY"))
+    has_auth_token = set?(Map.get(env, "ANTHROPIC_AUTH_TOKEN"))
     has_oauth_token = set?(Map.get(env, "CLAUDE_CODE_OAUTH_TOKEN"))
 
     strategy =
@@ -174,6 +188,7 @@ defmodule ClaudeWrapper.Auth do
         bedrock_enabled -> :bedrock
         vertex_enabled -> :vertex
         has_anthropic_api_key -> :api_key
+        has_auth_token -> :auth_token
         has_oauth_token -> :oauth_token
         true -> :subscription
       end
@@ -181,6 +196,7 @@ defmodule ClaudeWrapper.Auth do
     %Summary{
       strategy: strategy,
       has_anthropic_api_key: has_anthropic_api_key,
+      has_auth_token: has_auth_token,
       has_oauth_token: has_oauth_token,
       bedrock_enabled: bedrock_enabled,
       vertex_enabled: vertex_enabled

--- a/lib/claude_wrapper/commands/marketplace.ex
+++ b/lib/claude_wrapper/commands/marketplace.ex
@@ -76,15 +76,26 @@ defmodule ClaudeWrapper.Commands.Marketplace do
 
   @doc """
   Remove a configured marketplace by name.
+
+  ## Options
+
+    * `:scope` - Scope to remove from (`:user`, `:project`, or `:local`).
+      Omit to remove from all scopes.
   """
-  @spec remove(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
-  def remove(%Config{} = config, name) do
-    args = Config.base_args(config) ++ ["plugin", "marketplace", "remove", name]
+  @spec remove(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def remove(%Config{} = config, name, opts \\ []) do
+    args = Config.base_args(config) ++ remove_args(name, opts)
 
     case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
+  end
+
+  @doc false
+  @spec remove_args(String.t(), keyword()) :: [String.t()]
+  def remove_args(name, opts) do
+    ["plugin", "marketplace", "remove", name] ++ scope_args(opts[:scope])
   end
 
   @doc """

--- a/lib/claude_wrapper/commands/plugin.ex
+++ b/lib/claude_wrapper/commands/plugin.ex
@@ -70,16 +70,23 @@ defmodule ClaudeWrapper.Commands.Plugin do
   ## Options
 
     * `:scope` - Installation scope (`:user`, `:project`, or `:local`). Default: `:user`.
+    * `:config` - Manifest `userConfig` values set at install time, as a list of
+      `"key=value"` strings. Each entry emits a repeated `--config key=value`.
   """
   @spec install(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def install(%Config{} = config, plugin, opts \\ []) do
-    args = Config.base_args(config) ++ ["plugin", "install", plugin]
-    args = args ++ scope_args(opts[:scope])
+    args = Config.base_args(config) ++ install_args(plugin, opts)
 
     case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
+  end
+
+  @doc false
+  @spec install_args(String.t(), keyword()) :: [String.t()]
+  def install_args(plugin, opts) do
+    ["plugin", "install", plugin] ++ scope_args(opts[:scope]) ++ config_args(opts[:config])
   end
 
   @doc """
@@ -175,15 +182,26 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
   @doc """
   Validate a plugin or marketplace manifest at the given path.
+
+  ## Options
+
+    * `:strict` - Treat warnings as errors and exit non-zero (`--strict`,
+      boolean). Intended for CI / programmatic validation.
   """
-  @spec validate(Config.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
-  def validate(%Config{} = config, path) do
-    args = Config.base_args(config) ++ ["plugin", "validate", path]
+  @spec validate(Config.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def validate(%Config{} = config, path, opts \\ []) do
+    args = Config.base_args(config) ++ validate_args(path, opts)
 
     case Config.exec(config, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, code} -> {:error, Error.command_failed(code, output)}
     end
+  end
+
+  @doc false
+  @spec validate_args(String.t(), keyword()) :: [String.t()]
+  def validate_args(path, opts) do
+    ["plugin", "validate", path] ++ bool_flag(opts[:strict], "--strict")
   end
 
   @doc """
@@ -278,6 +296,11 @@ defmodule ClaudeWrapper.Commands.Plugin do
 
   defp bool_flag(true, flag), do: [flag]
   defp bool_flag(_falsy, _flag), do: []
+
+  defp config_args(nil), do: []
+
+  defp config_args(pairs) when is_list(pairs),
+    do: Enum.flat_map(pairs, fn kv -> ["--config", kv] end)
 
   defp value_flag(nil, _flag), do: []
   defp value_flag(value, flag), do: [flag, value]

--- a/lib/claude_wrapper/duplex_iex.ex
+++ b/lib/claude_wrapper/duplex_iex.ex
@@ -354,7 +354,9 @@ defmodule ClaudeWrapper.DuplexIEx do
   end
 
   defp truncate(s, max) when byte_size(s) <= max, do: s
-  defp truncate(s, max), do: binary_part(s, 0, max - 1) <> "…"
+  # String.slice (grapheme-based) rather than binary_part (byte-based), so a
+  # multibyte codepoint is never split into invalid UTF-8.
+  defp truncate(s, max), do: String.slice(s, 0, max - 1) <> "…"
 
   defp plural(1), do: ""
   defp plural(_), do: "s"

--- a/lib/claude_wrapper/query.ex
+++ b/lib/claude_wrapper/query.ex
@@ -38,6 +38,10 @@ defmodule ClaudeWrapper.Query do
           model: String.t() | nil,
           system_prompt: String.t() | nil,
           append_system_prompt: String.t() | nil,
+          system_prompt_file: String.t() | nil,
+          append_system_prompt_file: String.t() | nil,
+          permission_prompt_tool: String.t() | nil,
+          max_thinking_tokens: pos_integer() | nil,
           output_format: output_format() | nil,
           max_budget_usd: float() | nil,
           permission_mode: permission_mode() | nil,
@@ -89,6 +93,10 @@ defmodule ClaudeWrapper.Query do
     :model,
     :system_prompt,
     :append_system_prompt,
+    :system_prompt_file,
+    :append_system_prompt_file,
+    :permission_prompt_tool,
+    :max_thinking_tokens,
     :output_format,
     :max_budget_usd,
     :permission_mode,
@@ -156,6 +164,23 @@ defmodule ClaudeWrapper.Query do
   @doc "Append to the system prompt."
   @spec append_system_prompt(t(), String.t()) :: t()
   def append_system_prompt(%__MODULE__{} = q, prompt), do: %{q | append_system_prompt: prompt}
+
+  @doc "Set the system prompt from a file (`--system-prompt-file`), avoiding ARG_MAX limits from inlining a large prompt as argv. Verified against claude CLI 2.1.170 (hidden from --help)."
+  @spec system_prompt_file(t(), String.t()) :: t()
+  def system_prompt_file(%__MODULE__{} = q, path), do: %{q | system_prompt_file: path}
+
+  @doc "Append to the system prompt from a file (`--append-system-prompt-file`). Verified against claude CLI 2.1.170 (hidden from --help)."
+  @spec append_system_prompt_file(t(), String.t()) :: t()
+  def append_system_prompt_file(%__MODULE__{} = q, path),
+    do: %{q | append_system_prompt_file: path}
+
+  @doc "Delegate permission decisions to a custom MCP tool (`--permission-prompt-tool <tool>`) for programmatic headless gating. Verified against claude CLI 2.1.170 (hidden from --help)."
+  @spec permission_prompt_tool(t(), String.t()) :: t()
+  def permission_prompt_tool(%__MODULE__{} = q, tool), do: %{q | permission_prompt_tool: tool}
+
+  @doc "Cap the thinking-token budget (`--max-thinking-tokens`), a finer control than `--effort`. Verified against claude CLI 2.1.170 (hidden from --help)."
+  @spec max_thinking_tokens(t(), pos_integer()) :: t()
+  def max_thinking_tokens(%__MODULE__{} = q, n), do: %{q | max_thinking_tokens: n}
 
   @doc "Set output format."
   @spec output_format(t(), output_format()) :: t()
@@ -426,6 +451,10 @@ defmodule ClaudeWrapper.Query do
   defp apply_opt({:model, v}, q), do: model(q, v)
   defp apply_opt({:system_prompt, v}, q), do: system_prompt(q, v)
   defp apply_opt({:append_system_prompt, v}, q), do: append_system_prompt(q, v)
+  defp apply_opt({:system_prompt_file, v}, q), do: system_prompt_file(q, v)
+  defp apply_opt({:append_system_prompt_file, v}, q), do: append_system_prompt_file(q, v)
+  defp apply_opt({:permission_prompt_tool, v}, q), do: permission_prompt_tool(q, v)
+  defp apply_opt({:max_thinking_tokens, v}, q), do: max_thinking_tokens(q, v)
   defp apply_opt({:max_turns, v}, q), do: max_turns(q, v)
   defp apply_opt({:max_budget_usd, v}, q), do: max_budget_usd(q, v)
   defp apply_opt({:permission_mode, v}, q), do: permission_mode(q, v)
@@ -767,6 +796,10 @@ defmodule ClaudeWrapper.Query do
     |> add_opt("--model", q.model)
     |> add_opt("--system-prompt", q.system_prompt)
     |> add_opt("--append-system-prompt", q.append_system_prompt)
+    |> add_opt("--system-prompt-file", q.system_prompt_file)
+    |> add_opt("--append-system-prompt-file", q.append_system_prompt_file)
+    |> add_opt("--permission-prompt-tool", q.permission_prompt_tool)
+    |> add_opt("--max-thinking-tokens", q.max_thinking_tokens && to_string(q.max_thinking_tokens))
     |> add_opt("--output-format", format_output_format(q.output_format))
     |> add_opt("--max-budget-usd", q.max_budget_usd && to_string(q.max_budget_usd))
     |> add_opt("--permission-mode", format_permission_mode(q.permission_mode))

--- a/lib/claude_wrapper/retry.ex
+++ b/lib/claude_wrapper/retry.ex
@@ -51,7 +51,10 @@ defmodule ClaudeWrapper.Retry do
     * `:multiplier` - Backoff multiplier (default: 2)
     * `:jitter` - Add random jitter to delays (default: true)
     * `:retry_on` - Function that receives the error and returns whether to retry.
-      Defaults to retrying on timeouts and non-zero exits.
+      The default retries `:timeout` errors, plain non-zero `:command_failed`
+      exits, and rate limits (`:auth` errors with reason `:rate_limit`). Other
+      auth failures and rail-stop errors (`:max_turns_exceeded`,
+      `:max_budget_exceeded`) are not retried.
   """
   @spec execute(Query.t(), Config.t(), opts()) :: {:ok, Result.t()} | {:error, term()}
   def execute(%Query{} = query, %Config{} = config, opts \\ []) do
@@ -116,11 +119,18 @@ defmodule ClaudeWrapper.Retry do
     end
   end
 
-  defp default_retry_on({:error, %Error{kind: :timeout}}), do: true
+  @doc false
+  # The default `:retry_on` predicate. Public (@doc false) so it is unit-testable
+  # without a paid claude call.
+  def default_retry_on({:error, %Error{kind: :timeout}}), do: true
 
-  defp default_retry_on({:error, %Error{kind: :command_failed, exit_code: code}})
-       when code != 0,
-       do: true
+  def default_retry_on({:error, %Error{kind: :command_failed, exit_code: code}})
+      when code != 0,
+      do: true
 
-  defp default_retry_on(_), do: false
+  # Recognized rate limits are reclassified to :auth/:rate_limit by query.ex; a
+  # bounded backoff-retry is appropriate (other :auth reasons re-fail identically).
+  def default_retry_on({:error, %Error{kind: :auth, reason: :rate_limit}}), do: true
+
+  def default_retry_on(_), do: false
 end

--- a/test/claude_wrapper/auth_test.exs
+++ b/test/claude_wrapper/auth_test.exs
@@ -7,7 +7,7 @@ defmodule ClaudeWrapper.AuthTest do
   describe "detect/0" do
     test "reads the real process env and returns a summary" do
       assert %Summary{strategy: strategy} = Auth.detect()
-      assert strategy in [:bedrock, :vertex, :api_key, :oauth_token, :subscription]
+      assert strategy in [:bedrock, :vertex, :api_key, :auth_token, :oauth_token, :subscription]
     end
   end
 
@@ -17,9 +17,33 @@ defmodule ClaudeWrapper.AuthTest do
 
       assert s.strategy == :subscription
       refute s.has_anthropic_api_key
+      refute s.has_auth_token
       refute s.has_oauth_token
       refute s.bedrock_enabled
       refute s.vertex_enabled
+    end
+
+    test "ANTHROPIC_AUTH_TOKEN alone picks :auth_token" do
+      s = Auth.detect_from(%{"ANTHROPIC_AUTH_TOKEN" => "sk-ant-..."})
+
+      assert s.strategy == :auth_token
+      assert s.has_auth_token
+      refute s.has_anthropic_api_key
+    end
+
+    test "ANTHROPIC_API_KEY takes precedence over ANTHROPIC_AUTH_TOKEN" do
+      s = Auth.detect_from(%{"ANTHROPIC_API_KEY" => "sk-abc", "ANTHROPIC_AUTH_TOKEN" => "tok"})
+
+      assert s.strategy == :api_key
+      assert s.has_anthropic_api_key
+      assert s.has_auth_token
+    end
+
+    test "ANTHROPIC_AUTH_TOKEN takes precedence over CLAUDE_CODE_OAUTH_TOKEN" do
+      s =
+        Auth.detect_from(%{"ANTHROPIC_AUTH_TOKEN" => "tok", "CLAUDE_CODE_OAUTH_TOKEN" => "oauth"})
+
+      assert s.strategy == :auth_token
     end
 
     test "api key takes precedence over oauth token" do

--- a/test/claude_wrapper/duplex_iex_test.exs
+++ b/test/claude_wrapper/duplex_iex_test.exs
@@ -237,6 +237,29 @@ defmodule ClaudeWrapper.DuplexIExTest do
       assert output =~ "…"
     end
 
+    test "truncates long multibyte tool results without splitting a codepoint (#221)" do
+      # Each "é" is 2 bytes; 200 of them is 400 bytes, so a byte-offset
+      # truncation at 199 would land mid-codepoint and emit invalid UTF-8.
+      long_text = String.duplicate("é", 200)
+
+      event =
+        {:user,
+         %{
+           "message" => %{
+             "content" => [
+               %{
+                 "type" => "tool_result",
+                 "content" => [%{"type" => "text", "text" => long_text}]
+               }
+             ]
+           }
+         }}
+
+      output = capture_io(fn -> DuplexIEx.handle_event(event) end)
+      assert String.valid?(output)
+      assert output =~ "…"
+    end
+
     test "ignores unknown events" do
       assert capture_io(fn ->
                DuplexIEx.handle_event({:other, %{}})

--- a/test/claude_wrapper/query_test.exs
+++ b/test/claude_wrapper/query_test.exs
@@ -531,4 +531,33 @@ defmodule ClaudeWrapper.QueryTest do
       assert kind in [:command_failed, :auth]
     end
   end
+
+  describe "build_args/1 file + tool + thinking flags (#222)" do
+    test "the hidden one-shot flags round-trip through apply_opts + build_args" do
+      q =
+        Query.new("p")
+        |> Query.apply_opts(
+          system_prompt_file: "/sp.txt",
+          append_system_prompt_file: "/asp.txt",
+          permission_prompt_tool: "mcp__x__approve",
+          max_thinking_tokens: 4096
+        )
+
+      args = Query.build_args(q)
+
+      assert subsequence?(["--system-prompt-file", "/sp.txt"], args)
+      assert subsequence?(["--append-system-prompt-file", "/asp.txt"], args)
+      assert subsequence?(["--permission-prompt-tool", "mcp__x__approve"], args)
+      # the integer budget is stringified
+      assert subsequence?(["--max-thinking-tokens", "4096"], args)
+
+      # spawn-safe: they flow through spawn_args unchanged (not transport/print flags)
+      assert subsequence?(["--system-prompt-file", "/sp.txt"], Query.spawn_args(q))
+    end
+
+    test "the direct setter sets max_thinking_tokens" do
+      assert Query.new("p") |> Query.max_thinking_tokens(4096) |> Map.get(:max_thinking_tokens) ==
+               4096
+    end
+  end
 end

--- a/test/claude_wrapper_test.exs
+++ b/test/claude_wrapper_test.exs
@@ -764,6 +764,20 @@ defmodule ClaudeWrapperTest do
         assert delay <= 4000
       end
     end
+
+    test "default_retry_on retries timeouts, plain command failures, and rate limits" do
+      assert Retry.default_retry_on({:error, %Error{kind: :timeout}})
+      assert Retry.default_retry_on({:error, %Error{kind: :command_failed, exit_code: 1}})
+      assert Retry.default_retry_on({:error, %Error{kind: :auth, reason: :rate_limit}})
+    end
+
+    test "default_retry_on does not retry other auth failures or rail stops" do
+      refute Retry.default_retry_on({:error, %Error{kind: :auth, reason: :not_authenticated}})
+      refute Retry.default_retry_on({:error, %Error{kind: :auth, reason: :expired}})
+      refute Retry.default_retry_on({:error, %Error{kind: :max_turns_exceeded}})
+      refute Retry.default_retry_on({:error, %Error{kind: :max_budget_exceeded}})
+      refute Retry.default_retry_on({:error, %Error{kind: :command_failed, exit_code: 0}})
+    end
   end
 
   describe "SessionServer" do
@@ -824,10 +838,40 @@ defmodule ClaudeWrapperTest do
       assert {:enable, 3} in Plugin.__info__(:functions)
       assert {:disable, 3} in Plugin.__info__(:functions)
       assert {:update, 3} in Plugin.__info__(:functions)
-      assert {:validate, 2} in Plugin.__info__(:functions)
+      assert {:validate, 3} in Plugin.__info__(:functions)
       assert {:tag, 2} in Plugin.__info__(:functions)
       assert {:details, 2} in Plugin.__info__(:functions)
       assert {:prune, 2} in Plugin.__info__(:functions)
+      assert {:install_args, 2} in Plugin.__info__(:functions)
+      assert {:validate_args, 2} in Plugin.__info__(:functions)
+    end
+
+    test "install_args threads scope and repeatable config pairs" do
+      assert Plugin.install_args("p", []) == ["plugin", "install", "p"]
+
+      assert Plugin.install_args("p", scope: :project, config: ["a=1", "b=2"]) ==
+               [
+                 "plugin",
+                 "install",
+                 "p",
+                 "--scope",
+                 "project",
+                 "--config",
+                 "a=1",
+                 "--config",
+                 "b=2"
+               ]
+    end
+
+    test "validate_args emits --strict only when set" do
+      assert Plugin.validate_args("./m", []) == ["plugin", "validate", "./m"]
+
+      assert Plugin.validate_args("./m", strict: true) == [
+               "plugin",
+               "validate",
+               "./m",
+               "--strict"
+             ]
     end
 
     test "tag_args defaults to just the subcommand" do
@@ -1266,10 +1310,18 @@ defmodule ClaudeWrapperTest do
       Code.ensure_loaded!(Marketplace)
       assert {:list, 1} in Marketplace.__info__(:functions)
       assert {:add, 3} in Marketplace.__info__(:functions)
-      assert {:remove, 2} in Marketplace.__info__(:functions)
+      assert {:remove, 3} in Marketplace.__info__(:functions)
       assert {:update, 2} in Marketplace.__info__(:functions)
       assert {:add_args, 2} in Marketplace.__info__(:functions)
       assert {:update_args, 1} in Marketplace.__info__(:functions)
+      assert {:remove_args, 2} in Marketplace.__info__(:functions)
+    end
+
+    test "remove_args emits --scope only when set" do
+      assert Marketplace.remove_args("m", []) == ["plugin", "marketplace", "remove", "m"]
+
+      assert Marketplace.remove_args("m", scope: :local) ==
+               ["plugin", "marketplace", "remove", "m", "--scope", "local"]
     end
 
     test "add_args defaults to source with no flags" do


### PR DESCRIPTION
Wrapper cleanup, batch 2 of 3 (features + small fixes). Specs from the triage workflow.

| # | Change |
|---|---|
| #222 | Expose four help-hidden one-shot flags: `Query.system_prompt_file/2`, `append_system_prompt_file/2` (dodge ARG_MAX), `permission_prompt_tool/2` (headless gating), `max_thinking_tokens/2`. Round-trip through `apply_opts`/`build_args`/`spawn_args`. |
| #223 | Expose `plugin install --config` (repeatable `key=value`), `plugin validate --strict`, `marketplace remove --scope`. Arg builders extracted + unit-tested. |
| #224 | Detect `ANTHROPIC_AUTH_TOKEN` → new `:auth_token` strategy + `has_auth_token` flag (Bearer token, distinct from the `x-api-key` `ANTHROPIC_API_KEY`), ordered after `:api_key`. |
| #225 | `Retry` default now retries rate limits (`:auth`/`:rate_limit`); doc states exact coverage; `default_retry_on/1` promoted to a `@doc false` public fn for unit testing. |
| #221 | `DuplexIEx.truncate/2` used byte-offset `binary_part` (could split a multibyte codepoint → invalid UTF-8); now grapheme-based `String.slice`. |

`.credo.exs` `StructFieldAmount` 50→56 (Query mirrors every CLI flag; the 4 new push it to 52).

## Gate
`format`, `compile --warnings-as-errors`, `credo --strict`, `docs --warnings-as-errors`, `dialyzer` (0), `test` **669 passed / 40 excluded**.

Closes #221, closes #222, closes #223, closes #224, closes #225