### PR TITLE
test: shell-escaper + streaming-runner + execute/stream edges; expand CI matrix (#217/#218/#232/#233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
         include:
           - elixir: "1.18"
             otp: "27"
+          - elixir: "1.19"
+            otp: "28"
+          - elixir: "1.20"
+            otp: "29"
 
     steps:
       - uses: actions/checkout@v7
@@ -68,8 +72,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.18"
-          otp-version: "27"
+          elixir-version: "1.20"
+          otp-version: "29"
 
       - name: Restore deps cache
         uses: actions/cache@v6
@@ -77,7 +81,7 @@ jobs:
           path: |
             deps
             _build
-          key: mix-docs-1.18-27-${{ hashFiles('mix.lock') }}
+          key: mix-docs-1.20-29-${{ hashFiles('mix.lock') }}
 
       - name: Install dependencies
         run: mix deps.get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.18"
-          otp-version: "27"
+          elixir-version: "1.20"
+          otp-version: "29"
 
       - name: Install dependencies
         run: mix deps.get

--- a/lib/claude_wrapper/stream.ex
+++ b/lib/claude_wrapper/stream.ex
@@ -232,7 +232,15 @@ defmodule ClaudeWrapper.Stream do
   end
 
   defp cleanup(%{session: session, pid: pid, ref: ref}) do
-    DuplexSession.unsubscribe(session)
+    # The session may already be dead (an abnormal close is exactly the case the
+    # :duplex_closed terminal covers); swallow the exit so the Stream.resource
+    # after-callback still completes cleanly instead of crashing the consumer.
+    try do
+      DuplexSession.unsubscribe(session)
+    catch
+      :exit, _ -> :ok
+    end
+
     Process.demonitor(ref, [:flush])
     if Process.alive?(pid), do: Process.exit(pid, :kill)
     :ok

--- a/test/claude_wrapper/command_test.exs
+++ b/test/claude_wrapper/command_test.exs
@@ -24,6 +24,57 @@ defmodule ClaudeWrapper.CommandTest do
     test "escapes an embedded single quote" do
       assert Command.shell_escape("it's") == ~S('it'\''s')
     end
+
+    test "single-quotes every shell-significant character" do
+      for c <- [
+            "<",
+            ">",
+            "*",
+            "?",
+            "[",
+            "]",
+            "\t",
+            ";",
+            "|",
+            "&",
+            "$",
+            "`",
+            " ",
+            "\"",
+            "\\",
+            "\n"
+          ] do
+        assert Command.shell_escape("x" <> c <> "y") == "'x" <> c <> "y'"
+      end
+
+      # the bare single quote is the one char needing the '\'' dance
+      assert Command.shell_escape("'") == ~S(''\''')
+    end
+  end
+
+  describe "shell_escape/1 /bin/sh round-trip (#217)" do
+    test "an adversarial argv survives /bin/sh verbatim (no split, glob, or substitution)" do
+      argv = [
+        "--setting-sources",
+        "",
+        "--strict-mcp-config",
+        "a b",
+        "a>b",
+        "glob_*.txt",
+        "it's",
+        "a;rm -rf x",
+        "$HOME",
+        "`id`"
+      ]
+
+      fmt = String.duplicate("%s\\n", length(argv))
+      ["-c", shell_cmd] = Command.shell_cmd_args("printf", [fmt | argv])
+
+      {out, 0} = System.cmd("/bin/sh", ["-c", shell_cmd])
+
+      received = out |> String.split("\n", trim: false) |> Enum.take(length(argv))
+      assert received == argv
+    end
   end
 
   describe "shell_cmd_args/2 (#196)" do

--- a/test/claude_wrapper/runner_config_test.exs
+++ b/test/claude_wrapper/runner_config_test.exs
@@ -6,7 +6,7 @@ defmodule ClaudeWrapper.RunnerConfigTest do
   # async: false -- the raw/2 and stream tests swap the global `:runner`.
   use ExUnit.Case, async: false
 
-  alias ClaudeWrapper.{Config, Error, Query}
+  alias ClaudeWrapper.{Config, Error, Query, Result}
 
   defmodule TimeoutRunner do
     @behaviour ClaudeWrapper.Runner
@@ -20,6 +20,56 @@ defmodule ClaudeWrapper.RunnerConfigTest do
     @behaviour ClaudeWrapper.Runner
     @impl true
     def run(_binary, _args, _opts, _timeout), do: {:ok, {"out\n", 0}}
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout), do: []
+  end
+
+  # Leading noise + a decoy system/init line before the terminal result line, to
+  # exercise extract_json's noise-skipping and last-JSON-line selection (#232).
+  defmodule NoisyJsonRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout) do
+      stdout =
+        [
+          "[warning] npm notice",
+          Jason.encode!(%{"type" => "system", "subtype" => "init", "session_id" => "s1"}),
+          Jason.encode!(%{
+            "type" => "result",
+            "subtype" => "success",
+            "result" => "ok",
+            "num_turns" => 1
+          })
+        ]
+        |> Enum.join("\n")
+
+      {:ok, {stdout, 0}}
+    end
+
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout), do: []
+  end
+
+  defmodule NoJsonRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"warning: something\nstill not json", 0}}
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout), do: []
+  end
+
+  defmodule EmptyRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:ok, {"", 0}}
+    @impl true
+    def stream_lines(_binary, _args, _opts, _timeout), do: []
+  end
+
+  defmodule IoErrorRunner do
+    @behaviour ClaudeWrapper.Runner
+    @impl true
+    def run(_binary, _args, _opts, _timeout), do: {:error, :closed}
     @impl true
     def stream_lines(_binary, _args, _opts, _timeout), do: []
   end
@@ -108,6 +158,35 @@ defmodule ClaudeWrapper.RunnerConfigTest do
 
       assert last.type == "error"
       assert last.data["error"] == "stream_truncated"
+    end
+  end
+
+  describe "Query.execute/2 offline via Runner override (#232)" do
+    defp execute(runner) do
+      Application.put_env(:claude_wrapper, :runner, runner)
+      "hi" |> Query.new() |> Query.execute(Config.new())
+    end
+
+    test "skips leading noise and selects the last JSON line" do
+      # proves extract_json both skips the warning line AND picks the terminal
+      # result over the earlier system/init decoy.
+      assert {:ok, %Result{result: "ok", num_turns: 1}} = execute(NoisyJsonRunner)
+    end
+
+    test "maps non-JSON stdout to an Error.json" do
+      assert {:error, %Error{kind: :json}} = execute(NoJsonRunner)
+    end
+
+    test "maps empty stdout to an Error.json" do
+      assert {:error, %Error{kind: :json}} = execute(EmptyRunner)
+    end
+
+    test "maps a runner timeout to Error.timeout" do
+      assert {:error, %Error{kind: :timeout}} = execute(TimeoutRunner)
+    end
+
+    test "maps a generic runner error to Error.io" do
+      assert {:error, %Error{kind: :io}} = execute(IoErrorRunner)
     end
   end
 end

--- a/test/claude_wrapper/runner_test.exs
+++ b/test/claude_wrapper/runner_test.exs
@@ -79,5 +79,43 @@ defmodule ClaudeWrapper.RunnerTest do
       assert micros < 2_000_000,
              "stream took #{div(micros, 1000)}ms (the 5s close stall regressed)"
     end
+
+    test "an idle producer halts at the idle timeout instead of hanging (#217)" do
+      {micros, lines} =
+        :timer.tc(fn ->
+          "sh"
+          |> Port.stream_lines(["-c", "echo first; sleep 10"], [], 200)
+          |> Enum.to_list()
+        end)
+
+      assert lines == ["first"]
+      # halts on the 200ms idle bound, not the 10s sleep
+      assert micros < 2_000_000
+    end
+
+    test "propagates :env to the spawned process (#217)" do
+      lines =
+        "sh"
+        |> Port.stream_lines(["-c", "echo $CW_TEST"], [env: [{~c"CW_TEST", ~c"hello217"}]], nil)
+        |> Enum.to_list()
+
+      assert lines == ["hello217"]
+    end
+
+    test "propagates :cd to the spawned process (#217)" do
+      # A unique leaf dir: `pwd` may resolve a parent symlink (/var -> /private/var
+      # on macOS), so compare on the unique basename rather than the full path.
+      dir = Path.join(System.tmp_dir!(), "cw_cd_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      lines =
+        "sh"
+        |> Port.stream_lines(["-c", "pwd"], [cd: dir], nil)
+        |> Enum.to_list()
+
+      assert [pwd] = lines
+      assert String.ends_with?(pwd, Path.basename(dir))
+    end
   end
 end

--- a/test/claude_wrapper/stream_test.exs
+++ b/test/claude_wrapper/stream_test.exs
@@ -170,6 +170,26 @@ defmodule ClaudeWrapper.StreamTest do
       assert {:error, %ClaudeWrapper.Error{kind: :turn_in_flight}} = List.last(events)
     end
 
+    test "an abnormal turn-process exit surfaces a terminal :duplex_closed (no hang, #233)" do
+      pid = start_with_fake_claude()
+      # start_link linked this session to the test process; unlink so the brutal
+      # kill below does not also take down the test.
+      Process.unlink(pid)
+
+      # Once the stream has subscribed, the turn's send/3 is a GenServer.call in
+      # flight; brutally killing the session makes that call exit abnormally, so
+      # the stream's monitored turn process goes DOWN non-:normal -- the branch
+      # under test (and cleanup/1's unsubscribe then hits a dead session).
+      spawn(fn ->
+        wait_for_subscriber(pid)
+        Process.exit(pid, :kill)
+      end)
+
+      events = pid |> CWStream.stream("hi") |> Enum.to_list()
+
+      assert [{:error, %ClaudeWrapper.Error{kind: :duplex_closed}}] = events
+    end
+
     # The occupying turn registers a pending_turn but no subscriber; wait
     # for the pending turn to be in flight before the stream sends.
     defp wait_for_subscriber_free(pid, deadline \\ nil) do


### PR DESCRIPTION
Wrapper cleanup, batch 3 of 3 (tests + CI) — takes the backlog to **zero**.

| # | Change |
|---|---|
| #217 | `command_test`: `shell_escape` single-quotes every shell-significant char + an adversarial argv survives a real `/bin/sh` round-trip verbatim. `runner_test`: `Port.stream_lines` idle-timeout halt, `:env` + `:cd` passthrough. |
| #218 | CI `test` matrix fans out over the declared range (1.18/27, 1.19/28, 1.20/29) instead of one leg; docs + publish jobs bumped to 1.20/29. |
| #232 | Offline `Query.execute/2` coverage via the `:runner` override: `extract_json` noise-skipping + last-line selection; non-JSON/empty → `:json`; timeout → `:timeout`; io → `:io`. |
| #233 | **Fix + test**: `Stream.cleanup/1` crashed the consumer on an abnormal close (unsubscribe → dead session → `:noproc`); wrapped in try/catch. Test pins the terminal `:duplex_closed` element on a brutal session kill. |

## Gate
`format`, `compile --warnings-as-errors`, `credo --strict`, `docs --warnings-as-errors`, `dialyzer` (0), `test` **680 passed / 40 excluded**.

Closes #217, closes #218, closes #232, closes #233